### PR TITLE
Resolve() fail fast

### DIFF
--- a/lib/image_mapping_test.go
+++ b/lib/image_mapping_test.go
@@ -1,6 +1,7 @@
 package sous
 
 import (
+	"log"
 	"strings"
 	"testing"
 
@@ -60,6 +61,24 @@ func TestRoundTrip(t *testing.T) {
 		assert.Equal(cn, ncn)
 	}
 
+}
+
+func TestMissingName(t *testing.T) {
+	assert := assert.New(t)
+	log.SetFlags(log.Flags() | log.Lshortfile)
+	dc := docker_registry.NewDummyClient()
+	nc := NewNameCache(dc, "sqlite3", ":memory:")
+
+	v := semv.MustParse("4.5.6")
+	sv := SourceVersion{
+		Version:    v,
+		RepoURL:    RepoURL("https://github.com/opentable/brand-new-idea"),
+		RepoOffset: RepoOffset("nested/there"),
+	}
+
+	name, err := nc.GetImageName(sv)
+	assert.Equal("", name)
+	assert.Error(err)
 }
 
 func TestUnion(t *testing.T) {

--- a/lib/rectifier.go
+++ b/lib/rectifier.go
@@ -2,7 +2,6 @@ package sous
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 	"sync"
 
@@ -132,7 +131,7 @@ func (r *rectifier) rectifyCreates(cc chan *Deployment, errs chan<- Rectificatio
 	for d := range cc {
 		name, err := r.sing.ImageName(d)
 		if err != nil {
-			log.Printf("% +v", d)
+			// log.Printf("% +v", d)
 			errs <- &CreateError{Deployment: d, Err: err}
 			continue
 		}
@@ -140,14 +139,14 @@ func (r *rectifier) rectifyCreates(cc chan *Deployment, errs chan<- Rectificatio
 		reqID := computeRequestID(d)
 		err = r.sing.PostRequest(d.Cluster, reqID, d.NumInstances)
 		if err != nil {
-			log.Printf("%T %#v", d, d)
+			// log.Printf("%T %#v", d, d)
 			errs <- &CreateError{Deployment: d, Err: err}
 			continue
 		}
 
 		err = r.sing.Deploy(d.Cluster, newDepID(), reqID, name, d.Resources)
 		if err != nil {
-			log.Printf("% +v", d)
+			// log.Printf("% +v", d)
 			errs <- &CreateError{Deployment: d, Err: err}
 			continue
 		}

--- a/lib/test/integration_test.go
+++ b/lib/test/integration_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"testing"
 	"time"
@@ -177,10 +176,7 @@ func deploymentWithRepo(assert *assert.Assertions, repo string) (sous.Deployment
 
 func findRepo(deps sous.Deployments, repo string) int {
 	for i := range deps {
-		log.Printf("deps[%d] = %+v\n", i, deps[i])
 		if deps[i] != nil {
-			log.Printf("deps[%d].SV.RUrl = %+v\n", i, deps[i].SourceVersion.RepoURL)
-			log.Printf("repo = %+v\n", repo)
 			if deps[i].SourceVersion.RepoURL == sous.RepoURL(repo) {
 				return i
 			}

--- a/util/shell/sh.go
+++ b/util/shell/sh.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 )
@@ -101,7 +100,6 @@ func (s *Sh) Cmd(name string, args ...interface{}) Cmd {
 
 // List returns all files (including dotfiles) inside Dir.
 func (s *Sh) List() ([]os.FileInfo, error) {
-	log.Println("")
 	return ioutil.ReadDir(s.Cwd)
 }
 
@@ -109,7 +107,6 @@ func (s *Sh) List() ([]os.FileInfo, error) {
 // any errors and returns false, in the case that e.g. permissions
 // prevent the check from working correctly.
 func (s *Sh) Exists(path string) bool {
-	log.Println("")
 	_, err := s.Stat(path)
 	return err == nil
 }
@@ -117,7 +114,6 @@ func (s *Sh) Exists(path string) bool {
 // Stat calls os.Stat on the path provided, relative to the current
 // shell's working directory.
 func (s *Sh) Stat(path string) (os.FileInfo, error) {
-	log.Println("")
 	return os.Stat(s.Abs(path))
 }
 


### PR DESCRIPTION
If we don't know the image name for a source version, Resolve() (and therefore
`sous rectify`) will exit early rather than attempt a deploy that will then
fail.