### PR TITLE
Validation

### DIFF
--- a/sous/manifest.go
+++ b/sous/manifest.go
@@ -13,14 +13,14 @@ type (
 	// Manifest has a direct two-way mapping to/from Deployments.
 	Manifest struct {
 		// Source is the location of the source code for this piece of software.
-		Source SourceLocation `validate:"nonZero"`
+		Source SourceLocation `validate:"nonzero"`
 		// Owners is a list of named owners of this repository. The type of this
 		// field is subject to change.
 		Owners []string
 		// Kind is the kind of software that SourceRepo represents.
-		Kind ManifestKind `validate:"nonZero"`
+		Kind ManifestKind `validate:"nonzero"`
 		// Deployments is a map of cluster names to DeploymentSpecs
-		Deployments map[string]PartialDeploySpec `validate:"nonEmpty,valuesNonZero"`
+		Deployments map[string]PartialDeploySpec `validate:"keys=nonempty,values=nonzero"`
 	}
 	// ManifestKind describes the broad category of a piece of software, such as
 	// a long-running HTTP service, or a scheduled task, etc. It is used to
@@ -47,7 +47,7 @@ type (
 		//        the source code repository containing this application.
 		//     2. The metadata field is the full revision ID of the commit
 		//        which the tag in 1. points to.
-		Version semv.Version `validate:"nonZero"`
+		Version semv.Version `validate:"nonzero"`
 		// clusterName is the name of the cluster this deployment belongs to. Upon
 		// parsing the Manifest, this will be set to the key in
 		// Manifests.Deployments which points at this Deployment.
@@ -60,12 +60,12 @@ type (
 	DeployConfig struct {
 		// Resources represents the resources each instance of this software
 		// will be given by the execution environment.
-		Resources Resources `validate:"nonZero"`
+		Resources Resources `validate:"keys=nonempty,values=nonempty"`
 		// Env is a list of environment variables to set for each instance of
 		// of this deployment. It will be checked for conflict with the
 		// definitions found in State.Defs.EnvVars, and if not in conflict
 		// assumes the greatest priority.
-		Env map[string]string
+		Env map[string]string `validate:"keys=nonempty,values=nonempty"`
 		// NumInstances is a guide to the number of instances that should be
 		// deployed in this cluster, note that the actual number may differ due
 		// to decisions made by Sous. If set to zero, Sous will decide how many

--- a/util/validator/validator.go
+++ b/util/validator/validator.go
@@ -1,0 +1,239 @@
+package validator
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type (
+	Interface interface {
+		Validate() error
+	}
+	validator func(reflect.Value) error
+	ctx       struct {
+		parent *ctx
+		field  *reflect.StructField
+		typ    reflect.Type
+		key    bool
+		index  *string
+	}
+	// ValidationError indicates an error with validation.
+	ValidationError struct {
+		ctx
+		Problem string
+	}
+)
+
+var validators = map[string]func(reflect.Value, *ctx) error{
+	"nonempty":        nonempty,
+	"keys=nonempty":   keys(nonempty),
+	"values=nonempty": values(nonempty),
+	"nonzero":         nonzero,
+	"keys=nonzero":    keys(nonzero),
+	"values=nonzero":  values(nonzero),
+}
+
+func (e ValidationError) Error() string {
+	return fmt.Sprintf("%s %s", e.ctx, e.Problem)
+}
+
+func (c ctx) String() string {
+	if c.parent == nil {
+		return c.ownString()
+	}
+	return c.parent.String() + "." + c.ownString()
+}
+
+func (c ctx) ownString() string {
+	if c.typ != nil {
+		return c.typ.String()
+	}
+	if c.field != nil {
+		return c.field.Name
+	}
+	if c.key {
+		return "(key)"
+	}
+	if c.index != nil {
+		return fmt.Sprintf("[%s]", *c.index)
+	}
+	return "?"
+}
+
+func (c ctx) validationErrorf(format string, a ...interface{}) ValidationError {
+	return ValidationError{c, fmt.Sprintf(format, a...)}
+}
+
+func (c ctx) err(err error) error {
+	if ve, ok := err.(ValidationError); ok {
+		ve.ctx = c
+		return ve
+	}
+	return c.validationErrorf(err.Error())
+}
+
+func (c ctx) enterField(f reflect.StructField) ctx {
+	return ctx{parent: &c, field: &f}
+}
+
+func (c ctx) enterKey() ctx {
+	return ctx{parent: &c, key: true}
+}
+
+func (c ctx) enterIndex(index reflect.Value) ctx {
+	i := fmt.Sprint(index.Interface())
+	return ctx{parent: &c, index: &i}
+}
+
+func errIf(condition bool, format string, a ...interface{}) error {
+	if !condition {
+		return nil
+	}
+	return fmt.Errorf(format, a...)
+}
+
+func (c *ctx) validationNotPossible(which, format string, a ...interface{}) error {
+	m := fmt.Sprintf(format, a...)
+	return fmt.Errorf("validation rule invalid: %s `validate:%q` (%s)", c, which, m)
+}
+
+func nonempty(v reflect.Value, c *ctx) error {
+	switch v.Kind() {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
+		if v.Len() != 0 {
+			return nil
+		}
+		return c.validationErrorf("is nil or empty")
+	}
+	return c.validationNotPossible("nonempty", "nonempty validation not possible for %s", v.Type())
+}
+
+func nonzero(v reflect.Value, c *ctx) error {
+	zero := reflect.Zero(v.Type())
+	if v.Interface() == zero.Interface() {
+		return c.validationErrorf("is equal to zero value (%+v)", zero.Interface())
+	}
+	return nil
+}
+
+func keys(f func(reflect.Value, *ctx) error) func(reflect.Value, *ctx) error {
+	return func(v reflect.Value, c *ctx) error {
+		if v.Kind() != reflect.Map {
+			return fmt.Errorf("keys validator used on %s; only allowed on maps", v.Type())
+		}
+		for _, k := range v.MapKeys() {
+			if err := f(k, c); err != nil {
+				return c.enterKey().err(err)
+			}
+		}
+		return nil
+	}
+}
+
+func values(f func(reflect.Value, *ctx) error) func(reflect.Value, *ctx) error {
+	return func(v reflect.Value, c *ctx) error {
+		if v.Kind() == reflect.Map {
+			return mapValues(f, v, c)
+		}
+		if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+			return sliceValues(f, v, c)
+		}
+		return fmt.Errorf("nonemptyValues validator used on %s; only allowed on map, slice, array", v.Type())
+	}
+}
+
+func mapValues(f func(reflect.Value, *ctx) error, v reflect.Value, c *ctx) error {
+	for _, k := range v.MapKeys() {
+		vk := v.MapIndex(k)
+		if err := validateInterface(vk, c); err != nil {
+			return c.enterIndex(k).err(err)
+		}
+		if err := f(vk, c); err != nil {
+			return c.enterIndex(k).err(err)
+		}
+	}
+	return nil
+}
+
+func sliceValues(f func(reflect.Value, *ctx) error, v reflect.Value, c *ctx) error {
+	for i := 0; i < v.Len(); i++ {
+		vi := v.Index(i)
+		if err := validateInterface(vi, c); err != nil {
+			return c.enterIndex(reflect.ValueOf(i)).err(err)
+		}
+		if err := f(vi, c); err != nil {
+			return c.enterIndex(reflect.ValueOf(i)).err(err)
+		}
+	}
+	return nil
+}
+
+func Validate(x interface{}) error {
+	if x == nil {
+		return fmt.Errorf("cannot validate nil")
+	}
+	v := reflect.ValueOf(x)
+	c := &ctx{typ: v.Type()}
+	return validateStruct(v, c)
+}
+
+func validateStruct(v reflect.Value, c *ctx) error {
+	if err := validateInterface(v, c); err != nil {
+		return err
+	}
+	k := v.Kind()
+	t := v.Type()
+	if k != reflect.Struct {
+		if k == reflect.Ptr {
+			return validateStruct(v.Elem(), c)
+		}
+		return fmt.Errorf("cannot validate %s (non-struct value) without context", t)
+	}
+	for i := 0; i < v.NumField(); i++ {
+		f := t.Field(i)
+		if err := validateStructField(v.Field(i), f, c.enterField(f)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateInterface(v reflect.Value, c *ctx) error {
+	if v.CanInterface() {
+		if vi, ok := v.Interface().(Interface); ok {
+			if err := vi.Validate(); err != nil {
+				return c.validationErrorf(err.Error())
+			}
+		}
+	}
+	return nil
+}
+
+func validateStructField(v reflect.Value, f reflect.StructField, c ctx) error {
+	// Get validators first as a separate step, so we can fail for
+	// misconfiguration before failing for any validation errors.
+	validators, err := getValidators(f.Tag.Get("validate"), f.Type)
+	if err != nil {
+		return err
+	}
+	for _, validate := range validators {
+		if err := validate(v, &c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getValidators(tag string, typ reflect.Type) ([]func(reflect.Value, *ctx) error, error) {
+	vs := []func(reflect.Value, *ctx) error{}
+	tags := strings.Split(tag, ",")
+	for _, tag := range tags {
+		validate, ok := validators[tag]
+		if !ok {
+			return nil, fmt.Errorf("no validator named %q", tag)
+		}
+		vs = append(vs, validate)
+	}
+	return vs, nil
+}

--- a/util/validator/validator_test.go
+++ b/util/validator/validator_test.go
@@ -85,71 +85,24 @@ func TestValidate_Invalid(t *testing.T) {
 	}
 }
 
-func TestValidate_NonZeroStruct(t *testing.T) {
-	shouldBeValid := []NonZeroStruct{
-		{Struct{String: "x"}},
-		{Struct{Int: 1}},
+func TestValidate_Valid(t *testing.T) {
+	valid := []interface{}{
+		NonemptyString{"x"},
+		NonZeroStruct{Struct{String: "x"}},
+		NonZeroStruct{Struct{Int: 1}},
+		NonemptyMap{Map: map[string]string{"": ""}},
+		NonemptyMap{Map: map[string]string{"": "x"}},
+		NonemptyMap{Map: map[string]string{"x": ""}},
+		NonemptySlice{Slice: []string{""}},
+		NonemptySlice{Slice: []string{"hi"}},
+		NonemptyStringMapKey{Map: nil},
+		NonemptyStringMapKey{Map: map[string]string{"x": ""}},
+		NonemptyStringMapVal{Map: nil},
+		NonemptyStringMapVal{Map: map[string]string{"": "x"}},
 	}
-	for _, x := range shouldBeValid {
+	for _, x := range valid {
 		if err := Validate(x); err != nil {
 			t.Errorf("unexpected error %q for %+v", err, x)
-		}
-	}
-}
-
-func TestValidate_NonemptyStringMapKey(t *testing.T) {
-	shouldBeValid := []NonemptyStringMapKey{
-		{Map: nil},
-		{Map: map[string]string{"x": ""}},
-	}
-	for _, x := range shouldBeValid {
-		if err := Validate(x); err != nil {
-			t.Errorf("unexpected error %q for %+v", err, x)
-		}
-	}
-}
-
-func TestValidate_NonemptyStringMapVal(t *testing.T) {
-	shouldBeValid := []NonemptyStringMapVal{
-		{Map: nil},
-		{Map: map[string]string{"": "x"}},
-	}
-	for _, x := range shouldBeValid {
-		if err := Validate(x); err != nil {
-			t.Errorf("unexpected error %q for %+v", err, x)
-		}
-	}
-}
-
-func TestValidate_NonemptyString(t *testing.T) {
-	x := NonemptyString{"x"}
-	if err := Validate(x); err != nil {
-		t.Errorf("unexpected error %q", err)
-	}
-}
-
-func TestValidate_NonemptyMap(t *testing.T) {
-	shouldBeValid := []NonemptyMap{
-		{Map: map[string]string{"": ""}},
-		{Map: map[string]string{"": "x"}},
-		{Map: map[string]string{"x": ""}},
-	}
-	for _, x := range shouldBeValid {
-		if err := Validate(x); err != nil {
-			t.Errorf("unexpected error %q", err)
-		}
-	}
-}
-
-func TestValidate_NonemptySlice(t *testing.T) {
-	shouldBeValid := []NonemptySlice{
-		{Slice: []string{""}},
-		{Slice: []string{"hi"}},
-	}
-	for _, x := range shouldBeValid {
-		x.Slice = []string{""}
-		if err := Validate(x); err != nil {
-			t.Errorf("unexpected error %q", err)
 		}
 	}
 }

--- a/util/validator/validator_test.go
+++ b/util/validator/validator_test.go
@@ -1,0 +1,155 @@
+package validator
+
+import "testing"
+
+type (
+	inout struct {
+		in  interface{}
+		out string
+	}
+	NonemptyString struct {
+		String string `validate:"nonempty"`
+	}
+	NonemptyMap struct {
+		Map map[string]string `validate:"nonempty"`
+	}
+	NonemptySlice struct {
+		Slice []string `validate:"nonempty"`
+	}
+	// InvalidNonemptyInt cannot be validated since ints do not support nonempty.
+	InvalidNonemptyInt struct {
+		Int int `validate:"nonempty"`
+	}
+	NonemptyStringMapKey struct {
+		Map map[string]string `validate:"keys=nonempty"`
+	}
+	NonemptyStringMapVal struct {
+		Map map[string]string `validate:"values=nonempty"`
+	}
+	NonZeroStruct struct {
+		Struct `validate:"nonzero"`
+	}
+	Struct struct {
+		String string
+		Int    int
+	}
+	NonzeroStructMapKey struct {
+		Map map[Struct]Struct `validate:"keys=nonzero"`
+	}
+	NonzeroStructMapValue struct {
+		Map map[Struct]Struct `validate:"values=nonzero"`
+	}
+)
+
+func TestValidate_Invalid(t *testing.T) {
+	invalid := []inout{
+		{NonemptyString{},
+			"validator.NonemptyString.String is nil or empty"},
+		{NonemptyMap{Map: nil},
+			"validator.NonemptyMap.Map is nil or empty"},
+		{NonemptyMap{Map: map[string]string{}},
+			"validator.NonemptyMap.Map is nil or empty"},
+		{NonemptySlice{Slice: nil},
+			"validator.NonemptySlice.Slice is nil or empty"},
+		{NonemptySlice{Slice: []string{}},
+			"validator.NonemptySlice.Slice is nil or empty"},
+		{NonemptyStringMapKey{Map: map[string]string{"": ""}},
+			"validator.NonemptyStringMapKey.Map.(key) is nil or empty"},
+		{NonemptyStringMapKey{Map: map[string]string{"": "x"}},
+			"validator.NonemptyStringMapKey.Map.(key) is nil or empty"},
+		{NonemptyStringMapVal{Map: map[string]string{"": ""}},
+			"validator.NonemptyStringMapVal.Map.[] is nil or empty"},
+		{NonemptyStringMapVal{Map: map[string]string{"x": ""}},
+			"validator.NonemptyStringMapVal.Map.[x] is nil or empty"},
+		{NonZeroStruct{},
+			"validator.NonZeroStruct.Struct is equal to zero value ({String: Int:0})"},
+		{NonZeroStruct{Struct{String: ""}},
+			"validator.NonZeroStruct.Struct is equal to zero value ({String: Int:0})"},
+		{NonZeroStruct{Struct{Int: 0}},
+			"validator.NonZeroStruct.Struct is equal to zero value ({String: Int:0})"},
+		{InvalidNonemptyInt{Int: 80085},
+			"validation rule invalid: validator.InvalidNonemptyInt.Int `validate:\"nonempty\"` (nonempty validation not possible for int)"},
+	}
+	for _, pair := range invalid {
+		x := pair.in
+		expected := pair.out
+		err := Validate(x)
+		if err == nil {
+			t.Errorf("%+v unexpectedly reported as valid", x)
+			continue
+		}
+		actual := err.Error()
+		if actual != expected {
+			t.Errorf("got %q for %+v; want %q", actual, x, expected)
+		}
+	}
+}
+
+func TestValidate_NonZeroStruct(t *testing.T) {
+	shouldBeValid := []NonZeroStruct{
+		{Struct{String: "x"}},
+		{Struct{Int: 1}},
+	}
+	for _, x := range shouldBeValid {
+		if err := Validate(x); err != nil {
+			t.Errorf("unexpected error %q for %+v", err, x)
+		}
+	}
+}
+
+func TestValidate_NonemptyStringMapKey(t *testing.T) {
+	shouldBeValid := []NonemptyStringMapKey{
+		{Map: nil},
+		{Map: map[string]string{"x": ""}},
+	}
+	for _, x := range shouldBeValid {
+		if err := Validate(x); err != nil {
+			t.Errorf("unexpected error %q for %+v", err, x)
+		}
+	}
+}
+
+func TestValidate_NonemptyStringMapVal(t *testing.T) {
+	shouldBeValid := []NonemptyStringMapVal{
+		{Map: nil},
+		{Map: map[string]string{"": "x"}},
+	}
+	for _, x := range shouldBeValid {
+		if err := Validate(x); err != nil {
+			t.Errorf("unexpected error %q for %+v", err, x)
+		}
+	}
+}
+
+func TestValidate_NonemptyString(t *testing.T) {
+	x := NonemptyString{"x"}
+	if err := Validate(x); err != nil {
+		t.Errorf("unexpected error %q", err)
+	}
+}
+
+func TestValidate_NonemptyMap(t *testing.T) {
+	shouldBeValid := []NonemptyMap{
+		{Map: map[string]string{"": ""}},
+		{Map: map[string]string{"": "x"}},
+		{Map: map[string]string{"x": ""}},
+	}
+	for _, x := range shouldBeValid {
+		if err := Validate(x); err != nil {
+			t.Errorf("unexpected error %q", err)
+		}
+	}
+}
+
+func TestValidate_NonemptySlice(t *testing.T) {
+	shouldBeValid := []NonemptySlice{
+		{Slice: []string{""}},
+		{Slice: []string{"hi"}},
+	}
+	for _, x := range shouldBeValid {
+		x.Slice = []string{""}
+		if err := Validate(x); err != nil {
+			t.Errorf("unexpected error %q", err)
+		}
+	}
+}


### PR DESCRIPTION
Adds a validation helper using tags to validate non-emptiness and non-zeroness of values.

Also adds `validator.Interface` which can be implemented on any type, and will be run against all instances of that type whether they occur as structs, struct fields, map keys, or slice/map/array/pointer values.