### PR TITLE
Single cluster rectify TECHOPS-108

### DIFF
--- a/cli/rectify_test.go
+++ b/cli/rectify_test.go
@@ -1,0 +1,14 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPredicateBuilder(t *testing.T) {
+	assert := assert.New(t)
+
+	f := rectifyFlags{}
+	assert.Nil(f.buildPredicate())
+}

--- a/cli/rectify_test.go
+++ b/cli/rectify_test.go
@@ -70,6 +70,12 @@ func TestPredicateBuilder(t *testing.T) {
 	assert.Contains(filtered, ds[6])
 	assert.Contains(filtered, ds[7])
 	assert.Len(filtered, 4)
+
+	f = rectifyFlags{all: true}
+	pd = f.buildPredicate()
+	assert.NotNil(pd)
+	filtered = filter(ds, pd)
+	assert.Len(filtered, 8)
 }
 
 func filter(ds []*sous.Deployment, pd sous.DeploymentPredicate) (fd []*sous.Deployment) {

--- a/cli/rectify_test.go
+++ b/cli/rectify_test.go
@@ -3,12 +3,81 @@ package cli
 import (
 	"testing"
 
+	"github.com/opentable/sous/lib"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPredicateBuilder(t *testing.T) {
 	assert := assert.New(t)
 
+	ds := make([]*sous.Deployment, 0, 8)
+	cs := []string{"cluster1", "cluster2"}
+	rs := []sous.RepoURL{"github.com/ot/one", "github.com/ot/two"}
+	os := []sous.RepoOffset{"up", "down"}
+
+	for _, c := range cs {
+		for _, r := range rs {
+			for _, o := range os {
+				ds = append(ds, &sous.Deployment{
+					ClusterNickname: c,
+					SourceID: sous.SourceID{
+						RepoURL:    r,
+						RepoOffset: o,
+					},
+				})
+			}
+		}
+	}
+
+	//	for i, d := range ds {
+	//		fmt.Printf("%d: %#v\n", i, d)
+	//	}
+	//
 	f := rectifyFlags{}
 	assert.Nil(f.buildPredicate())
+
+	f.repo = string(rs[0])
+	pd := f.buildPredicate()
+	assert.NotNil(pd)
+	filtered := filter(ds, pd)
+	assert.Contains(filtered, ds[0])
+	assert.Contains(filtered, ds[1])
+	assert.Contains(filtered, ds[4])
+	assert.Contains(filtered, ds[5])
+	assert.Len(filtered, 4)
+
+	f.offset = string(os[0])
+	pd = f.buildPredicate()
+	assert.NotNil(pd)
+	filtered = filter(ds, pd)
+	assert.Contains(filtered, ds[0])
+	assert.Contains(filtered, ds[4])
+	assert.Len(filtered, 2)
+
+	f.cluster = cs[0]
+	pd = f.buildPredicate()
+	assert.NotNil(pd)
+	filtered = filter(ds, pd)
+	assert.Contains(filtered, ds[0])
+	assert.Len(filtered, 1)
+
+	f = rectifyFlags{cluster: cs[1]}
+	pd = f.buildPredicate()
+	assert.NotNil(pd)
+	filtered = filter(ds, pd)
+	assert.Contains(filtered, ds[4])
+	assert.Contains(filtered, ds[5])
+	assert.Contains(filtered, ds[6])
+	assert.Contains(filtered, ds[7])
+	assert.Len(filtered, 4)
+}
+
+func filter(ds []*sous.Deployment, pd sous.DeploymentPredicate) (fd []*sous.Deployment) {
+	for _, d := range ds {
+		if pd(d) {
+			fd = append(fd, d)
+		}
+	}
+	return
+
 }

--- a/cli/sous_rectify.go
+++ b/cli/sous_rectify.go
@@ -53,9 +53,9 @@ func (sr *SousRectify) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&sr.flags.dryrun, "dry-run", "none",
 		"prevent rectify from actually changing things - "+
 			"values are none,scheduler,registry,both")
-	fs.StringVar(&sr.flags.manifest, "repo", "",
+	fs.StringVar(&sr.flags.repo, "repo", "",
 		"consider only the repo `repository` for rectification")
-	fs.StringVar(&sr.flags.manifest, "offset", "",
+	fs.StringVar(&sr.flags.offset, "offset", "",
 		"consider only the offset `path` for rectification")
 	fs.StringVar(&sr.flags.cluster, "cluster", "",
 		"consider only the cluster `name` for rectification")
@@ -81,21 +81,21 @@ func (sr *SousRectify) Execute(args []string) cmdr.Result {
 func (f rectifyFlags) buildPredicate() sous.DeploymentPredicate {
 	var preds []sous.DeploymentPredicate
 
-	if sr.flags.repo != "" {
+	if f.repo != "" {
 		preds = append(preds, func(d *sous.Deployment) bool {
-			return d.SourceID.RepoURL == sous.RepoURL(sr.flags.repo)
+			return d.SourceID.RepoURL == sous.RepoURL(f.repo)
 		})
 	}
 
-	if sr.flags.offset != "" {
+	if f.offset != "" {
 		preds = append(preds, func(d *sous.Deployment) bool {
-			return d.SourceID.RepoOffset == sous.RepoOffset(sr.flags.offset)
+			return d.SourceID.RepoOffset == sous.RepoOffset(f.offset)
 		})
 	}
 
-	if sr.flags.cluster != "" {
+	if f.cluster != "" {
 		preds = append(preds, func(d *sous.Deployment) bool {
-			return d.ClusterNickname == sr.flags.cluster
+			return d.ClusterNickname == f.cluster
 		})
 	}
 

--- a/cli/sous_rectify.go
+++ b/cli/sous_rectify.go
@@ -24,6 +24,7 @@ type (
 	rectifyFlags struct {
 		dryrun,
 		repo, offset, cluster string
+		all bool
 	}
 )
 
@@ -40,6 +41,11 @@ together, the result is the intersection of their images - that is, the
 conditions are "anded." By implication, each can only be used once.
 NOTE: the successful use of these predicates requires all-team coordination.
 Use with great care.
+
+Because of the hazard involved in doing complete rectification at the command
+line, sous rectify requires the -all flag to consider the whole tree. This is
+almost certainly not what you want. Even if it is, you certainly want to trial
+your rectifies with -dry-run=scheduler first.
 
 Note: by default this command will query a live docker registry and make
 changes to live Singularity clusters.
@@ -59,6 +65,8 @@ func (sr *SousRectify) AddFlags(fs *flag.FlagSet) {
 		"consider only the offset `path` for rectification")
 	fs.StringVar(&sr.flags.cluster, "cluster", "",
 		"consider only the cluster `name` for rectification")
+	fs.BoolVar(&sr.flags.all, "all", false,
+		"actually do a full-tree recitification")
 }
 
 // Execute fulfils the cmdr.Executor interface
@@ -80,6 +88,10 @@ func (sr *SousRectify) Execute(args []string) cmdr.Result {
 
 func (f rectifyFlags) buildPredicate() sous.DeploymentPredicate {
 	var preds []sous.DeploymentPredicate
+
+	if f.all {
+		return func(*sous.Deployment) bool { return true }
+	}
 
 	if f.repo != "" {
 		preds = append(preds, func(d *sous.Deployment) bool {

--- a/doc/disjoint-rectification.md
+++ b/doc/disjoint-rectification.md
@@ -1,0 +1,31 @@
+# Disjoint Rectification
+
+Until Sous has working per-cluster servers,
+it will be important to be able to do rectifications at the command line.
+
+There's a hazard to doing this,
+as it relies on local copies of the global manifest,
+and changes across those differences will clobber one another during rectification.
+To help address this,
+`sous rectify` accepts flags to limit the scope it will consider.
+It's normal for single teams to use
+`sous rectify -repo github.com/team/project`
+for instance.
+Note well, however,
+that if there's a node that runs
+`sous rectify -all` without having merged all other manifests
+it will remove the deployments made by `-repo` runs.
+
+It is recommended that either
+all deployment handled by Sous be done through "disjoint" deploys
+(i.e. everyone uses '-repo')
+or else
+all deployments are done with `-all`,
+and modifications are made to a central, reviewed manifest.
+
+Once Sous attains its server feature,
+servers will implicitly run in a `-cluster` mode
+because each server will be responsible for its local cluster.
+At this point,
+most of the use cases that drove constrained rectification
+will be obsolete, but limited uses are still forseen.

--- a/lib/state.go
+++ b/lib/state.go
@@ -6,6 +6,7 @@ type (
 	// State contains the mutable state of an organisation's deployments.
 	// State is also known as the "Global Deploy Manifest" or GDM.
 	State struct {
+		singleCluster string
 		// Defs contains global definitions for this organisation.
 		Defs Defs `hy:"defs.yaml"`
 		// Manifests contains a mapping of source code repositories to global
@@ -71,12 +72,19 @@ type (
 	VarType string
 )
 
+// OnlyCluster sets a contraint on the State such that it will only consider a particular cluster
+func (s *State) OnlyCluster(nick string) {
+	s.singleCluster = nick
+}
+
 // ClusterMap returns the nicknames for all the clusters referred to in this state
 // paired with the URL for the named cluster
 func (s *State) ClusterMap() map[string]string {
 	m := make(map[string]string, len(s.Defs.Clusters))
 	for name, cluster := range s.Defs.Clusters {
-		m[name] = cluster.BaseURL
+		if s.singleCluster == "" || s.singleCluster == name {
+			m[name] = cluster.BaseURL
+		}
 	}
 	return m
 }

--- a/lib/state_test.go
+++ b/lib/state_test.go
@@ -1,0 +1,31 @@
+package sous
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClusterMap(t *testing.T) {
+	assert := assert.New(t)
+
+	s := State{
+		Defs: Defs{
+			Clusters: Clusters{
+				"one": Cluster{},
+				"two": Cluster{},
+			},
+		},
+	}
+
+	m := s.ClusterMap()
+	assert.Len(m, 2)
+	assert.Contains(m, "one")
+	assert.Contains(m, "two")
+
+	s.singleCluster = "one"
+	m = s.ClusterMap()
+	assert.Len(m, 1)
+	assert.Contains(m, "one")
+
+}


### PR DESCRIPTION
Adds -cluster flag to restrict rectify to considering only one cluster.
When used, also adds configuration to the GDM to only report that cluster,
so that we save queries targetting other clusters.

Also: renamed "-manifest" to "-repo" and added "-offset" so that manifests can
be properly constrained to.

Finally, adds "-all" because once Sous begins to be used in a "disjoint" mode,
gobal rectifies become hazardous.