### PR TITLE
Compile NodeJS projects in specialise "build" containers

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -15,7 +15,6 @@ sous build does not have any options yet`
 }
 
 func Build(sous *core.Sous, args []string) {
-	args = sous.ParseFlags(args)
 	targetName := "app"
 	if len(args) != 0 {
 		targetName = args[0]

--- a/commands/build.go
+++ b/commands/build.go
@@ -33,14 +33,21 @@ func Build(sous *core.Sous, args []string) {
 	}
 
 	target, context := sous.AssembleTargetContext(targetName)
-	if *forceBuild {
-		cli.Logf("Forcing new build")
-		sous.Build(target, context)
-	} else {
-		if !sous.BuildIfNecessary(target, context) {
-			cli.Successf("Already built: %s", context.DockerTag())
-		}
+
+	built, _ := sous.RunTarget(target, context)
+
+	if built {
+		cli.Successf("Already built: %s", context.DockerTag())
 	}
+
+	//if *forceBuild {
+	//	cli.Logf("Forcing new build")
+	//	sous.Build(target, context)
+	//} else {
+	//	if !sous.BuildIfNecessary(target, context) {
+	//		cli.Successf("Already built: %s", context.DockerTag())
+	//	}
+	//}
 	name := context.CanonicalPackageName()
 	cli.Successf("Successfully built %s v%s as %s", name, context.AppVersion, context.DockerTag())
 }

--- a/commands/build.go
+++ b/commands/build.go
@@ -48,6 +48,7 @@ func Build(sous *core.Sous, args []string) {
 	//		cli.Successf("Already built: %s", context.DockerTag())
 	//	}
 	//}
+
 	name := context.CanonicalPackageName()
 	cli.Successf("Successfully built %s v%s as %s", name, context.AppVersion, context.DockerTag())
 }

--- a/commands/build.go
+++ b/commands/build.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"flag"
+
 	"github.com/opentable/sous/core"
 	"github.com/opentable/sous/tools/cli"
 	"github.com/opentable/sous/tools/git"
@@ -14,7 +16,12 @@ projects. It builds a docker image, tagged and labelled correctly.
 sous build does not have any options yet`
 }
 
+var buildFlags = flag.NewFlagSet("build", flag.ExitOnError)
+var forceBuild = buildFlags.Bool("force", false, "force a new build, even if sous thinks it's not necessary")
+
 func Build(sous *core.Sous, args []string) {
+	buildFlags.Parse(args)
+	args = buildFlags.Args()
 	targetName := "app"
 	if len(args) != 0 {
 		targetName = args[0]
@@ -26,8 +33,13 @@ func Build(sous *core.Sous, args []string) {
 	}
 
 	target, context := sous.AssembleTargetContext(targetName)
-	if !sous.BuildIfNecessary(target, context) {
-		cli.Successf("Already built: %s", context.DockerTag())
+	if *forceBuild {
+		cli.Logf("Forcing new build")
+		sous.Build(target, context)
+	} else {
+		if !sous.BuildIfNecessary(target, context) {
+			cli.Successf("Already built: %s", context.DockerTag())
+		}
 	}
 	name := context.CanonicalPackageName()
 	cli.Successf("Successfully built %s v%s as %s", name, context.AppVersion, context.DockerTag())

--- a/commands/build.go
+++ b/commands/build.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"flag"
-
 	"github.com/opentable/sous/core"
 	"github.com/opentable/sous/tools/cli"
 	"github.com/opentable/sous/tools/git"
@@ -16,12 +14,8 @@ projects. It builds a docker image, tagged and labelled correctly.
 sous build does not have any options yet`
 }
 
-var buildFlags = flag.NewFlagSet("build", flag.ExitOnError)
-var forceBuild = buildFlags.Bool("force", false, "force a new build, even if sous thinks it's not necessary")
-
 func Build(sous *core.Sous, args []string) {
-	buildFlags.Parse(args)
-	args = buildFlags.Args()
+	args = sous.ParseFlags(args)
 	targetName := "app"
 	if len(args) != 0 {
 		targetName = args[0]
@@ -36,18 +30,9 @@ func Build(sous *core.Sous, args []string) {
 
 	built, _ := sous.RunTarget(target, context)
 
-	if built {
+	if !built {
 		cli.Successf("Already built: %s", context.DockerTag())
 	}
-
-	//if *forceBuild {
-	//	cli.Logf("Forcing new build")
-	//	sous.Build(target, context)
-	//} else {
-	//	if !sous.BuildIfNecessary(target, context) {
-	//		cli.Successf("Already built: %s", context.DockerTag())
-	//	}
-	//}
 
 	name := context.CanonicalPackageName()
 	cli.Successf("Successfully built %s v%s as %s", name, context.AppVersion, context.DockerTag())

--- a/commands/contracts.go
+++ b/commands/contracts.go
@@ -13,9 +13,9 @@ import (
 	"github.com/opentable/sous/tools/ports"
 )
 
-var flags = flag.NewFlagSet("contracts", flag.ExitOnError)
+var contractsFlags = flag.NewFlagSet("contracts", flag.ExitOnError)
 
-var timeoutFlag = flags.Duration("timeout", 10*time.Second, "per-contract timeout")
+var timeoutFlag = contractsFlags.Duration("timeout", 10*time.Second, "per-contract timeout")
 
 type Contract struct {
 	Name    string
@@ -64,8 +64,8 @@ func ContractsHelp() string {
 }
 
 func Contracts(sous *core.Sous, args []string) {
-	flags.Parse(args)
-	args = flags.Args()
+	contractsFlags.Parse(args)
+	args = contractsFlags.Args()
 	timeout := *timeoutFlag
 	targetName := "app"
 	if len(args) != 0 {
@@ -75,9 +75,8 @@ func Contracts(sous *core.Sous, args []string) {
 	core.RequireDocker()
 
 	target, context := sous.AssembleTargetContext(targetName)
-	if !sous.BuildImageIfNecessary(target, context) {
-		cli.Logf("No changes since last build, running %s", context.DockerTag())
-	}
+
+	sous.RunTarget(target, context)
 
 	cli.Logf("=> Running Contracts")
 	cli.Logf(`=> **TIP:** Open another terminal in this directory and type **sous logs -f**`)

--- a/commands/contracts.go
+++ b/commands/contracts.go
@@ -75,7 +75,7 @@ func Contracts(sous *core.Sous, args []string) {
 	core.RequireDocker()
 
 	target, context := sous.AssembleTargetContext(targetName)
-	if !sous.BuildIfNecessary(target, context) {
+	if !sous.BuildImageIfNecessary(target, context) {
 		cli.Logf("No changes since last build, running %s", context.DockerTag())
 	}
 

--- a/commands/contracts.go
+++ b/commands/contracts.go
@@ -98,7 +98,6 @@ func Contracts(sous *core.Sous, args []string) {
 		cli.Fatalf("Unable to start container: %s", err)
 	}
 	cli.AddCleanupTask(func() error {
-		cli.Logf("Killing contracts container %s", container)
 		return container.Kill()
 	})
 

--- a/commands/run.go
+++ b/commands/run.go
@@ -28,15 +28,15 @@ func Run(sous *core.Sous, args []string) {
 	//if !sous.BuildIfNecessary(target, context) {
 	//cli.Logf("No relevant changes since last build, running %s", context.DockerTag())
 	//}
-	var dr *docker.Run
-	if runner, ok := target.(core.DockerRunner); ok {
-		dr = runner.DockerRun(context)
-	} else {
-		dr = defaultDockerRun(context)
-	}
-	if code := dr.ExitCode(); code != 0 {
-		cli.Fatalf("Run failed with exit code %d", code)
-	}
+	//var dr *docker.Run
+	//if runner, ok := target.(core.DockerRunner); ok {
+	//	dr = runner.DockerRun(context)
+	//} else {
+	//	dr = defaultDockerRun(context)
+	//}
+	//if code := dr.ExitCode(); code != 0 {
+	//	cli.Fatalf("Run failed with exit code %d", code)
+	//}
 	cli.Success()
 }
 

--- a/commands/run.go
+++ b/commands/run.go
@@ -22,9 +22,12 @@ func Run(sous *core.Sous, args []string) {
 	core.RequireDocker()
 
 	target, context := sous.AssembleTargetContext(targetName)
-	if !sous.BuildIfNecessary(target, context) {
-		cli.Logf("No relevant changes since last build, running %s", context.DockerTag())
-	}
+
+	sous.RunTarget(target, context)
+
+	//if !sous.BuildIfNecessary(target, context) {
+	//cli.Logf("No relevant changes since last build, running %s", context.DockerTag())
+	//}
 	var dr *docker.Run
 	if runner, ok := target.(core.DockerRunner); ok {
 		dr = runner.DockerRun(context)

--- a/commands/run.go
+++ b/commands/run.go
@@ -14,6 +14,7 @@ func RunHelp() string {
 }
 
 func Run(sous *core.Sous, args []string) {
+	args = sous.ParseFlags(args)
 	targetName := "app"
 	if len(args) != 0 {
 		targetName = args[0]
@@ -25,18 +26,15 @@ func Run(sous *core.Sous, args []string) {
 
 	sous.RunTarget(target, context)
 
-	//if !sous.BuildIfNecessary(target, context) {
-	//cli.Logf("No relevant changes since last build, running %s", context.DockerTag())
-	//}
-	//var dr *docker.Run
-	//if runner, ok := target.(core.DockerRunner); ok {
-	//	dr = runner.DockerRun(context)
-	//} else {
-	//	dr = defaultDockerRun(context)
-	//}
-	//if code := dr.ExitCode(); code != 0 {
-	//	cli.Fatalf("Run failed with exit code %d", code)
-	//}
+	var dr *docker.Run
+	if runner, ok := target.(core.ContainerTarget); ok {
+		dr = runner.DockerRun(context)
+	} else {
+		dr = defaultDockerRun(context)
+	}
+	if code := dr.ExitCode(); code != 0 {
+		cli.Fatalf("Run failed with exit code %d", code)
+	}
 	cli.Success()
 }
 

--- a/commands/test.go
+++ b/commands/test.go
@@ -19,7 +19,7 @@ func Test(sous *core.Sous, args []string) {
 	core.RequireDocker()
 
 	target, context := sous.AssembleTargetContext("test")
-	if !sous.BuildIfNecessary(target, context) {
+	if !sous.BuildImageIfNecessary(target, context) {
 		cli.Logf("No changes since last build, running %s", context.DockerTag())
 	}
 

--- a/commands/test.go
+++ b/commands/test.go
@@ -19,9 +19,8 @@ func Test(sous *core.Sous, args []string) {
 	core.RequireDocker()
 
 	target, context := sous.AssembleTargetContext("test")
-	if !sous.BuildImageIfNecessary(target, context) {
-		cli.Logf("No changes since last build, running %s", context.DockerTag())
-	}
+
+	sous.RunTarget(target, context)
 
 	testRunExitCode := docker.NewRun(context.DockerTag()).ExitCode()
 

--- a/config/structs.go
+++ b/config/structs.go
@@ -12,8 +12,31 @@ type Packs struct {
 }
 
 type NodeJSConfig struct {
-	NodeVersionsToDockerBaseImages map[string]string
-	DockerTags                     map[string]string
-	AvailableNPMVersions           []string
-	DefaultNodeVersion             string
+	AvailableVersions    *StackVersions
+	DockerTags           map[string]string
+	AvailableNPMVersions []string
+	DefaultNodeVersion   string
+}
+
+type StackVersions []*StackVersion
+
+type StackVersion struct {
+	Name, DefaultImage string
+	TargetImages       BaseImageSet
+}
+
+type BaseImageSet map[string]string
+
+func (svs StackVersions) GetBaseImageTag(version, target string) (string, bool) {
+	for _, sv := range svs {
+		if sv.Name == version {
+			if specificImage, ok := sv.TargetImages[target]; ok {
+				return specificImage, true
+			}
+			if defaultImage, ok := sv.TargetImages["default"]; ok {
+				return defaultImage, true
+			}
+		}
+	}
+	return "", false
 }

--- a/config/structs.go
+++ b/config/structs.go
@@ -33,9 +33,7 @@ func (svs StackVersions) GetBaseImageTag(version, target string) (string, bool) 
 			if specificImage, ok := sv.TargetImages[target]; ok {
 				return specificImage, true
 			}
-			if defaultImage, ok := sv.TargetImages["default"]; ok {
-				return defaultImage, true
-			}
+			return sv.DefaultImage, true
 		}
 	}
 	return "", false

--- a/core/assembly.go
+++ b/core/assembly.go
@@ -65,9 +65,11 @@ func (s *Sous) AssembleTargetContext(targetName string) (Target, *Context) {
 // However, you may override this behaviour for a specific target by implementing
 // the Staler interface: { Stale(*Context) bool }
 func (s *Sous) BuildImageIfNecessary(target Target, context *Context) bool {
-	if !s.NeedsToBuildNewImage(target, context) {
+	stale, reason := s.NeedsToBuildNewImage(target, context)
+	if !stale {
 		return false
 	}
+	cli.Logf(" ===> Image is stale because %s; rebuilding...", reason)
 	s.BuildImage(target, context)
 	return true
 }

--- a/core/context.go
+++ b/core/context.go
@@ -17,6 +17,7 @@ import (
 
 type Context struct {
 	Git                  *git.Info
+	WorkDir              string
 	Action               string
 	DockerRegistry       string
 	Host, FullHost, User string
@@ -34,8 +35,13 @@ func GetContext(action string) *Context {
 	registry := c.DockerRegistry
 	gitInfo := git.GetInfo()
 	bs := GetBuildState(action, gitInfo)
+	wd, err := os.Getwd()
+	if err != nil {
+		cli.Fatalf("Unable to get current working directory: %s", err)
+	}
 	return &Context{
 		Git:            gitInfo,
+		WorkDir:        wd,
 		Action:         action,
 		DockerRegistry: registry,
 		Host:           cmd.Stdout("hostname"),

--- a/core/context.go
+++ b/core/context.go
@@ -88,21 +88,21 @@ func (c *Context) DockerTagForBuildNumber(n int) string {
 // by implementing the Staler interfact on individual build targets. This default
 // implementation rebuilds on absolutely any change in sous (i.e. new version/new
 // config) or in the working tree (new or modified files).
-func (s *Sous) NeedsBuild(t Target, c *Context) bool {
+func (s *Sous) NeedsToBuildNewImage(t Target, c *Context) bool {
 	changes := c.ChangesSinceLastBuild()
-	if staler, ok := t.(Staler); ok {
-		if staler.Stale(c) {
+	if staler, ok := t.(ImageIsStaler); ok {
+		if staler.ImageIsStale(c) {
 			return true
 		}
 	} else if changes.Any() {
 		return true
 	}
-	// Always force a rebuild if sous itself, or the relevant base image
-	// has been updated.
+	// Always force a rebuild if is base image has been updated.
 	if c.LastBuildImageExists() &&
 		docker.BaseImageUpdated(t.Dockerfile().From, c.PrevDockerTag()) {
 		return true
 	}
+	// Always force a build if Sous itself has been updated
 	return changes.SousUpdated
 }
 

--- a/core/detect.go
+++ b/core/detect.go
@@ -19,6 +19,9 @@ func DetectProjectType(packs []Pack) Pack {
 		}
 		pack = p
 	}
+	if pack == nil {
+		cli.Fatalf("no buildable project detected")
+	}
 	pack.Detect()
 	return pack
 }

--- a/core/sous.go
+++ b/core/sous.go
@@ -30,7 +30,7 @@ type Command struct {
 
 var sous *Sous
 
-func NewSous(version, revision, os, arch string, commands map[string]*Command, packs []Pack) *Sous {
+func NewSous(version, revision, os, arch string, commands map[string]*Command, packs []Pack, flags *SousFlags) *Sous {
 	if sous == nil {
 		sous = &Sous{
 			Version:      version,
@@ -39,26 +39,11 @@ func NewSous(version, revision, os, arch string, commands map[string]*Command, p
 			Arch:         arch,
 			Packs:        packs,
 			Commands:     commands,
-			Flags:        &SousFlags{},
+			Flags:        flags,
 			cleanupTasks: []func() error{},
 		}
 	}
 	return sous
-}
-
-func (s *Sous) ParseFlags(args []string) []string {
-	flagSet := flag.NewFlagSet("sous", flag.ExitOnError)
-	rebuild := flagSet.Bool("rebuild", false, "force a rebuild")
-	rebuildAll := flagSet.Bool("rebuild-all", false, "force a rebuild of this target plus all dependencies")
-	err := flagSet.Parse(args)
-	if err != nil {
-		cli.Fatalf("%s", err)
-	}
-	s.Flags = &SousFlags{
-		ForceRebuild:    *rebuild,
-		ForceRebuildAll: *rebuildAll,
-	}
-	return flagSet.Args()
 }
 
 func (s *Sous) UpdateBaseImage(image string) {

--- a/core/sous.go
+++ b/core/sous.go
@@ -19,7 +19,7 @@ type Sous struct {
 }
 
 type SousFlags struct {
-	ForceBuild, ForceRebuildAll bool
+	ForceRebuild, ForceRebuildAll bool
 }
 
 type Command struct {
@@ -48,15 +48,15 @@ func NewSous(version, revision, os, arch string, commands map[string]*Command, p
 
 func (s *Sous) ParseFlags(args []string) []string {
 	flagSet := flag.NewFlagSet("sous", flag.ExitOnError)
-	force := flagSet.Bool("force", false, "force a rebuild")
-	forceAll := flagSet.Bool("force-all", false, "force a rebuild of this target plus all dependencies")
+	rebuild := flagSet.Bool("rebuild", false, "force a rebuild")
+	rebuildAll := flagSet.Bool("rebuild-all", false, "force a rebuild of this target plus all dependencies")
 	err := flagSet.Parse(args)
 	if err != nil {
 		cli.Fatalf("%s", err)
 	}
 	s.Flags = &SousFlags{
-		ForceBuild:      *force,
-		ForceRebuildAll: *forceAll,
+		ForceRebuild:    *rebuild,
+		ForceRebuildAll: *rebuildAll,
 	}
 	return flagSet.Args()
 }

--- a/core/sous.go
+++ b/core/sous.go
@@ -1,5 +1,13 @@
 package core
 
+import (
+	"encoding/json"
+
+	"github.com/opentable/sous/config"
+	"github.com/opentable/sous/tools/cli"
+	"github.com/opentable/sous/tools/docker"
+)
+
 type Sous struct {
 	Version, Revision, OS, Arch string
 	Packs                       []Pack
@@ -28,4 +36,35 @@ func NewSous(version, revision, os, arch string, commands map[string]*Command, p
 		}
 	}
 	return sous
+}
+
+func (s *Sous) UpdateBaseImage(image string) {
+	// First, keep track of which images we are interested in...
+	key := "usedBaseImages"
+	images := config.Properties()[key]
+	var list []string
+	if len(images) != 0 {
+		json.Unmarshal([]byte(images), &list)
+	} else {
+		list = []string{}
+	}
+	if doesNotAppearInList(image, list) {
+		list = append(list, image)
+	}
+	listJSON, err := json.Marshal(list)
+	if err != nil {
+		cli.Fatalf("Unable to marshal base image list as JSON: %+v; %s", list, err)
+	}
+	config.Set(key, string(listJSON))
+	// Now lets grab the actual image
+	docker.Pull(image)
+}
+
+func doesNotAppearInList(item string, list []string) bool {
+	for _, i := range list {
+		if i == item {
+			return true
+		}
+	}
+	return false
 }

--- a/core/targets.go
+++ b/core/targets.go
@@ -87,6 +87,11 @@ type DockerRunner interface {
 	DockerRun(*Context) *docker.Run
 }
 
+type DockerContainer interface {
+	DockerRunner
+	DockerContainerName() string
+}
+
 type SetStater interface {
 	SetState(string, interface{})
 }

--- a/core/targets.go
+++ b/core/targets.go
@@ -32,6 +32,8 @@ type Target interface {
 	// Dockerfile is the shebang method which writes out a functionally complete *docker.Dockerfile
 	// This method is only invoked only once the Detect func has successfully detected target availability.
 	Dockerfile() *docker.Dockerfile
+	// Pack is the pack this Target belongs to.
+	Pack() Pack
 }
 
 // ContainerTarget is a specialisation of Target that in addition to building a Dockerfile,
@@ -54,6 +56,7 @@ type ContainerTarget interface {
 type TargetBase struct {
 	name,
 	genericDesc string
+	pack Pack
 }
 
 func (t *TargetBase) Name() string {
@@ -66,6 +69,10 @@ func (t *TargetBase) GenericDesc() string {
 
 func (t *TargetBase) String() string {
 	return t.Name()
+}
+
+func (t *TargetBase) Pack() Pack {
+	return t.pack
 }
 
 type Targets map[string]Target
@@ -89,12 +96,14 @@ func KnownTargets() map[string]TargetBase {
 
 // MustGetTargetBase returns a pointer to a new copy of a known target base,
 // or causes the program to fail if the named target does not exist.
-func MustGetTargetBase(name string) *TargetBase {
+func MustGetTargetBase(name string, pack Pack) *TargetBase {
 	b, ok := knownTargets[name]
 	if !ok {
 		cli.Fatalf("target %s not known", name)
 	}
-	return &b
+	targetCopy := b
+	targetCopy.pack = pack
+	return &targetCopy
 }
 
 type ImageIsStaler interface {

--- a/core/targets.go
+++ b/core/targets.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/opentable/sous/tools/cli"
 	"github.com/opentable/sous/tools/docker"
+	"github.com/opentable/sous/tools/file"
+	"github.com/opentable/sous/tools/path"
 )
 
 // Target describes a buildable Docker file that performs a particular task related to building
@@ -46,7 +48,7 @@ type ContainerTarget interface {
 	// ContainerIsStale should return true if the container needs to be rebuilt,
 	// otherwise it returns false. Certain conditions (like Sous itself being upgraded always cause root
 	// and branch rebuilds, regardless of this return value.
-	ContainerIsStale(*Context) bool
+	ContainerIsStale(*Context) (bool, string)
 }
 
 type TargetBase struct {
@@ -111,8 +113,20 @@ type Stater interface {
 	State(*Context) interface{}
 }
 
+// RunTarget is used to run the top-level target from build commands.
 func (s *Sous) RunTarget(t Target, c *Context) (bool, interface{}) {
-	fmt.Sprintf("Running target %s", t.Name())
+	if !c.ChangesSinceLastBuild().Any() {
+		if !s.Flags.ForceBuild {
+			cli.Logf("No changes since last build.")
+			cli.Logf("TIP: use -force to rebuild anyway, or -force-all to rebuild all dependencies")
+			return false, nil
+		}
+	}
+	cli.Logf(` ===> Building target "%s"`, t.Name())
+	return s.runTarget(t, c, false)
+}
+
+func (s *Sous) runTarget(t Target, c *Context, asDependency bool) (bool, interface{}) {
 	depsRebuilt := false
 	var state interface{}
 	deps := t.DependsOn()
@@ -120,7 +134,7 @@ func (s *Sous) RunTarget(t Target, c *Context) (bool, interface{}) {
 		for _, d := range deps {
 			cli.Logf(" ===> Building dependency %s", d.Name())
 			dt, dc := s.AssembleTargetContext(d.Name())
-			depsRebuilt, state = s.RunTarget(dt, dc)
+			depsRebuilt, state = s.runTarget(dt, dc, true)
 			if ss, ok := t.(SetStater); ok {
 				ss.SetState(dt.Name(), state)
 			}
@@ -133,7 +147,7 @@ func (s *Sous) RunTarget(t Target, c *Context) (bool, interface{}) {
 	// If this target specifies a docker container, invoke it.
 	if ct, ok := t.(ContainerTarget); ok {
 		fmt.Sprintf(" ===> Running target image %s", t.Name())
-		run, isNew := s.RunContainerTarget(ct, c)
+		run, isNew := s.RunContainerTarget(ct, c, rebuilt)
 		if isNew {
 			cli.Logf(" ===> Preparing %s container for first use", t.Name())
 		}
@@ -148,23 +162,116 @@ func (s *Sous) RunTarget(t Target, c *Context) (bool, interface{}) {
 	return rebuilt || depsRebuilt, state
 }
 
-func (s *Sous) RunContainerTarget(t ContainerTarget, c *Context) (*docker.Run, bool) {
+func (s *Sous) RunContainerTarget(t ContainerTarget, c *Context, imageRebuilt bool) (*docker.Run, bool) {
 	container := docker.ContainerWithName(t.ContainerName(c))
-	if !container.Exists() || t.ContainerIsStale(c) || s.OverrideContainerRebuild(t, container) {
-		cli.Logf("Re-using build container %s", container)
-		return docker.NewReRun(container), false
+	if !container.Exists() {
+		cli.Logf(" ===> Creating new %s container, as no existing one found...", t.Name())
+		return t.DockerRun(c), true
 	}
-	if err := container.Remove(); err != nil {
-		cli.Fatalf("Unable to remove outdated container %s", container)
+	if stale, reason := s.ContainerIsStale(t, c, imageRebuilt); stale {
+		cli.Logf(" ===> Creating new %s container becuase %s", t.Name(), reason)
+		if err := container.Remove(); err != nil {
+			cli.Fatalf("Unable to remove outdated container %s", container)
+		}
+		return t.DockerRun(c), true
 	}
-	return t.DockerRun(c), true
+	cli.Logf(" ===> Re-using build container %s", container)
+	return docker.NewReRun(container), false
 }
 
-func (s *Sous) OverrideContainerRebuild(t ContainerTarget, container docker.Container) bool {
+func (s *Sous) ContainerIsStale(t ContainerTarget, c *Context, imageRebuilt bool) (bool, string) {
+	if imageRebuilt {
+		return true, "its underlying image was rebuilt"
+	}
+	container := docker.ContainerWithName(t.ContainerName(c))
+	if stale, reason := t.ContainerIsStale(c); stale {
+		return true, reason
+	}
+	if stale, reason := s.OverrideContainerRebuild(t, container); stale {
+		return true, reason
+	}
+	return false, ""
+}
+
+func (s *Sous) OverrideContainerRebuild(t ContainerTarget, container docker.Container) (bool, string) {
 	image := container.Image()
 	baseImage := t.Dockerfile().From
-	return docker.BaseImageUpdated(baseImage, image)
+	if docker.BaseImageUpdated(baseImage, image) {
+		return true, fmt.Sprintf("base image %s updated", baseImage)
+	}
+	return false, ""
+}
 
+// BuildIfNecessary usually rebuilds any target if anything of the following
+// are true:
+//
+// - No build is available at all
+// - Any files in the working tree have changed
+// - Sous has been updated
+// - Sous config has changed
+//
+// However, you may override this behaviour for a specific target by implementing
+// the Staler interface: { Stale(*Context) bool }
+func (s *Sous) BuildImageIfNecessary(target Target, context *Context) bool {
+	return s.buildImageIfNecessary(target, context, false)
+}
+
+func (s *Sous) buildImageIfNecessary(target Target, context *Context, asDependency bool) bool {
+	stale, reason := s.NeedsToBuildNewImage(target, context, asDependency)
+	if !stale {
+		return false
+	}
+	cli.Logf(" ===> Image is stale because %s; rebuilding...", reason)
+	s.BuildImage(target, context)
+	return true
+}
+
+// NeedsBuild detects if the project's last
+// build is stale, and if it therefore needs to be rebuilt. This can be overidden
+// by implementing the Staler interfact on individual build targets. This default
+// implementation rebuilds on absolutely any change in sous (i.e. new version/new
+// config) or in the working tree (new or modified files).
+func (s *Sous) NeedsToBuildNewImage(t Target, c *Context, asDependency bool) (bool, string) {
+	if s.Flags.ForceRebuildAll {
+		return true, "-force-all flag was used"
+	}
+	if s.Flags.ForceBuild && !asDependency {
+		return true, "-force flag was used"
+	}
+	changes := c.ChangesSinceLastBuild()
+	if staler, ok := t.(ImageIsStaler); ok {
+		if stale, reason := staler.ImageIsStale(c); stale {
+			return true, reason
+		}
+	} else if changes.Any() {
+		return true, "default change detector detected changes"
+	}
+	// Always force a rebuild if is base image has been updated.
+	baseImage := t.Dockerfile().From
+	if c.LastBuildImageExists() && docker.BaseImageUpdated(baseImage, c.PrevDockerTag()) {
+		return true, fmt.Sprintf("the base image %s was updated", baseImage)
+	}
+	// Always force a build if Sous itself has been updated
+	if changes.SousUpdated {
+		return true, fmt.Sprintf("Sous itself or its config was updated")
+	}
+	return false, ""
+}
+
+func (s *Sous) BuildImage(target Target, context *Context) {
+	context.IncrementBuildNumber()
+	if file.Exists("Dockerfile") {
+		cli.Logf("WARNING: Your local Dockerfile is ignored by sous, use `sous dockerfile %s` to see the dockerfile being used here", target.Name())
+	}
+	dfPath := path.Resolve(context.FilePath("Dockerfile"))
+	if prebuilder, ok := target.(PreDockerBuilder); ok {
+		prebuilder.PreDockerBuild(context)
+		// NB: Always rebuild the Dockerfile after running pre-build, since pre-build
+		// may update target state to reflect things like copied file locations etc.
+		s.BuildDockerfile(target, context)
+	}
+	docker.BuildFile(dfPath, ".", context.DockerTag())
+	context.Commit()
 }
 
 var knownTargets = map[string]TargetBase{

--- a/core/targets.go
+++ b/core/targets.go
@@ -104,11 +104,13 @@ func (s *Sous) RunTarget(t Target, c *Context) (bool, interface{}) {
 	depsRebuilt := false
 	var state interface{}
 	for _, d := range t.DependsOn() {
+		cli.Logf("======> Building dependency %s", d.Name())
 		depsRebuilt, state = s.RunTarget(d, c)
 		if ss, ok := t.(SetStater); ok {
 			ss.SetState(d.Name(), state)
 		}
 	}
+	cli.Logf("=======> All dependencies of %s built", t.Name())
 	// Now we have run all dependencies, run this
 	// one if necessary...
 	rebuilt := s.BuildIfNecessary(t, c)

--- a/core/targets.go
+++ b/core/targets.go
@@ -34,6 +34,10 @@ type Staler interface {
 	Stale(*Context) bool
 }
 
+type DockerRunner interface {
+	DockerRun(*Context) *docker.Run
+}
+
 // Target describes a buildable Docker image that performs a particular task related to building
 // testing and deploying the application. Each pack under packs/ will customise its targets for
 // the specific jobs that need to be performed for that pack.

--- a/core/targets.go
+++ b/core/targets.go
@@ -241,7 +241,17 @@ func (s *Sous) NeedsToBuildNewImage(t Target, c *Context, asDependency bool) (bo
 			return true, reason
 		}
 	} else if changes.Any() {
-		return true, "default change detector detected changes"
+		reason := "changes were detected"
+		if changes.WorkingTreeChanged {
+			reason = "your working tree has changed"
+		} else if changes.NewCommit {
+			reason = "you have a new commit"
+		} else if changes.NoBuiltImage {
+			reason = "no corresponding image exists yet"
+		} else if changes.SousUpdated {
+			reason = "sous itself was updated"
+		}
+		return true, reason
 	}
 	// Always force a rebuild if is base image has been updated.
 	baseImage := t.Dockerfile().From

--- a/core/targets.go
+++ b/core/targets.go
@@ -30,6 +30,10 @@ type Target interface {
 	Dockerfile() *docker.Dockerfile
 }
 
+type Staler interface {
+	Stale(*Context) bool
+}
+
 // Target describes a buildable Docker image that performs a particular task related to building
 // testing and deploying the application. Each pack under packs/ will customise its targets for
 // the specific jobs that need to be performed for that pack.

--- a/core/targets.go
+++ b/core/targets.go
@@ -96,7 +96,7 @@ func MustGetTargetBase(name string) *TargetBase {
 }
 
 type ImageIsStaler interface {
-	ImageIsStale(*Context) bool
+	ImageIsStale(*Context) (bool, string)
 }
 
 type PreDockerBuilder interface {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 	"os/signal"
 	"syscall"
@@ -17,12 +18,14 @@ func main() {
 	if len(os.Args) < 2 {
 		usage()
 	}
-	command := os.Args[1]
+	sousFlags, args := parseFlags(os.Args)
+	command := args[1]
 	if command != "config" {
 		updateHourly()
 	}
 	cfg := config.Load()
-	sous := core.NewSous(Version, Revision, OS, Arch, loadCommands(), BuildPacks(cfg))
+	sous := core.NewSous(Version, Revision, OS, Arch,
+		loadCommands(), BuildPacks(cfg), sousFlags)
 	c, ok := sous.Commands[command]
 	if !ok {
 		cli.Fatalf("Command %s not recognised; try `sous help`", command)
@@ -32,6 +35,20 @@ func main() {
 	c.Func(sous, os.Args[2:])
 	// If it does not, we assume it failed...
 	cli.Fatalf("Command did not complete correctly")
+}
+
+func parseFlags(args []string) (*core.SousFlags, []string) {
+	flagSet := flag.NewFlagSet("sous", flag.ExitOnError)
+	rebuild := flagSet.Bool("rebuild", false, "force a rebuild")
+	rebuildAll := flagSet.Bool("rebuild-all", false, "force a rebuild of this target plus all dependencies")
+	err := flagSet.Parse(args)
+	if err != nil {
+		cli.Fatalf("%s", err)
+	}
+	return &core.SousFlags{
+		ForceRebuild:    *rebuild,
+		ForceRebuildAll: *rebuildAll,
+	}, flagSet.Args()
 }
 
 func usage() {

--- a/main.go
+++ b/main.go
@@ -13,18 +13,19 @@ import (
 
 func main() {
 	trapSignals()
-	sous := core.NewSous(Version, Revision, OS, Arch, loadCommands(), buildPacks)
 	defer cli.Cleanup()
 	if len(os.Args) < 2 {
 		usage()
 	}
 	command := os.Args[1]
+	if command != "config" {
+		updateHourly()
+	}
+	cfg := config.Load()
+	sous := core.NewSous(Version, Revision, OS, Arch, loadCommands(), BuildPacks(cfg))
 	c, ok := sous.Commands[command]
 	if !ok {
 		cli.Fatalf("Command %s not recognised; try `sous help`", command)
-	}
-	if command != "config" {
-		updateHourly()
 	}
 	// It is the responsibility of the command to exit with an appropriate
 	// error code...

--- a/packs/nodejs/app_target.go
+++ b/packs/nodejs/app_target.go
@@ -48,16 +48,7 @@ func (t *AppTarget) PreDockerBuild(c *core.Context) {
 	}
 	filename := path.Base(t.artifactPath)
 	localArtifact := filename
-	cli.AddCleanupTask(func() error {
-		if file.Exists(localArtifact) {
-			file.Remove(localArtifact)
-		}
-		if file.Exists(localArtifact) {
-			return fmt.Errorf("Unable to clean up link %s; please remove it manually", localArtifact)
-		}
-		return nil
-	})
-	file.Link(t.artifactPath, localArtifact)
+	file.TemporaryLink(t.artifactPath, localArtifact)
 	t.artifactPath = localArtifact
 }
 

--- a/packs/nodejs/app_target.go
+++ b/packs/nodejs/app_target.go
@@ -11,8 +11,8 @@ type AppTarget struct {
 	*NodeJSTarget
 }
 
-func NewAppTarget(np *NodePackage) *AppTarget {
-	return &AppTarget{NewNodeJSTarget("app", np)}
+func NewAppTarget(pack *Pack) *AppTarget {
+	return &AppTarget{NewNodeJSTarget("app", pack)}
 }
 
 func (t *AppTarget) DependsOn() []string { return nil }
@@ -24,15 +24,15 @@ func (t *AppTarget) Desc() string {
 }
 
 func (t *AppTarget) Check() error {
-	if len(t.PackageJSON.Scripts.Start) == 0 {
+	if len(t.Pack.PackageJSON.Scripts.Start) == 0 {
 		return fmt.Errorf("package.json does not specify a start script")
 	}
 	return nil
 }
 
 func (t *AppTarget) Dockerfile() *docker.Dockerfile {
-	np := t.PackageJSON
-	df := baseDockerfile(np)
+	np := t.Pack.PackageJSON
+	df := t.Pack.baseDockerfile(np.Version)
 	if np.Scripts.InstallProduction != "" {
 		df.AddRun(np.Scripts.InstallProduction)
 	} else {

--- a/packs/nodejs/app_target.go
+++ b/packs/nodejs/app_target.go
@@ -3,6 +3,7 @@ package nodejs
 import (
 	"fmt"
 
+	"github.com/opentable/sous/core"
 	"github.com/opentable/sous/tools"
 	"github.com/opentable/sous/tools/docker"
 )
@@ -15,7 +16,11 @@ func NewAppTarget(pack *Pack) *AppTarget {
 	return &AppTarget{NewNodeJSTarget("app", pack)}
 }
 
-func (t *AppTarget) DependsOn() []string { return nil }
+func (t *AppTarget) DependsOn() []core.Target {
+	return []core.Target{
+		NewCompileTarget(t.Pack),
+	}
+}
 
 func (t *AppTarget) RunAfter() []string { return []string{"compile"} }
 

--- a/packs/nodejs/compile_target.go
+++ b/packs/nodejs/compile_target.go
@@ -1,0 +1,64 @@
+package nodejs
+
+import (
+	"fmt"
+
+	"github.com/opentable/sous/tools/cli"
+	"github.com/opentable/sous/tools/docker"
+)
+
+type CompileTarget struct {
+	*NodeJSTarget
+}
+
+func NewCompileTarget(pack *Pack) *CompileTarget {
+	return &CompileTarget{NewNodeJSTarget("compile", pack)}
+}
+
+func (t *CompileTarget) DependsOn() []string { return nil }
+
+func (t *CompileTarget) RunAfter() []string { return nil }
+
+func (t *CompileTarget) Desc() string {
+	return "The NodeJS compile target invokes `npm install` inside the container, and zips up the resultant app dir"
+}
+
+func (t *CompileTarget) Check() error {
+	return nil
+}
+
+func (t *CompileTarget) Dockerfile() *docker.Dockerfile {
+	//np := t.PackageJSON
+	df := &docker.Dockerfile{}
+	df.From = ""
+	df.CMD = []string{"cd /wd && ls -lah / &&  ./build.bash"}
+	return df
+}
+
+// Run first checks if a container with the right name has already been built. If so,
+// it re-uses that container (note: this container is built exactly once per project,
+// per configuration par change or upgrade to sous, not when source code generally,
+// nor even dependencies change.
+//
+// It builds a stateful container with the NPM cache that implies, which is re-used
+// for every build of this project. It's basically a caching layer. It is based on the
+// exact same OS and Arch as the production containers, but with additional build tools
+// which enable the building of complex dependencies.
+func (t *CompileTarget) Run() {
+	np := t.Pack.PackageJSON
+	containerName := fmt.Sprintf("sous-builder_%s", np.Name)
+	container := docker.ContainerWithName(containerName)
+	if container.Exists() {
+		if err := container.Start(); err != nil {
+			cli.Fatalf("ERROR: Failed to start build container: %s", err)
+		}
+	} else {
+		cli.Logf("=====> Preparing build container for first run")
+		run := docker.NewRun("")
+		if run.ExitCode() != 0 {
+			cli.Fatalf("ERROR: Preparing build container failed, see logs above.")
+		}
+	}
+	// docker run -v "$PWD:/wd" -v "$HOME/.sous:/artifacts" start-page-builder
+	docker.NewRun("")
+}

--- a/packs/nodejs/compile_target.go
+++ b/packs/nodejs/compile_target.go
@@ -39,8 +39,8 @@ func (t *CompileTarget) Dockerfile() *docker.Dockerfile {
 // This image does not get stale because of any changes to the project itself.
 // Everything is stale when Sous or its configuration is updated, or when the
 // relevant Docker base image is updated.
-func (t *CompileTarget) ImageIsStale(c *core.Context) bool {
-	return false
+func (t *CompileTarget) ImageIsStale(c *core.Context) (bool, string) {
+	return false, ""
 }
 
 // This container does not get stale unless the working directory is changed, but

--- a/packs/nodejs/compile_target.go
+++ b/packs/nodejs/compile_target.go
@@ -17,7 +17,7 @@ func NewCompileTarget(pack *Pack) *CompileTarget {
 	return &CompileTarget{NewNodeJSTarget("compile", pack)}
 }
 
-func (t *CompileTarget) DependsOn() []string { return nil }
+func (t *CompileTarget) DependsOn() []core.Target { return nil }
 
 func (t *CompileTarget) RunAfter() []string { return nil }
 
@@ -57,7 +57,7 @@ func (t *CompileTarget) DockerRun(c *core.Context) *docker.Run {
 	containerName := fmt.Sprintf("%s_reusable_builder", c.CanonicalPackageName())
 	container := docker.ContainerWithName(containerName)
 	if container.Exists() {
-		cli.Logf("Re-using build container")
+		cli.Logf("Re-using build container %s", container)
 		return docker.NewReRun(container)
 	}
 	cli.Logf("====> Preparing build container for first use")

--- a/packs/nodejs/compile_target.go
+++ b/packs/nodejs/compile_target.go
@@ -47,8 +47,8 @@ func (t *CompileTarget) ImageIsStale(c *core.Context) (bool, string) {
 // we currently don't have a way to check this.
 // TODO: Record WD changes in context so we can invalidate the container when the
 // WD changes.
-func (t *CompileTarget) ContainerIsStale(c *core.Context) bool {
-	return false
+func (t *CompileTarget) ContainerIsStale(c *core.Context) (bool, string) {
+	return false, ""
 }
 
 func (t *CompileTarget) ImageTag(c *core.Context) string {

--- a/packs/nodejs/compile_target.go
+++ b/packs/nodejs/compile_target.go
@@ -35,13 +35,11 @@ func (t *CompileTarget) Dockerfile() *docker.Dockerfile {
 	return df
 }
 
-// Stale for this target only rebuilds when Sous itself is updated. This is
-// because we want to preserve the same container as long as possible, as it
-// builds up a cache, speeding up builds. When Sous itself is updated (either a
-// new version of the binary, or the config is changed) we must always re-build
-// everything, as base images and policies may have been updated.
+// This image does not get stale because of any changes to the project itself.
+// Everything is stale when Sous or its configuration is updated, or when the
+// relevant Docker base image is updated.
 func (t *CompileTarget) Stale(c *core.Context) bool {
-	return c.ChangesSinceLastBuild().SousUpdated
+	return false
 }
 
 // Run first checks if a container with the right name has already been built. If so,

--- a/packs/nodejs/compile_target.go
+++ b/packs/nodejs/compile_target.go
@@ -31,7 +31,7 @@ func (t *CompileTarget) Check() error {
 }
 
 func (t *CompileTarget) Dockerfile() *docker.Dockerfile {
-	df := t.Pack.baseDockerfile(t.Name())
+	df := t.NodeJSPack.baseDockerfile(t.Name())
 	df.AddRun("npm install -g npm@2")
 	return df
 }

--- a/packs/nodejs/nodejs.go
+++ b/packs/nodejs/nodejs.go
@@ -57,7 +57,7 @@ var wd = "/srv/app/"
 func (p *Pack) baseDockerfile(target string) *docker.Dockerfile {
 	np := p.PackageJSON
 	nodeVersion := p.bestSupportedNodeVersion()
-	from := p.dockerFrom(nodeVersion, target)
+	from := p.dockerFrom(nodeVersion, target) + ":latest"
 	npmVer := defaultNPMVersion
 	if np.Engines.NPM != "" {
 		npmVer = version.Range(np.Engines.NPM).BestMatchFrom(npmVersions)

--- a/packs/nodejs/nodejs.go
+++ b/packs/nodejs/nodejs.go
@@ -72,8 +72,8 @@ func (p *Pack) baseDockerfile(target string) *docker.Dockerfile {
 		Workdir:     wd,
 		LabelPrefix: "com.opentable",
 	}
-	npmMajorVer := npmVer.String()[0:1]
-	df.AddRun("npm install -g npm@%s", npmMajorVer)
+	//npmMajorVer := npmVer.String()[0:1]
+	//df.AddRun("npm install -g npm@%s", npmMajorVer)
 	df.AddLabel("stack.name", "NodeJS")
 	df.AddLabel("stack.id", "nodejs")
 	df.AddLabel("stack.nodejs.version", nodeVersion)

--- a/packs/nodejs/nodejs_pack_test.go
+++ b/packs/nodejs/nodejs_pack_test.go
@@ -1,0 +1,24 @@
+package nodejs
+
+import (
+	"testing"
+
+	"github.com/opentable/sous/core"
+)
+
+func TestCompileTarget(t *testing.T) {
+	target := interface{}(&CompileTarget{})
+	if _, ok := target.(core.ImageIsStaler); !ok {
+		t.Errorf("%T does not implement ImageIsStaler", target)
+	}
+	if _, ok := target.(core.Stater); !ok {
+		t.Errorf("%T does not implement Stater", target)
+	}
+}
+
+func TestAppTarget(t *testing.T) {
+	target := interface{}(&AppTarget{})
+	if _, ok := target.(core.SetStater); !ok {
+		t.Errorf("%T does not implement SetStater", target)
+	}
+}

--- a/packs/nodejs/nodejs_target.go
+++ b/packs/nodejs/nodejs_target.go
@@ -5,11 +5,11 @@ import "github.com/opentable/sous/core"
 // NodeJSTarget is the base for all NodeJS targets
 type NodeJSTarget struct {
 	*core.TargetBase
-	Pack *Pack
+	NodeJSPack *Pack
 }
 
 // NewNodeJSTarget creates a new NodeJSTarget based on a known target name
 // from core.
 func NewNodeJSTarget(name string, pack *Pack) *NodeJSTarget {
-	return &NodeJSTarget{core.MustGetTargetBase(name), pack}
+	return &NodeJSTarget{core.MustGetTargetBase(name, pack), pack}
 }

--- a/packs/nodejs/nodejs_target.go
+++ b/packs/nodejs/nodejs_target.go
@@ -5,11 +5,11 @@ import "github.com/opentable/sous/core"
 // NodeJSTarget is the base for all NodeJS targets
 type NodeJSTarget struct {
 	*core.TargetBase
-	PackageJSON *NodePackage
+	Pack *Pack
 }
 
 // NewNodeJSTarget creates a new NodeJSTarget based on a known target name
 // from core.
-func NewNodeJSTarget(name string, np *NodePackage) *NodeJSTarget {
-	return &NodeJSTarget{core.MustGetTargetBase(name), np}
+func NewNodeJSTarget(name string, pack *Pack) *NodeJSTarget {
+	return &NodeJSTarget{core.MustGetTargetBase(name), pack}
 }

--- a/packs/nodejs/test_target.go
+++ b/packs/nodejs/test_target.go
@@ -10,8 +10,8 @@ type TestTarget struct {
 	*NodeJSTarget
 }
 
-func NewTestTarget(np *NodePackage) *TestTarget {
-	return &TestTarget{NewNodeJSTarget("test", np)}
+func NewTestTarget(pack *Pack) *TestTarget {
+	return &TestTarget{NewNodeJSTarget("test", pack)}
 }
 
 func (t *TestTarget) DependsOn() []string { return nil }
@@ -23,14 +23,14 @@ func (t *TestTarget) Desc() string {
 }
 
 func (t *TestTarget) Check() error {
-	if len(t.PackageJSON.Scripts.Test) == 0 {
+	if len(t.Pack.PackageJSON.Scripts.Test) == 0 {
 		return fmt.Errorf("package.json does not specify a test script")
 	}
 	return nil
 }
 
 func (t *TestTarget) Dockerfile() *docker.Dockerfile {
-	df := baseDockerfile(t.PackageJSON)
+	df := t.Pack.baseDockerfile("test")
 	df.AddRun("cd " + wd + " && npm install")
 	df.AddLabel("com.opentable.tests", "true")
 	df.CMD = []string{"npm", "test"}

--- a/packs/nodejs/test_target.go
+++ b/packs/nodejs/test_target.go
@@ -3,6 +3,7 @@ package nodejs
 import (
 	"fmt"
 
+	"github.com/opentable/sous/core"
 	"github.com/opentable/sous/tools/docker"
 )
 
@@ -14,7 +15,7 @@ func NewTestTarget(pack *Pack) *TestTarget {
 	return &TestTarget{NewNodeJSTarget("test", pack)}
 }
 
-func (t *TestTarget) DependsOn() []string { return nil }
+func (t *TestTarget) DependsOn() []core.Target { return nil }
 
 func (t *TestTarget) RunAfter() []string { return []string{"compile"} }
 

--- a/packs/nodejs/test_target.go
+++ b/packs/nodejs/test_target.go
@@ -24,14 +24,14 @@ func (t *TestTarget) Desc() string {
 }
 
 func (t *TestTarget) Check() error {
-	if len(t.Pack.PackageJSON.Scripts.Test) == 0 {
+	if len(t.NodeJSPack.PackageJSON.Scripts.Test) == 0 {
 		return fmt.Errorf("package.json does not specify a test script")
 	}
 	return nil
 }
 
 func (t *TestTarget) Dockerfile() *docker.Dockerfile {
-	df := t.Pack.baseDockerfile("test")
+	df := t.NodeJSPack.baseDockerfile("test")
 	df.AddRun("cd " + wd + " && npm install")
 	df.AddLabel("com.opentable.tests", "true")
 	df.CMD = []string{"npm", "test"}

--- a/registry.go
+++ b/registry.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"github.com/opentable/sous/config"
 	"github.com/opentable/sous/core"
 	"github.com/opentable/sous/packs/nodejs"
 )
 
-var buildPacks = []core.Pack{
-	&nodejs.Pack{},
+func BuildPacks(c *config.Config) []core.Pack {
+	return []core.Pack{
+		nodejs.New(c.Packs.NodeJS),
+	}
 }

--- a/scripts/install-dev
+++ b/scripts/install-dev
@@ -34,6 +34,7 @@ if ! go install -ldflags "$FLAGS"; then
 fi
 if ! go test ./...; then
 	echo "Tests failed."
+	exit 1
 fi
 # Finally, make sure we can still execute sous version
 sous version

--- a/tools/cmd/cmd.go
+++ b/tools/cmd/cmd.go
@@ -36,6 +36,7 @@ func (C *CMD) execute() (code int, err error) {
 	c := exec.Command(C.Name, C.Args...)
 	c.Stdout = C.Stdout
 	c.Stderr = C.Stderr
+	c.Env = os.Environ()
 	if C.EchoStdout {
 		c.Stdout = io.MultiWriter(os.Stdout, c.Stdout)
 	}
@@ -48,11 +49,11 @@ func (C *CMD) execute() (code int, err error) {
 	if C.WriteStderr != nil {
 		c.Stderr = io.MultiWriter(C.WriteStderr, c.Stderr)
 	}
-	if err := c.Start(); err != nil {
-		cli.Fatalf("Unable to begin command execution; %s", err)
-	}
 	if C.EchoStdout || C.EchoStderr {
 		cli.Logf("shell> %s", C)
+	}
+	if err := c.Start(); err != nil {
+		cli.Fatalf("Unable to begin command execution; %s", err)
 	}
 	err = c.Wait()
 	if err != nil {

--- a/tools/docker/container.go
+++ b/tools/docker/container.go
@@ -1,0 +1,68 @@
+package docker
+
+import (
+	"fmt"
+
+	"github.com/opentable/sous/tools/cli"
+	"github.com/opentable/sous/tools/cmd"
+)
+
+type Container interface {
+	CID() string
+	Name() string
+	String() string
+	Kill() error
+	Start() error
+	Exists() bool
+}
+
+type container struct {
+	cid, name string
+}
+
+func ContainerWithName(name string) Container {
+	return &container{"", name}
+}
+
+func ContainerWithCID(cid string) Container {
+	return &container{cid, ""}
+}
+
+func (c *container) CID() string  { return c.cid }
+func (c *container) Name() string { return c.name }
+
+func (c *container) Exists() bool {
+	t := cmd.Table("docker", "ps", "-a", "--no-trunc")
+	var match func([]string) bool
+	if c.name != "" {
+		match = func(row []string) bool { return row[6] == c.name }
+	} else if c.cid != "" {
+		match = func(row []string) bool { return row[0] == c.cid }
+	} else {
+		cli.Fatalf("Sous Programmer Error: Container has neither CID nor Name")
+	}
+	for _, r := range t {
+		if match(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *container) Kill() error {
+	if ex := cmd.ExitCode("docker", "kill", c.cid); ex != 0 {
+		return fmt.Errorf("Unable to kill docker container %s", c)
+	}
+	return nil
+}
+
+func (c *container) Start() error {
+	if ex := cmd.ExitCode("docker", "start", c.cid); ex != 0 {
+		return fmt.Errorf("Unable to start docker container %s", c)
+	}
+	return nil
+}
+
+func (c *container) String() string {
+	return c.cid
+}

--- a/tools/docker/container.go
+++ b/tools/docker/container.go
@@ -10,6 +10,7 @@ import (
 type Container interface {
 	CID() string
 	Name() string
+	Image() string
 	String() string
 	Kill() error
 	Remove() error
@@ -51,6 +52,22 @@ func (c *container) Running() bool {
 	}
 	cli.Fatalf("Sous Programmer Error: Container has neither CID nor Name")
 	return false
+}
+
+func (c *container) Image() string {
+	var dc []DockerContainer
+	cmd.JSON(&dc, "docker", "inspect", c.Name())
+	if len(dc) == 0 {
+		cli.Fatalf("Container %s does not exist.", c)
+	}
+	if len(dc) != 1 {
+		cli.Fatalf("Multiple containers match %s", c)
+	}
+	return dc[0].Image
+}
+
+type DockerContainer struct {
+	ID, Name, Image string
 }
 
 func (c *container) Kill() error {

--- a/tools/docker/container.go
+++ b/tools/docker/container.go
@@ -35,9 +35,9 @@ func (c *container) Name() string { return c.name }
 
 func (c *container) Exists() bool {
 	if c.name != "" {
-		return len(cmd.Lines("docker", "ps", "-a", "--filter", "name="+c.name)) != 0
+		return len(cmd.Lines("docker", "ps", "-a", "--filter", "name="+c.name)) > 1
 	} else if c.cid != "" {
-		return len(cmd.Lines("docker", "ps", "-a", "--filter", "id="+c.cid)) != 0
+		return len(cmd.Lines("docker", "ps", "-a", "--filter", "id="+c.cid)) > 1
 	}
 	cli.Fatalf("Sous Programmer Error: Container has neither CID nor Name")
 	return false
@@ -45,9 +45,9 @@ func (c *container) Exists() bool {
 
 func (c *container) Running() bool {
 	if c.name != "" {
-		return len(cmd.Lines("docker", "ps", "--filter", "name="+c.name)) != 0
+		return len(cmd.Lines("docker", "ps", "--filter", "name="+c.name)) > 1
 	} else if c.cid != "" {
-		return len(cmd.Lines("docker", "ps", "--filter", "id="+c.cid)) != 0
+		return len(cmd.Lines("docker", "ps", "--filter", "id="+c.cid)) > 1
 	}
 	cli.Fatalf("Sous Programmer Error: Container has neither CID nor Name")
 	return false

--- a/tools/docker/docker.go
+++ b/tools/docker/docker.go
@@ -97,11 +97,13 @@ func BuildFile(dockerfile, dir, tag string) string {
 		if file.Exists(".dockerignore") {
 			cli.Logf("WARNING: Local .dockerignore found; it is recommended to remove this, and allow Sous to use your .gitignore instead")
 		} else {
-			file.Link(".gitignore", ".dockerignore")
-			file.RemoveOnExit(".dockerignore")
+			file.TemporaryLink(".gitignore", ".dockerignore")
+			// We try to clean this file up early, in preperation for the next build step
+			defer file.Remove(".dockerignore")
 		}
 	}
-	file.Link(dockerfile, localDockerfile)
+	file.TemporaryLink(dockerfile, localDockerfile)
+	// We try to clean the local Dockerfile up early, in preperation for the next build step
 	defer file.Remove(localDockerfile)
 	return dockerCmd("build", "-f", localDockerfile, "-t", tag, dir).Out()
 }

--- a/tools/docker/docker.go
+++ b/tools/docker/docker.go
@@ -156,6 +156,9 @@ func ImageID(image string) string {
 }
 
 func BaseImageUpdated(baseImageTag, builtImageTag string) bool {
+	if !ImageExists(baseImageTag) {
+		return true
+	}
 	baseImageID := ImageID(baseImageTag)
 	layers := Layers(builtImageTag)
 	for _, l := range layers {

--- a/tools/docker/run.go
+++ b/tools/docker/run.go
@@ -61,7 +61,7 @@ func (r *Run) ExitCode() int {
 	return r.prepareCommand().ExitCode()
 }
 
-func (r *Run) Start() (*Container, error) {
+func (r *Run) Start() (*container, error) {
 	r.inBackground = true
 	c := r.prepareCommand()
 	cid := c.Out()
@@ -72,16 +72,5 @@ func (r *Run) Start() (*Container, error) {
 	if err != nil {
 		cli.Fatalf("Unable to tail logs: %s", err)
 	}
-	return &Container{cid}, nil
-}
-
-type Container struct {
-	CID string
-}
-
-func (c *Container) Kill() error {
-	if ex := cmd.ExitCode("docker", "kill", c.CID); ex != 0 {
-		return fmt.Errorf("exit code %d", ex)
-	}
-	return nil
+	return &container{cid, ""}, nil
 }

--- a/tools/file/cleanup.go
+++ b/tools/file/cleanup.go
@@ -15,8 +15,16 @@ func RemoveOnExit(path string) {
 			Remove(path)
 		}
 		if Exists(path) {
-			return fmt.Errorf("Unable to remove temporary file %s", path)
+			return fmt.Errorf("Unable to remove temporary object %s; please remove it manually.", path)
 		}
 		return nil
 	})
+}
+
+func TemporaryLink(path, newPath string) {
+	if Exists(newPath) {
+		cli.Fatalf("Unable to link file to %s, it already exists", newPath)
+	}
+	RemoveOnExit(newPath)
+	Link(path, newPath)
 }


### PR DESCRIPTION
This avoids having production containers with too many dependencies installed, like make, gcc, etc.

Also contains updates to stale build detection, and adds -rebuild and -rebuild-all flags to the build, test, run, and contracts commands.