### PR TITLE
Significant stabilization of resolution

### DIFF
--- a/lib/actual_deployment_set.go
+++ b/lib/actual_deployment_set.go
@@ -155,10 +155,12 @@ func singPipeline(
 	defer catchAndSend(fmt.Sprintf("get requests: %s", client), errs)
 	rs, err := getRequestsFromSingularity(client)
 	if err != nil {
+		Log.Vomit.Print(err)
 		errs <- err
 		return
 	}
 	for _, r := range rs {
+		Log.Vomit.Print("Req: ", r)
 		dw.Add(1)
 		reqs <- r
 	}
@@ -201,9 +203,11 @@ func depPipeline(
 }
 
 func assembleDeployment(cl RectificationClient, req SingReq) (*Deployment, error) {
+	Log.Vomit.Print("Assembling from: ", req)
 	uc := NewDeploymentBuilder(cl, req)
 	err := uc.CompleteConstruction()
 	if err != nil {
+		Log.Vomit.Print(err)
 		return nil, err
 	}
 

--- a/lib/build_test.go
+++ b/lib/build_test.go
@@ -33,7 +33,9 @@ func TestBuild(t *testing.T) {
 	}
 
 	dockerID := "1234512345"
-	tagStr := "docker.wearenice.com/awesomeproject:1.2.3"
+	tagStr := "awesomeproject:1.2.3"
+	dockerHost := "docker.wearenice.com"
+	imageName := dockerHost + "/" + tagStr
 
 	sourceDir := "/home/jenny-dev/project"
 	sourceFiles := map[string]string{
@@ -75,12 +77,13 @@ func TestBuild(t *testing.T) {
 
 	assert.Regexp("^"+regexp.QuoteMeta("docker build .")+reTail, sourceSh.History[0])
 
-	assert.Regexp("^"+regexp.QuoteMeta("docker build -t "+tagStr+" -")+reTail, sourceSh.History[1])
+	assert.Regexp("^"+regexp.QuoteMeta("docker build -t "+imageName+" -")+reTail, sourceSh.History[1])
 	assert.Regexp("FROM "+dockerID, sourceSh.History[1].StdinString())
 	assert.Regexp("com.opentable.sous.repo_url=github.com/opentable/awesomeproject", sourceSh.History[1].StdinString())
 
-	assert.Regexp("^"+regexp.QuoteMeta("docker push "+tagStr)+reTail, sourceSh.History[2])
+	assert.Regexp("^"+regexp.QuoteMeta("docker push "+imageName)+reTail, sourceSh.History[2])
 	docker.FeedMetadata(docker_registry.Metadata{
+		Registry: dockerHost,
 		Labels: map[string]string{
 			DockerVersionLabel:  "1.2.3",
 			DockerRevisionLabel: revision,

--- a/lib/deployment_builder.go
+++ b/lib/deployment_builder.go
@@ -139,10 +139,10 @@ func (uc *deploymentBuilder) retrieveImageLabels() error {
 
 	// !!! HTTP request
 	labels, err := uc.rectification.ImageLabels(imageName)
-	Log.Debug.Print("Labels: ", labels, err)
 	if err != nil {
 		return malformedResponse{err.Error()}
 	}
+	Log.Vomit.Print("Labels: ", labels)
 
 	uc.Target.SourceVersion, err = SourceVersionFromLabels(labels)
 	if err != nil {
@@ -154,7 +154,7 @@ func (uc *deploymentBuilder) retrieveImageLabels() error {
 
 func (uc *deploymentBuilder) unpackDeployConfig() error {
 	uc.Target.Env = uc.deploy.Env
-	Log.Debug.Printf("%+v", uc.deploy.Env)
+	Log.Vomit.Printf("Env %+v", uc.deploy.Env)
 	if uc.Target.Env == nil {
 		uc.Target.Env = make(map[string]string)
 	}
@@ -179,7 +179,7 @@ func (uc *deploymentBuilder) unpackDeployConfig() error {
 				Mode:      VolumeMode(v.Mode),
 			})
 	}
-	Log.Debug.Printf("%+v", uc.Target.DeployConfig.Volumes)
+	Log.Vomit.Printf("Volumes %+v", uc.Target.DeployConfig.Volumes)
 	if len(uc.Target.DeployConfig.Volumes) > 0 {
 		Log.Debug.Printf("%+v", uc.Target.DeployConfig.Volumes[0])
 	}

--- a/lib/deployment_diff.go
+++ b/lib/deployment_diff.go
@@ -1,5 +1,7 @@
 package sous
 
+import "strings"
+
 type (
 	// DeploymentPair is a pair of deployments that represent a "before and after" style relationship
 	DeploymentPair struct {
@@ -84,7 +86,11 @@ func (d Deployments) Diff(other Deployments) DiffChans {
 }
 
 func newDiffer(intended Deployments) *differ {
-	Log.Debug.Print("Computing diff from:", intended)
+	ds := []string{"Computing diff from:"}
+	for _, e := range intended {
+		ds = append(ds, e.String())
+	}
+	Log.Debug.Print(strings.Join(ds, "\n    "))
 
 	startMap := make(map[DepName]*Deployment)
 	for _, dep := range intended {
@@ -97,7 +103,12 @@ func newDiffer(intended Deployments) *differ {
 }
 
 func (d *differ) diff(existing Deployments) {
-	Log.Debug.Print("Computing diff to: ", existing)
+	ds := []string{"Computing diff to:"}
+	for _, e := range existing {
+		ds = append(ds, e.String())
+	}
+	Log.Debug.Print(strings.Join(ds, "\n    "))
+
 	for i := range existing {
 		name := existing[i].Name()
 		if indep, ok := d.from[name]; ok {

--- a/lib/image_mapping.go
+++ b/lib/image_mapping.go
@@ -109,7 +109,7 @@ func (nc *NameCache) GetSourceVersion(in string) (SourceVersion, error) {
 	}
 
 	md, err := nc.registryClient.GetImageMetadata(in, etag)
-	Log.Debug.Printf("%+ v %v", md, err)
+	Log.Vomit.Printf("%+ v %v", md, err)
 	if _, ok := err.(NotModifiedErr); ok {
 		Log.Debug.Printf("Image name: %s -> Source version: %v", in, sv)
 		return sv, nil
@@ -303,7 +303,7 @@ func (nc *NameCache) dbInsert(sv SourceVersion, in, etag string) error {
 		return fmt.Errorf("%v for %v", err, in)
 	}
 
-	Log.Debug.Printf("Inserting name %s", ref.Name())
+	Log.Vomit.Printf("Inserting name %s", ref.Name())
 	nr, err := nc.db.Exec("insert into docker_repo_name "+
 		"(name) values ($1);", ref.Name())
 	nid, err := nr.LastInsertId()
@@ -330,7 +330,7 @@ func (nc *NameCache) dbInsert(sv SourceVersion, in, etag string) error {
 		return err
 	}
 
-	Log.Debug.Printf("Inserting metadata %v %v %v %v", id, etag, in, sv.Version)
+	Log.Vomit.Printf("Inserting metadata %v %v %v %v", id, etag, in, sv.Version)
 	res, err = nc.db.Exec("insert into docker_search_metadata "+
 		"(location_id, etag, canonicalName, version) values ($1, $2, $3, $4);",
 		id, etag, in, sv.Version.Format(semv.MMPPre))

--- a/lib/image_mapping.go
+++ b/lib/image_mapping.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	// triggers the loading of sqlite3 as a database driver
+	"github.com/docker/distribution"
 	"github.com/docker/distribution/reference"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/opentable/sous/util/docker_registry"
@@ -109,8 +110,12 @@ func (nc *NameCache) GetSourceVersion(in string) (SourceVersion, error) {
 	}
 
 	md, err := nc.registryClient.GetImageMetadata(in, etag)
-	Log.Vomit.Printf("%+ v %v", md, err)
+	Log.Vomit.Printf("%+ v %v %T %#v", md, err, err, err)
 	if _, ok := err.(NotModifiedErr); ok {
+		Log.Debug.Printf("Image name: %s -> Source version: %v", in, sv)
+		return sv, nil
+	}
+	if err == distribution.ErrManifestNotModified {
 		Log.Debug.Printf("Image name: %s -> Source version: %v", in, sv)
 		return sv, nil
 	}

--- a/lib/image_mapping_test.go
+++ b/lib/image_mapping_test.go
@@ -21,7 +21,8 @@ func TestRoundTrip(t *testing.T) {
 		RepoURL:    RepoURL("https://github.com/opentable/wackadoo"),
 		RepoOffset: RepoOffset("nested/there"),
 	}
-	base := "docker.repo.io/ot/wackadoo"
+	host := "docker.repo.io"
+	base := "ot/wackadoo"
 	in := base + ":version-1.2.3"
 	digest := "sha256:012345678901234567890123456789AB012345678901234567890123456789AB"
 	err := nc.Insert(sv, in, digest)
@@ -45,6 +46,7 @@ func TestRoundTrip(t *testing.T) {
 
 	cn = base + "@" + digest
 	dc.FeedMetadata(docker_registry.Metadata{
+		Registry:      host,
 		Labels:        newSV.DockerLabels(),
 		Etag:          digest,
 		CanonicalName: cn,
@@ -55,9 +57,9 @@ func TestRoundTrip(t *testing.T) {
 		assert.Equal(newSV, sv)
 	}
 
-	ncn, err := nc.GetCanonicalName(in)
+	ncn, err := nc.GetCanonicalName(host + "/" + in)
 	if assert.Nil(err) {
-		assert.Equal(cn, ncn)
+		assert.Equal(host+"/"+cn, ncn)
 	}
 }
 
@@ -81,13 +83,15 @@ func TestHarvesting(t *testing.T) {
 		RepoOffset: RepoOffset("nested/there"),
 	}
 
-	base := "docker.repo.io/ot/wackadoo"
+	host := "docker.repo.io"
+	base := "ot/wackadoo"
 	tag := "version-1.2.3"
 	digest := "sha256:012345678901234567890123456789AB012345678901234567890123456789AB"
 	cn := base + "@" + digest
 	in := base + ":" + tag
 
 	dc.FeedMetadata(docker_registry.Metadata{
+		Registry:      host,
 		Labels:        sv.DockerLabels(),
 		Etag:          digest,
 		CanonicalName: cn,
@@ -104,6 +108,7 @@ func TestHarvesting(t *testing.T) {
 	in = base + ":" + tag
 	digest = "sha256:abcdefabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdefffffffff"
 	dc.FeedMetadata(docker_registry.Metadata{
+		Registry:      host,
 		Labels:        sisterSV.DockerLabels(),
 		Etag:          digest,
 		CanonicalName: cn,
@@ -112,7 +117,7 @@ func TestHarvesting(t *testing.T) {
 
 	nin, err := nc.GetImageName(sisterSV)
 	if assert.NoError(err) {
-		assert.Equal(cn, nin)
+		assert.Equal(host+"/"+cn, nin)
 	}
 }
 

--- a/lib/logging.go
+++ b/lib/logging.go
@@ -9,13 +9,17 @@ import (
 var (
 	// Log collects various loggers to use for different levels of logging
 	Log = struct {
-		Debug *log.Logger
-		Info  *log.Logger
-		Warn  *log.Logger
+		Debug  *log.Logger
+		Info   *log.Logger
+		Warn   *log.Logger
+		Notice *log.Logger
+		Vomit  *log.Logger
 	}{
 		// Debug is a logger - use log.SetOutput to get output from
-		Debug: log.New(ioutil.Discard, "debug: ", log.Lshortfile),
-		Info:  log.New(ioutil.Discard, "info: ", 0),
-		Warn:  log.New(os.Stderr, "warn: ", 0),
+		Vomit:  log.New(ioutil.Discard, "vomit: ", log.Lshortfile),
+		Debug:  log.New(ioutil.Discard, "debug: ", log.Lshortfile),
+		Info:   log.New(ioutil.Discard, "info: ", 0),
+		Warn:   log.New(os.Stderr, "warn: ", 0),
+		Notice: log.New(ioutil.Discard, "notice: ", 0),
 	}
 )

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -155,25 +155,36 @@ const (
 
 // Equal is used to compare DeployConfigs
 func (dc *DeployConfig) Equal(o DeployConfig) bool {
-	Log.Debug.Printf("%+ v ?= %+ v", dc, o)
+	Log.Vomit.Printf("%+ v ?= %+ v", dc, o)
 	return (dc.NumInstances == o.NumInstances && dc.Env.Equal(o.Env) && dc.Resources.Equal(o.Resources) && dc.Volumes.Equal(o.Volumes))
 }
 
 // Equal is used to compare Volumes pairs
 func (vs Volumes) Equal(o Volumes) bool {
 	if len(vs) != len(o) {
+		Log.Debug.Print("Volume lengths differ")
 		return false
 	}
 	c := append(Volumes{}, o...)
 	for _, v := range vs {
+		m := false
 		for i, ov := range c {
 			if v == ov {
+				m = true
 				c[i] = c[len(c)-1]
 				c = c[:len(c)-1]
 			}
 		}
+		if !m {
+			Log.Debug.Printf("missing volume: %v", v)
+			return false
+		}
 	}
-	return len(c) == 0
+	if len(c) == 0 {
+		return true
+	}
+	Log.Debug.Printf("missing volumes: %v", c)
+	return false
 }
 
 func (vs Volumes) String() string {
@@ -238,24 +249,24 @@ func (r Resources) ports() int32 {
 
 // Equal checks equivalence between resource maps
 func (r Resources) Equal(o Resources) bool {
-	Log.Debug.Printf("Comparing resources: %+ v ?= %+ v", r, o)
+	Log.Vomit.Printf("Comparing resources: %+ v ?= %+ v", r, o)
 	if len(r) != len(o) {
-		Log.Debug.Println("Lengths differ")
+		Log.Vomit.Println("Lengths differ")
 		return false
 	}
 
 	if r.ports() != o.ports() {
-		Log.Debug.Println("Ports differ")
+		Log.Vomit.Println("Ports differ")
 		return false
 	}
 
 	if math.Abs(r.cpus()-o.cpus()) > 0.001 {
-		Log.Debug.Println("Cpus differ")
+		Log.Vomit.Println("Cpus differ")
 		return false
 	}
 
 	if math.Abs(r.memory()-o.memory()) > 0.001 {
-		Log.Debug.Println("Memory differ")
+		Log.Vomit.Println("Memory differ")
 		return false
 	}
 

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -110,25 +110,6 @@ type (
 	// Env is a mapping of environment variable name to value, used to provision
 	// single instances of an application.
 	Env map[string]string
-
-	// Volume describes a deployment's volume mapping
-	Volume struct {
-		Host, Container string
-		Mode            VolumeMode
-	}
-
-	// Volumes represents a list of volume mappings
-	Volumes []*Volume
-
-	//VolumeMode is either readwrite or readonly
-	VolumeMode string
-)
-
-const (
-	// ReadOnly specifies that a volume can only be read
-	ReadOnly VolumeMode = "RO"
-	// ReadWrite specifies that the container can write to the volume
-	ReadWrite VolumeMode = "RW"
 )
 
 // FileLocation returns the path that the manifest should be saved to
@@ -157,42 +138,6 @@ const (
 func (dc *DeployConfig) Equal(o DeployConfig) bool {
 	Log.Vomit.Printf("%+ v ?= %+ v", dc, o)
 	return (dc.NumInstances == o.NumInstances && dc.Env.Equal(o.Env) && dc.Resources.Equal(o.Resources) && dc.Volumes.Equal(o.Volumes))
-}
-
-// Equal is used to compare Volumes pairs
-func (vs Volumes) Equal(o Volumes) bool {
-	if len(vs) != len(o) {
-		Log.Debug.Print("Volume lengths differ")
-		return false
-	}
-	c := append(Volumes{}, o...)
-	for _, v := range vs {
-		m := false
-		for i, ov := range c {
-			if v == ov {
-				m = true
-				c[i] = c[len(c)-1]
-				c = c[:len(c)-1]
-			}
-		}
-		if !m {
-			Log.Debug.Printf("missing volume: %v", v)
-			return false
-		}
-	}
-	if len(c) == 0 {
-		return true
-	}
-	Log.Debug.Printf("missing volumes: %v", c)
-	return false
-}
-
-func (vs Volumes) String() string {
-	res := "["
-	for _, v := range vs {
-		res += fmt.Sprintf("%v,", v)
-	}
-	return res + "]"
 }
 
 // SingMap produces a dtoMap appropriate for building a Singularity

--- a/lib/recti-agent.go
+++ b/lib/recti-agent.go
@@ -68,6 +68,7 @@ func (ra *RectiAgent) Deploy(cluster, depID, reqID, dockerImage string, r Resour
 		"Env":           map[string]string(e),
 	})
 	Log.Debug.Printf("Deploy: %+ v", dep)
+	Log.Debug.Printf("  Container: %+ v", ci)
 
 	depReq, err := dtos.LoadMap(&dtos.SingularityDeployRequest{}, dtoMap{"Deploy": dep})
 	if err != nil {
@@ -157,6 +158,7 @@ func (ra *RectiAgent) singularityClient(url string) *singularity.Client {
 	ra.Lock()
 	defer ra.Unlock()
 	cl = singularity.NewClient(url)
+	//cl.Debug = true
 	ra.singClients[url] = cl
 	return cl
 }

--- a/lib/recti-agent.go
+++ b/lib/recti-agent.go
@@ -69,6 +69,7 @@ func (ra *RectiAgent) Deploy(cluster, depID, reqID, dockerImage string, r Resour
 	})
 	Log.Debug.Printf("Deploy: %+ v", dep)
 	Log.Debug.Printf("  Container: %+ v", ci)
+	Log.Debug.Printf("  Docker: %+ v", dockerInfo)
 
 	depReq, err := dtos.LoadMap(&dtos.SingularityDeployRequest{}, dtoMap{"Deploy": dep})
 	if err != nil {

--- a/lib/rectifier.go
+++ b/lib/rectifier.go
@@ -218,7 +218,8 @@ func (r rectifier) changesReq(pair *DeploymentPair) bool {
 func changesDep(pair *DeploymentPair) bool {
 	return !(pair.prior.SourceVersion.Equal(pair.post.SourceVersion) &&
 		pair.prior.Resources.Equal(pair.post.Resources) &&
-		pair.prior.Env.Equal(pair.post.Env))
+		pair.prior.Env.Equal(pair.post.Env) &&
+		pair.prior.DeployConfig.Volumes.Equal(pair.post.DeployConfig.Volumes))
 }
 
 func computeRequestID(d *Deployment) string {

--- a/lib/resolve.go
+++ b/lib/resolve.go
@@ -66,7 +66,7 @@ func ResolveFilteredDeployments(rc RectificationClient, state State, pr Deployme
 	re := &ResolveErrors{Causes: []error{}}
 	for err := range errs {
 		re.Causes = append(re.Causes, err)
-		Log.Vomit.Printf("resolve error = %+v\n", err)
+		Log.Debug.Printf("resolve error = %+v\n", err)
 	}
 
 	if len(re.Causes) > 0 {

--- a/lib/test/deployment_builder_test.go
+++ b/lib/test/deployment_builder_test.go
@@ -33,7 +33,7 @@ func TestBuildDeployments(t *testing.T) {
 	ra := sous.NewRectiAgent(nc)
 
 	singCl := singularity.NewClient(singularityURL)
-	singCl.Debug = true
+	//singCl.Debug = true
 
 	sr, err := singReqDep(
 		singularityURL,

--- a/lib/test/integration_test.go
+++ b/lib/test/integration_test.go
@@ -177,7 +177,7 @@ func TestResolve(t *testing.T) {
 	}
 
 	if !assert.NoError(err) {
-		assert.Fail(err)
+		assert.Fail(err.Error())
 	}
 	// ****
 

--- a/lib/test/integration_test.go
+++ b/lib/test/integration_test.go
@@ -105,6 +105,8 @@ func TestMissingImage(t *testing.T) {
 
 func TestResolve(t *testing.T) {
 	assert := assert.New(t)
+	sous.Log.Vomit.SetOutput(os.Stderr)
+	sous.Log.Debug.SetOutput(os.Stderr)
 
 	clusterDefs := sous.Defs{
 		Clusters: sous.Clusters{
@@ -199,7 +201,7 @@ func TestResolve(t *testing.T) {
 		assert.Equal(0, deps[which].NumInstances)
 	}
 
-	resetSingularity()
+	// XXX DON'T MERGE WITH THIS COMMENTED resetSingularity()
 }
 
 func deploymentWithRepo(assert *assert.Assertions, ra sous.RectificationClient, repo string) (sous.Deployments, int) {
@@ -249,7 +251,7 @@ func manifest(nc sous.ImageMapper, drepo, containerDir, sourceURL, version strin
 					Args:         []string{},
 					Env:          sous.Env{"repo": drepo}, //map[s]s
 					NumInstances: 1,
-					Volumes:      sous.Volumes{&sous.Volume{"h", "c", sous.VolumeMode("RO")}},
+					Volumes:      sous.Volumes{&sous.Volume{"/tmp", "/tmp", sous.VolumeMode("RO")}},
 				},
 				Version: semv.MustParse(version),
 				//clusterName: "it",

--- a/lib/test/integration_test.go
+++ b/lib/test/integration_test.go
@@ -165,7 +165,7 @@ func TestResolve(t *testing.T) {
 
 	// XXX Let's hope this is a temporary solution to a testing issue
 	// The problem is laid out in DCOPS-7625
-	for tries := 0; tries < 10; tries++ {
+	for tries := 0; tries < 30; tries++ {
 		err = sous.Resolve(ra, stateTwoThree)
 		if err != nil {
 			if !conflictRE.MatchString(err.Error()) {

--- a/lib/test/integration_test.go
+++ b/lib/test/integration_test.go
@@ -175,6 +175,10 @@ func TestResolve(t *testing.T) {
 			time.Sleep(1 * time.Second)
 		}
 	}
+
+	if !assert.NoError(err) {
+		assert.Fail(err)
+	}
 	// ****
 
 	deps, which = deploymentWithRepo(assert, ra, repoTwo)

--- a/lib/test/name_cache_test.go
+++ b/lib/test/name_cache_test.go
@@ -12,7 +12,6 @@ import (
 func TestNameCache(t *testing.T) {
 	assert := assert.New(t)
 	sous.Log.Debug.SetOutput(os.Stdout)
-	sous.Log.Vomit.SetOutput(os.Stdout)
 
 	resetSingularity()
 	defer resetSingularity()

--- a/lib/test/name_cache_test.go
+++ b/lib/test/name_cache_test.go
@@ -1,0 +1,37 @@
+package test
+
+import (
+	"os"
+	"testing"
+
+	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/docker_registry"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNameCache(t *testing.T) {
+	assert := assert.New(t)
+	sous.Log.Debug.SetOutput(os.Stdout)
+	sous.Log.Vomit.SetOutput(os.Stdout)
+
+	resetSingularity()
+	defer resetSingularity()
+
+	drc := docker_registry.NewClient()
+	drc.BecomeFoolishlyTrusting()
+
+	nc := sous.NewNameCache(drc, "sqlite3", sous.InMemoryConnection("testnamecache"))
+
+	repoOne := "https://github.com/opentable/one.git"
+	manifest(nc, "opentable/one", "test-one", repoOne, "1.1.1")
+
+	cn, err := nc.GetCanonicalName(buildImageName("opentable/one", "1.1.1"))
+	if err != nil {
+		assert.FailNow(err.Error())
+	}
+	labels, err := drc.LabelsForImageName(cn)
+
+	if assert.NoError(err) {
+		assert.Equal("1.1.1", labels[sous.DockerVersionLabel])
+	}
+}

--- a/lib/volumes.go
+++ b/lib/volumes.go
@@ -1,0 +1,68 @@
+package sous
+
+import "fmt"
+
+type (
+	// Volume describes a deployment's volume mapping
+	Volume struct {
+		Host, Container string
+		Mode            VolumeMode
+	}
+
+	// Volumes represents a list of volume mappings
+	Volumes []*Volume
+
+	//VolumeMode is either readwrite or readonly
+	VolumeMode string
+)
+
+const (
+	// ReadOnly specifies that a volume can only be read
+	ReadOnly VolumeMode = "RO"
+	// ReadWrite specifies that the container can write to the volume
+	ReadWrite VolumeMode = "RW"
+)
+
+// Equal is used to compare Volumes pairs
+func (vs Volumes) Equal(o Volumes) bool {
+	if len(vs) != len(o) {
+		Log.Debug.Print("Volume lengths differ")
+		return false
+	}
+	c := append(Volumes{}, o...)
+	for _, v := range vs {
+		m := false
+		for i, ov := range c {
+			if v.Equal(ov) {
+				m = true
+				if i < len(c) {
+					c[i] = c[len(c)-1]
+				}
+				c = c[:len(c)-1]
+				break
+			}
+		}
+		if !m {
+			Log.Debug.Printf("missing volume: %v", v)
+			return false
+		}
+	}
+	if len(c) == 0 {
+		return true
+	}
+	Log.Debug.Printf("missing volumes: %v", c)
+	return false
+}
+
+// Equal is used to compare *Volume pairs
+func (v *Volume) Equal(o *Volume) bool {
+	return v.Host == o.Host && v.Container == o.Container && v.Mode == o.Mode
+}
+
+func (vs Volumes) String() string {
+	res := "["
+	for _, v := range vs {
+		res += fmt.Sprintf("%v,", v)
+	}
+	return res + "]"
+}

--- a/lib/volumes_test.go
+++ b/lib/volumes_test.go
@@ -1,0 +1,39 @@
+package sous
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type vpair struct {
+	v Volumes
+	i int
+}
+
+func TestVolumesEqual(t *testing.T) {
+	Log.Vomit.SetOutput(os.Stderr)
+	Log.Debug.SetOutput(os.Stderr)
+	assert := assert.New(t)
+	vs := []vpair{
+		vpair{Volumes{&Volume{"a", "a", "RO"}, &Volume{"a", "a", "RO"}}, 1},
+		vpair{Volumes{&Volume{"a", "a", "RO"}, &Volume{"a", "a", "RO"}}, 1},
+		vpair{Volumes{&Volume{"a", "a", "RO"}}, 4},
+		vpair{Volumes{&Volume{"a", "b", "RO"}, &Volume{"a", "a", "RO"}}, 2},
+		vpair{Volumes{&Volume{"a", "a", "RW"}, &Volume{"a", "a", "RO"}}, 3},
+	}
+
+	for _, l := range vs {
+		for _, r := range vs {
+			if l.i == r.i {
+				log.Print("=", l, r)
+				assert.True(l.v.Equal(r.v))
+			} else {
+				log.Print("!=", l, r)
+				assert.False(l.v.Equal(r.v))
+			}
+		}
+	}
+}

--- a/util/docker_registry/client.go
+++ b/util/docker_registry/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"strings"
 
@@ -50,6 +51,7 @@ type (
 
 	// Metadata represents the descriptive data for a docker image
 	Metadata struct {
+		Registry      string
 		Labels        map[string]string
 		Etag          string
 		CanonicalName string
@@ -204,6 +206,7 @@ func (c *liveClient) metadataForImage(regHost string, ref reference.Named, etag 
 	}
 
 	md = Metadata{
+		Registry: regHost,
 		AllNames: make([]string, 2),
 		Labels:   make(map[string]string),
 		Etag:     headers.Get("Etag"),
@@ -324,6 +327,8 @@ func (r *registry) getManifestWithEtag(ctx context.Context, ref reference.Named,
 	var err error
 
 	u, err := r.ub.BuildManifestURL(ref)
+
+	log.Print(u)
 	if err != nil {
 		return nil, http.Header{}, err
 	}

--- a/util/docker_registry/client.go
+++ b/util/docker_registry/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"strings"
 
@@ -328,7 +327,6 @@ func (r *registry) getManifestWithEtag(ctx context.Context, ref reference.Named,
 
 	u, err := r.ub.BuildManifestURL(ref)
 
-	log.Print(u)
 	if err != nil {
 		return nil, http.Header{}, err
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -121,6 +121,10 @@
 			"revision": "20fa47886d8ab72eb1e29b1160ed716e7ffac36a"
 		},
 		{
+			"path": "github.com/docker/image",
+			"revision": ""
+		},
+		{
 			"checksumSHA1": "kwd8rShKDCxGTQA0qkxsE1NFJFo=",
 			"path": "github.com/docker/libtrust",
 			"revision": "c8d2b36d60a84f3fa7d5e5e355be64f0fbe0b481"


### PR DESCRIPTION
This PR ensures that all docker image names used with Singularity are digest
(aka canonical) names. The result is that Sous can be absolutely certain that
either the image deployed to singularity corresponds to information it has, or
else that knowledge of the contents of that image has been lost. Prior to this,
version tags were being used, which allowed for significant drift without Sous
being aware of a change. As a concequence, the resolution protocol is much more
consistent and should be more robust.

A number of outright errors were uncovered which had been concealed by the
less stable process, including variations in the volume configuration.

Re: image knowledge being lost: it's possible that the tag-name under which a
particular image was pushed would be reused, which would leave the underlying
image orphaned and the digest unrecognized. The container would still run,
obviously, but if the name cache were destroyed, removed or hadn't captured
that digest at a Sous node, Sous wouldn't know what the labels on that image
were. Note that Sous positively would know that it doesn't know the contents of
the image in question, as opposed to erroneously believing that it did.

There are two approaches (not exclusive of one another) to avoid these
"orphaned" containers. First, whenever a container is built for production
deploy, it should be tagged with its _revision_ as well as separately its
version tag (i.e. git tag -> docker tag). It's unlikely for a revision tag to
be rebuilt - there is the case where two nodes build the same source version
near-simultaneously, which would result in closely related images registered
with the same revision. Before it was deployed, however, there would be a
stable instance of the image.

The second approach would be to copy the Sous metadata into _Singularity
Deploy_ labels. These would be advisory only, since there wouldn't be the
safeguards and immutability involved with image labels. However, they're much
more accessible, and might serve to bridge gaps if a deployed digest were
orphaned by an image name reuse.