### PR TITLE
Storage: correct hy tags and test data.

### DIFF
--- a/ext/storage/storage_test.go
+++ b/ext/storage/storage_test.go
@@ -4,13 +4,12 @@ import (
 	"os/exec"
 	"testing"
 
-	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/yaml"
 	"github.com/samsalisbury/semv"
 )
 
 func TestWriteState(t *testing.T) {
-	t.Skip("Doesn't marshal fields of child structs to files - see DCOPS-7430")
 
 	s := exampleState()
 

--- a/ext/storage/test_data/clusters/cluster-1.yaml
+++ b/ext/storage/test_data/clusters/cluster-1.yaml
@@ -1,4 +1,0 @@
-Name: ""
-Kind: singularity
-BaseURL: http://singularity.example.com
-Env: {}

--- a/ext/storage/test_data/clusters/other-cluster.yaml
+++ b/ext/storage/test_data/clusters/other-cluster.yaml
@@ -1,4 +1,0 @@
-Name: ""
-Kind: singularity
-BaseURL: http://some.singularity.cluster
-Env: {}

--- a/ext/storage/test_data/defs.yaml
+++ b/ext/storage/test_data/defs.yaml
@@ -1,3 +1,14 @@
 DockerRepo: docker.somewhere.horse
+Clusters:
+  cluster-1:
+    Name: ""
+    Kind: singularity
+    BaseURL: http://singularity.example.com
+    Env: {}
+  other-cluster:
+    Name: ""
+    Kind: singularity
+    BaseURL: http://some.singularity.cluster
+    Env: {}
 EnvVars: []
 Resources: []

--- a/lib/state.go
+++ b/lib/state.go
@@ -21,7 +21,7 @@ type (
 		// DockerRepo is the host:port (no schema) to connect to the Docker repository
 		DockerRepo string
 		// Clusters is a collection of logical deployment environments.
-		Clusters Clusters `hy:"clusters/"`
+		Clusters Clusters
 		// EnvVars contains definitions for global environment variables.
 		EnvVars EnvDefs
 		// Resources contains definitions for resource types available to
@@ -54,7 +54,7 @@ type (
 	// purpose, etc.
 	Cluster struct {
 		// Name is the unique name of this cluster.
-		Name string `hy:",filename"`
+		Name string
 		// Kind is the kind of cluster. Currently the only legal value is
 		// "singularity"
 		Kind string

--- a/util/hy/context.go
+++ b/util/hy/context.go
@@ -88,7 +88,7 @@ func (c ctx) getStructTargets(v interface{}) (targets, error) {
 func (c ctx) readDirTarget(source, name string, val reflect.Value) (*target, error) {
 	typ := val.Type()
 	if typ.Kind() != reflect.Map {
-		return nil, fmt.Errorf("directory targets only accept maps for now")
+		return nil, fmt.Errorf("directory targets only accept maps")
 	}
 	elemType, err := getElemType(typ)
 	if err != nil {


### PR DESCRIPTION
- Using flattened defs file containing all non-manifest data

See comments in DCOPS-7430
