### PR TITLE
Single manifest

### DIFF
--- a/cli/sous_rectify.go
+++ b/cli/sous_rectify.go
@@ -68,7 +68,7 @@ func (sr *SousRectify) Execute(args []string) cmdr.Result {
 	} else {
 		rc = sous.NewRectiAgent(nc)
 	}
-	var predicate func(*sous.Deployment) bool
+	var predicate sous.DeploymentPredicate
 	if sr.flags.manifest != "" {
 		predicate = func(d *sous.Deployment) bool {
 			return d.SourceVersion.RepoURL == sous.RepoURL(sr.flags.manifest)

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -118,6 +118,18 @@ func (ds *Deployments) Add(d *Deployment) {
 	*ds = append(*ds, d)
 }
 
+// Filter returns a new Deployments, filtered based on a predicate. A predicate
+// value of nil returns an unfiltered copy of ds.
+func (ds *Deployments) Filter(predicate func(*Deployment) bool) Deployments {
+	out := Deployments{}
+	for _, d := range *ds {
+		if predicate == nil || predicate(d) {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
 // BuildDeployment constructs a deployment out of a Manifest
 func BuildDeployment(m *Manifest, spec PartialDeploySpec, inherit DeploymentSpecs) (*Deployment, error) {
 	ownMap := OwnerSet{}

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -49,6 +49,10 @@ type (
 		RequestID string
 	}
 
+	// DeploymentPredicate takes a *Deployment and returns true if the deployment
+	// matches the predicate. Used by Filter to select a subset of a Deployments
+	DeploymentPredicate func(*Deployment) bool
+
 	// DeploymentIntentions represents deployments commanded by a user.
 	DeploymentIntentions []DeploymentIntention
 
@@ -119,11 +123,14 @@ func (ds *Deployments) Add(d *Deployment) {
 }
 
 // Filter returns a new Deployments, filtered based on a predicate. A predicate
-// value of nil returns an unfiltered copy of ds.
-func (ds *Deployments) Filter(predicate func(*Deployment) bool) Deployments {
+// value of nil returns ds.
+func (ds Deployments) Filter(p DeploymentPredicate) Deployments {
+	if p == nil {
+		return ds
+	}
 	out := Deployments{}
-	for _, d := range *ds {
-		if predicate == nil || predicate(d) {
+	for _, d := range ds {
+		if p(d) {
 			out = append(out, d)
 		}
 	}

--- a/lib/image_mapping_test.go
+++ b/lib/image_mapping_test.go
@@ -2,7 +2,6 @@ package sous
 
 import (
 	"log"
-	"os"
 	"testing"
 
 	"github.com/opentable/sous/util/docker_registry"
@@ -44,7 +43,6 @@ func TestRoundTrip(t *testing.T) {
 		RepoOffset: RepoOffset("nested/there"),
 	}
 
-	Log.Debug.SetOutput(os.Stderr)
 	cn = base + "@" + digest
 	dc.FeedMetadata(docker_registry.Metadata{
 		Labels:        newSV.DockerLabels(),

--- a/lib/rectifier.go
+++ b/lib/rectifier.go
@@ -120,7 +120,8 @@ func (e *ChangeError) IntendedDeployment() *Deployment {
 }
 
 // Rectify takes a DiffChans and issues the commands to the infrastructure to reconcile the differences
-func Rectify(dcs DiffChans, errs chan<- RectificationError, s RectificationClient) {
+func Rectify(dcs DiffChans, s RectificationClient) chan RectificationError {
+	errs := make(chan RectificationError)
 	rect := rectifier{s}
 	wg := &sync.WaitGroup{}
 	wg.Add(3)
@@ -128,6 +129,8 @@ func Rectify(dcs DiffChans, errs chan<- RectificationError, s RectificationClien
 	go func() { rect.rectifyDeletes(dcs.Deleted, errs); wg.Done() }()
 	go func() { rect.rectifyModifys(dcs.Modified, errs); wg.Done() }()
 	go func() { wg.Wait(); close(errs) }()
+
+	return errs
 }
 
 func (r *rectifier) rectifyCreates(cc chan *Deployment, errs chan<- RectificationError) {

--- a/lib/rectifier_test.go
+++ b/lib/rectifier_test.go
@@ -38,8 +38,7 @@ func TestModifyScale(t *testing.T) {
 	nc := NewDummyNameCache()
 	client := NewDummyRectificationClient(nc)
 
-	errs := make(chan RectificationError)
-	Rectify(chanset, errs, client)
+	errs := Rectify(chanset, client)
 	chanset.Modified <- pair
 	chanset.Close()
 	for e := range errs {
@@ -86,8 +85,7 @@ func TestModifyImage(t *testing.T) {
 	nc := NewDummyNameCache()
 	client := NewDummyRectificationClient(nc)
 
-	errs := make(chan RectificationError)
-	Rectify(chanset, errs, client)
+	errs := Rectify(chanset, client)
 	chanset.Modified <- pair
 	chanset.Close()
 	for e := range errs {
@@ -138,8 +136,7 @@ func TestModifyResources(t *testing.T) {
 	nc := NewDummyNameCache()
 	client := NewDummyRectificationClient(nc)
 
-	errs := make(chan RectificationError)
-	Rectify(chanset, errs, client)
+	errs := Rectify(chanset, client)
 	chanset.Modified <- pair
 	chanset.Close()
 	for e := range errs {
@@ -185,8 +182,7 @@ func TestModify(t *testing.T) {
 	nc := NewDummyNameCache()
 	client := NewDummyRectificationClient(nc)
 
-	errs := make(chan RectificationError)
-	Rectify(chanset, errs, client)
+	errs := Rectify(chanset, client)
 	chanset.Modified <- pair
 	chanset.Close()
 	for e := range errs {
@@ -221,8 +217,7 @@ func TestDeletes(t *testing.T) {
 	nc := NewDummyNameCache()
 	client := NewDummyRectificationClient(nc)
 
-	errs := make(chan RectificationError)
-	Rectify(chanset, errs, client)
+	errs := Rectify(chanset, client)
 	chanset.Deleted <- deleted
 	chanset.Close()
 	for e := range errs {
@@ -246,8 +241,7 @@ func TestCreates(t *testing.T) {
 	nc := NewDummyNameCache()
 	client := NewDummyRectificationClient(nc)
 
-	errs := make(chan RectificationError)
-	Rectify(chanset, errs, client)
+	errs := Rectify(chanset, client)
 
 	created := &Deployment{
 		SourceVersion: SourceVersion{

--- a/lib/resolve.go
+++ b/lib/resolve.go
@@ -40,10 +40,7 @@ func ResolveFilteredDeployments(rc RectificationClient, state State, pr Deployme
 
 	differ := ads.Diff(gdm)
 
-	errs := make(chan RectificationError)
-	defer close(errs)
-
-	Rectify(differ, errs, rc)
+	errs := Rectify(differ, rc)
 
 	for err := range errs {
 		log.Printf("err = %+v\n", err)

--- a/lib/resolve.go
+++ b/lib/resolve.go
@@ -20,9 +20,9 @@ func Resolve(rc RectificationClient, state State) error {
 
 // ResolveFilteredDeployments is similar to Resolve, but also accepts a
 // predicate to filter those deployments. See Deploments.Filter for details.
-func ResolveFilteredDeployments(rc RectificationClient, state State, predicate func(*Deployment) bool) error {
+func ResolveFilteredDeployments(rc RectificationClient, state State, pr DeploymentPredicate) error {
 	gdm, err := state.Deployments()
-	gdm = gdm.Filter(predicate)
+	gdm = gdm.Filter(pr)
 	if err != nil {
 		return err
 	}
@@ -84,11 +84,11 @@ func ResolveFromDir(rc RectificationClient, dir string) error {
 
 // ResolveFromDirFiltered is similar to ResolveFromDir, but additionally filters
 // the deployments to be resolved based on the predicate.
-func ResolveFromDirFiltered(rc RectificationClient, dir string, predicate func(*Deployment) bool) error {
+func ResolveFromDirFiltered(rc RectificationClient, dir string, pr DeploymentPredicate) error {
 	config, err := LoadState(dir)
 	if err != nil {
 		return err
 	}
 
-	return ResolveFilteredDeployments(rc, config, predicate)
+	return ResolveFilteredDeployments(rc, config, pr)
 }


### PR DESCRIPTION
This is effectively "yes merge, but..."

Two variations from your original, @samsalisbury - I created a type for the predicate function, and changed the Deployments.Filter function to return the Deployments itself if the function is nil. Mostly a little efficiency, but I can see the argument for returning a copy. Let me know what you think.