### PR TITLE
dependency-injected flags

### DIFF
--- a/cli/add_flags.go
+++ b/cli/add_flags.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"flag"
+	"log"
+	"reflect"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// AddFlags sniffs out struct fields from target and adds them as var flags to
+// the flag set.
+func AddFlags(fs *flag.FlagSet, target interface{}, help string) error {
+	if fs == nil {
+		return errors.Errorf("cannot add flags to nil *flag.FlagSet")
+	}
+	v := reflect.ValueOf(target)
+	k := v.Kind()
+	if target == nil || k != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
+		return errors.Errorf("target is %T; want pointer to struct", target)
+	}
+
+	v = v.Elem()
+	t := v.Type()
+	numFields := t.NumField()
+	for i := 0; i < numFields; i++ {
+		f := t.Field(i)
+		ft := f.Type
+		fp := v.Field(i).Addr().Interface()
+		name := strings.ToLower(f.Name)
+		switch field := fp.(type) {
+		default:
+			return errors.Errorf("target field %s.%s is %s; want string, int",
+				t, f.Name, ft)
+		case *string:
+			log.Println("Adding field", name)
+			fs.StringVar(field, name, "", "usage")
+		}
+	}
+
+	return nil
+}

--- a/cli/add_flags.go
+++ b/cli/add_flags.go
@@ -20,6 +20,11 @@ func AddFlags(fs *flag.FlagSet, target interface{}, help string) error {
 		return errors.Errorf("target is %T; want pointer to struct", target)
 	}
 
+	usage, err := parseUsage(help)
+	if err != nil {
+		return errors.Wrapf(err, "parsing usage text")
+	}
+
 	v = v.Elem()
 	t := v.Type()
 	numFields := t.NumField()
@@ -28,14 +33,37 @@ func AddFlags(fs *flag.FlagSet, target interface{}, help string) error {
 		ft := f.Type
 		fp := v.Field(i).Addr().Interface()
 		name := strings.ToLower(f.Name)
+		u, ok := usage[name]
+		if !ok {
+			return errors.Errorf("no usage text for flag -%s", name)
+		}
 		switch field := fp.(type) {
 		default:
 			return errors.Errorf("target field %s.%s is %s; want string, int",
 				t, f.Name, ft)
 		case *string:
-			fs.StringVar(field, name, "", "usage")
+			fs.StringVar(field, name, "", u)
 		}
 	}
 
 	return nil
+}
+
+func parseUsage(s string) (map[string]string, error) {
+	parts := strings.Split("\t"+strings.TrimSpace(s), "\t-")
+	m := make(map[string]string, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if len(p) == 0 {
+			continue
+		}
+		lines := strings.Split(p, "\n")
+		if len(lines) < 2 {
+			return nil, errors.Errorf("section has too few lines: %q", p)
+		}
+		name := strings.Split(lines[0], " ")[0]
+		usage := strings.TrimSpace(lines[1])
+		m[name] = usage
+	}
+	return m, nil
 }

--- a/cli/add_flags.go
+++ b/cli/add_flags.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"flag"
-	"log"
 	"reflect"
 	"strings"
 
@@ -34,7 +33,6 @@ func AddFlags(fs *flag.FlagSet, target interface{}, help string) error {
 			return errors.Errorf("target field %s.%s is %s; want string, int",
 				t, f.Name, ft)
 		case *string:
-			log.Println("Adding field", name)
 			fs.StringVar(field, name, "", "usage")
 		}
 	}

--- a/cli/add_flags_test.go
+++ b/cli/add_flags_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestAddFlags(t *testing.T) {
+	fs := flag.NewFlagSet("source", flag.ContinueOnError)
+
+	actual := SourceFlags{}
+
+	if err := AddFlags(fs, &actual, sourceFlagsHelp); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := SourceFlags{
+		Repo: "github.com/opentable/sous",
+	}
+
+	args := []string{"-repo", expected.Repo}
+	if err := fs.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	if actual.Repo != expected.Repo {
+		t.Errorf("got repo %q; want %q", actual.Repo, expected.Repo)
+	}
+}
+
+type AddFlagsInput struct {
+	FlagSet *flag.FlagSet
+	Target  interface{}
+	Help    string
+}
+
+type BadFlagStruct struct {
+	PtrField *string
+}
+
+func newFS() *flag.FlagSet { return flag.NewFlagSet("", flag.ContinueOnError) }
+
+func TestAddFlags_badInputs(t *testing.T) {
+	var s string
+	stringPtr := &s
+	var badAddFlagsInputs = map[AddFlagsInput]string{
+		{nil, nil, ""}:                  "cannot add flags to nil *flag.FlagSet",
+		{newFS(), nil, ""}:              "target is <nil>; want pointer to struct",
+		{newFS(), "", ""}:               "target is string; want pointer to struct",
+		{newFS(), SourceFlags{}, ""}:    "target is cli.SourceFlags; want pointer to struct",
+		{newFS(), stringPtr, ""}:        "target is *string; want pointer to struct",
+		{newFS(), &BadFlagStruct{}, ""}: "target field cli.BadFlagStruct.PtrField is *string; want string, int",
+	}
+	for in, expected := range badAddFlagsInputs {
+		actualErr := AddFlags(in.FlagSet, in.Target, in.Help)
+		if actualErr == nil {
+			t.Fatalf("got nil; want error %q", expected)
+		}
+		actual := actualErr.Error()
+		if actual != expected {
+			t.Errorf("got error %q; want error %q", actual, expected)
+		}
+	}
+}

--- a/cli/add_flags_test.go
+++ b/cli/add_flags_test.go
@@ -1,9 +1,22 @@
 package cli
 
 import (
+	"bytes"
 	"flag"
+	"strings"
 	"testing"
 )
+
+var expectedHelpText = `
+  -offset string
+        source code relative repository offset
+  -repo string
+        source code repository root
+  -revision string
+        source code revision ID
+  -tag string
+        source code revision tag
+`
 
 func TestAddFlags(t *testing.T) {
 	fs := flag.NewFlagSet("source", flag.ContinueOnError)
@@ -18,12 +31,34 @@ func TestAddFlags(t *testing.T) {
 		Repo: "github.com/opentable/sous",
 	}
 
-	args := []string{"-repo", expected.Repo}
+	args := []string{
+		"-repo", expected.Repo,
+		"-offset", expected.Offset,
+		"-tag", expected.Tag,
+		"-revision", expected.Revision,
+	}
 	if err := fs.Parse(args); err != nil {
 		t.Fatal(err)
 	}
 	if actual.Repo != expected.Repo {
-		t.Errorf("got repo %q; want %q", actual.Repo, expected.Repo)
+		t.Errorf("got %q; want %q", actual.Repo, expected.Repo)
+	}
+	if actual.Offset != expected.Offset {
+		t.Errorf("got %q; want %q", actual.Offset, expected.Offset)
+	}
+	if actual.Tag != expected.Tag {
+		t.Errorf("got %q; want %q", actual.Tag, expected.Tag)
+	}
+	if actual.Revision != expected.Revision {
+		t.Errorf("got %q; want %q", actual.Revision, expected.Revision)
+	}
+	buf := &bytes.Buffer{}
+	fs.SetOutput(buf)
+	fs.PrintDefaults()
+	actualHelp := strings.TrimSpace(buf.String())
+	expectedHelp := strings.TrimSpace(expectedHelpText)
+	if actualHelp != expectedHelp {
+		t.Errorf("got help text:\n%s\nwant:\n%s", actualHelp, expectedHelp)
 	}
 }
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,4 +1,4 @@
-// The cli package implements the Sous Command Line Interface. It is a
+// Package cli implements the Sous Command Line Interface. It is a
 // presentation layer, and contains no core logic.
 package cli
 
@@ -23,6 +23,7 @@ var (
 	EnsureErrorResult = cmdr.EnsureErrorResult
 )
 
+// SuccessYAML lets you return YAML on the command line.
 func SuccessYAML(v interface{}) cmdr.Result {
 	b, err := yaml.Marshal(v)
 	if err != nil {
@@ -31,6 +32,7 @@ func SuccessYAML(v interface{}) cmdr.Result {
 	return SuccessData(b)
 }
 
+// NewSousCLI creates a new Sous cli app.
 func NewSousCLI(v semv.Version, out, errout io.Writer) (*cmdr.CLI, error) {
 
 	s := &Sous{Version: v}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -51,10 +51,7 @@ func NewSousCLI(v semv.Version, out, errout io.Writer) (*cmdr.CLI, error) {
 	}
 
 	// Create the CLI dependency graph.
-	g, err := BuildGraph(s, c)
-	if err != nil {
-		return nil, err
-	}
+	g := BuildGraph(s, c)
 
 	// Before Execute is called on any command, inject it with values from the
 	// graph.

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -1,48 +1,44 @@
 package cli
 
-import "github.com/samsalisbury/semv"
-
-// Flags defines the flags available to all sous commands.
-type Flags struct {
-	Repo       string       `flag:"repo"`
-	Offset     string       `flag:"offset"`
-	Version    semv.Version `flag:"version"`
-	Tag        string       `flag:"tag"`
-	Revision   string       `flag:"revision"`
-	Strict     bool         `flag:"strict"`
-	Deployer   string       `flag:"deployer"`
-	Builder    string       `flag:"builder"`
-	DryRun     bool         `flag:"dry-run"`
-	ForceClone bool         `flag:"force-clone"`
-	Cluster    string       `flag:"cluster"`
+// BuildFlags are CLI flags used to set build options.
+type BuildFlags struct {
+	Strict  bool   `flag:"strict"`
+	Builder string `flag:"builder"`
 }
 
-var flagDescriptions = `
-	-repo=REPOSITORY_NAME
-		set the repository context
+// DeployFlags are CLI flags used to set deployment context and options.
+type DeployFlags struct {
+	Deployer   string `flag:"deployer"`
+	DryRun     bool   `flag:"dry-run"`
+	ForceClone bool   `flag:"force-clone"`
+	Cluster    string `flag:"cluster"`
+}
 
-		The repository context is the name of a source code repository whose
-		code, configuration, artifacts, deployments, etc. will be acted upon.
-		If sous is run from inside a Git repository, then repo will default to
-		the normalised git-configured fetch URL of any remote named "upstream"
-		or "origin", in that order.
+var deployFlags = `
+	-deployment.cluster=CLUSTER_NAME
+		set deployment context: cluster
 
-		Sous uses go-style repository URLs, and currently only supports GitHub-
-		based repositories, e.g. "github.com/user/repo"
-
-	
-	-offset=RELATIVE_PATH
-		set the repository context offset
-
-		Repository context offset is the relative path within a repository where
-		a piece of software is defined.
+	-deployment.dry-run
+		do not make any changes deployments
 		
-		If you are working in a subdirectory of a repository, the default value
-		for offset will be the relative path of the current working directory
-		from the repository root.
+		Instead of performing deployment actions on running clusters, just
+		display the actions that would be taken without this flag.
+`
 
-		Note: if you supply the -repo flag but not -offset, then -offset
-		defaults to "".
-	
-	-
+var buildFlags = `
+	-build.strict
+		fail build if any advisories apply
+
+		Intended to produce production-grade build artifacts.
+
+	-build.force-clone
+		build from a fresh isolated clone
+
+		Force building from a new shallow clone of the source context.
+
+		Usually if building inside a repository using the default context, the
+		code inside the current working directory is built. If you specify a
+		context which does not match the default context, the source identified
+		the context is cloned into your local scratch directory, and built from
+		there.
 `

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -1,0 +1,48 @@
+package cli
+
+import "github.com/samsalisbury/semv"
+
+// Flags defines the flags available to all sous commands.
+type Flags struct {
+	Repo       string       `flag:"repo"`
+	Offset     string       `flag:"offset"`
+	Version    semv.Version `flag:"version"`
+	Tag        string       `flag:"tag"`
+	Revision   string       `flag:"revision"`
+	Strict     bool         `flag:"strict"`
+	Deployer   string       `flag:"deployer"`
+	Builder    string       `flag:"builder"`
+	DryRun     bool         `flag:"dry-run"`
+	ForceClone bool         `flag:"force-clone"`
+	Cluster    string       `flag:"cluster"`
+}
+
+var flagDescriptions = `
+	-repo=REPOSITORY_NAME
+		set the repository context
+
+		The repository context is the name of a source code repository whose
+		code, configuration, artifacts, deployments, etc. will be acted upon.
+		If sous is run from inside a Git repository, then repo will default to
+		the normalised git-configured fetch URL of any remote named "upstream"
+		or "origin", in that order.
+
+		Sous uses go-style repository URLs, and currently only supports GitHub-
+		based repositories, e.g. "github.com/user/repo"
+
+	
+	-offset=RELATIVE_PATH
+		set the repository context offset
+
+		Repository context offset is the relative path within a repository where
+		a piece of software is defined.
+		
+		If you are working in a subdirectory of a repository, the default value
+		for offset will be the relative path of the current working directory
+		from the repository root.
+
+		Note: if you supply the -repo flag but not -offset, then -offset
+		defaults to "".
+	
+	-
+`

--- a/cli/flags_source.go
+++ b/cli/flags_source.go
@@ -10,7 +10,7 @@ type SourceFlags struct {
 }
 
 const sourceFlagsHelp = `
-	-source.repo=REPOSITORY_NAME
+	-repo=REPOSITORY_NAME
 		set source context: repository
 
 		The repository context is the name of a source code repository whose
@@ -23,7 +23,7 @@ const sourceFlagsHelp = `
 		based repositories, e.g. "github.com/user/repo"
 
 	
-	-source.offset=RELATIVE_PATH
+	-offset=RELATIVE_PATH
 		set source context: repository offset
 
 		Repository context offset is the relative path within a repository where
@@ -36,12 +36,12 @@ const sourceFlagsHelp = `
 		Note: if you supply the -repo flag but not -offset, then -offset
 		defaults to "".
 	
-	-source.tag=TAG_NAME
+	-tag=TAG_NAME
 		set source context: repository tag
 
 		Repository tag is the name of a tag in the repository to act upon.
 
-	-source.revision=REVISION_ID
+	-revision=REVISION_ID
 		set source context: revision ID
 
 		Revision ID is the ID of a revision in the repository to act upon.

--- a/cli/flags_source.go
+++ b/cli/flags_source.go
@@ -1,0 +1,48 @@
+package cli
+
+// SourceFlags are CLI flags used to set the source context for a given command
+// invocation.
+type SourceFlags struct {
+	Repo     string
+	Offset   string
+	Tag      string
+	Revision string
+}
+
+const sourceFlagsHelp = `
+	-source.repo=REPOSITORY_NAME
+		set source context: repository
+
+		The repository context is the name of a source code repository whose
+		code, configuration, artifacts, deployments, etc. will be acted upon.
+		If sous is run from inside a Git repository, then repo will default to
+		the normalised git-configured fetch URL of any remote named "upstream"
+		or "origin", in that order.
+
+		Sous uses go-style repository URLs, and currently only supports GitHub-
+		based repositories, e.g. "github.com/user/repo"
+
+	
+	-source.offset=RELATIVE_PATH
+		set source context: repository offset
+
+		Repository context offset is the relative path within a repository where
+		a piece of software is defined.
+		
+		If you are working in a subdirectory of a repository, the default value
+		for offset will be the relative path of the current working directory
+		from the repository root.
+
+		Note: if you supply the -repo flag but not -offset, then -offset
+		defaults to "".
+	
+	-source.tag=TAG_NAME
+		set source context: repository tag
+
+		Repository tag is the name of a tag in the repository to act upon.
+
+	-source.revision=REVISION_ID
+		set source context: revision ID
+
+		Revision ID is the ID of a revision in the repository to act upon.
+`

--- a/cli/flags_source.go
+++ b/cli/flags_source.go
@@ -10,8 +10,8 @@ type SourceFlags struct {
 }
 
 const sourceFlagsHelp = `
-	-repo=REPOSITORY_NAME
-		set source context: repository
+	-repo REPOSITORY_NAME
+		source code repository location
 
 		The repository context is the name of a source code repository whose
 		code, configuration, artifacts, deployments, etc. will be acted upon.
@@ -23,8 +23,8 @@ const sourceFlagsHelp = `
 		based repositories, e.g. "github.com/user/repo"
 
 	
-	-offset=RELATIVE_PATH
-		set source context: repository offset
+	-offset RELATIVE_PATH
+		source code relative repository offset
 
 		Repository context offset is the relative path within a repository where
 		a piece of software is defined.
@@ -36,13 +36,13 @@ const sourceFlagsHelp = `
 		Note: if you supply the -repo flag but not -offset, then -offset
 		defaults to "".
 	
-	-tag=TAG_NAME
-		set source context: repository tag
+	-tag TAG_NAME
+		source code revision tag
 
 		Repository tag is the name of a tag in the repository to act upon.
 
-	-revision=REVISION_ID
-		set source context: revision ID
+	-revision REVISION_ID
+		source code revision ID
 
 		Revision ID is the ID of a revision in the repository to act upon.
 `

--- a/cli/graph.go
+++ b/cli/graph.go
@@ -50,7 +50,7 @@ type (
 	// LocalGitRepo is the git repository containing WorkDir.
 	LocalGitRepo struct{ *git.Repo }
 	// GitSourceContext is the source context according to the local git repo.
-	GitSourceContext *sous.SourceContext
+	GitSourceContext struct{ *sous.SourceContext }
 	// SourceContextFunc returns the current source context.
 	SourceContextFunc func() (*sous.SourceContext, error)
 	// BuildContextFunc returns the current build context.
@@ -125,20 +125,7 @@ func newSourceFlags(c *cmdr.CLI) (*SourceFlags, error) {
 
 func newGitSourceContext(g LocalGitRepo) (GitSourceContext, error) {
 	c, err := g.SourceContext()
-	return c, initErr(err, "getting local git context")
-}
-
-func newSourceContextFunc(g GitSourceContext, f *SourceFlags) SourceContextFunc {
-	var c *sous.SourceContext = g
-	return func() (*sous.SourceContext, error) {
-		if f.Repo != "" {
-			if c.RemoteURL != f.Repo {
-				return nil, fmt.Errorf("repo %q (in flag) does not match local repo %q",
-					f.Repo, c.RemoteURL)
-			}
-		}
-		return c, nil
-	}
+	return GitSourceContext{c}, initErr(err, "getting local git context")
 }
 
 func newBuildContextFunc(wd LocalWorkDirShell, cf SourceContextFunc) BuildContextFunc {

--- a/cli/graph.go
+++ b/cli/graph.go
@@ -21,8 +21,6 @@ import (
 )
 
 type (
-	// Flags is the global flag set.
-	Flags *flag.FlagSet
 	// Out is an output used for real data a Command returns. This should only
 	// be used when a command needs to write directly to stdout, using the
 	// formatting options that come with an output. Usually, you should use a

--- a/cli/graph.go
+++ b/cli/graph.go
@@ -74,10 +74,8 @@ type (
 
 // BuildGraph builds the dependency injection graph, used to populate commands
 // invoked by the user.
-func BuildGraph(s *Sous, c *cmdr.CLI) (*SousCLIGraph, error) {
-	g := &SousCLIGraph{psyringe.New()}
-	return g, g.Fill(
-		s, c,
+func BuildGraph(s *Sous, c *cmdr.CLI) *SousCLIGraph {
+	return &SousCLIGraph{psyringe.New(s, c,
 		newOut,
 		newErrOut,
 		newLocalUser,
@@ -102,7 +100,7 @@ func BuildGraph(s *Sous, c *cmdr.CLI) (*SousCLIGraph, error) {
 		newLocalStateReader,
 		newLocalStateWriter,
 		newCurrentGDM,
-	)
+	)}
 }
 
 func newOut(c *cmdr.CLI) Out {

--- a/cli/graph.go
+++ b/cli/graph.go
@@ -227,9 +227,9 @@ func makeDockerRegistry(cfg LocalSousConfig, cl LocalDockerClient) (*docker.Name
 	dbCfg := cfg.Docker.DBConfig()
 	db, err := docker.GetDatabase(&dbCfg)
 	if err != nil {
-		return nil, fmt.Errorf("unable to build name cache DB: ", err)
+		return nil, fmt.Errorf("unable to build name cache DB: %s", err)
 	}
-	return &docker.NameCache{cl.Client, db}, nil
+	return &docker.NameCache{RegistryClient: cl.Client, DB: db}, nil
 }
 
 // makeDockerBuilder creates a Docker version of sous.Builder

--- a/cli/graph_sourcecontext.go
+++ b/cli/graph_sourcecontext.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"github.com/opentable/sous/lib"
+	"github.com/pkg/errors"
+)
+
+func newSourceContextFunc(g GitSourceContext, f *SourceFlags) SourceContextFunc {
+	c := g.SourceContext
+	return func() (*sous.SourceContext, error) {
+		sl, err := resolveSourceLocation(f, c)
+		if err != nil {
+			return nil, errors.Wrap(err, "resolving source location")
+		}
+		if sl != g.SourceLocation() {
+			// TODO: Clone the repository, and use the cloned dir as source context.
+			return nil, errors.Errorf("source location outside of current directory not yet supported")
+		}
+		return c, nil
+	}
+}
+
+func resolveSourceLocation(f *SourceFlags, g *sous.SourceContext) (sous.SourceLocation, error) {
+	if g == nil {
+		g = &sous.SourceContext{}
+	}
+	if f == nil {
+		f = &SourceFlags{}
+	}
+	var repo, offset = g.PrimaryRemoteURL, g.OffsetDir
+	if f.Repo != "" {
+		repo = f.Repo
+	}
+	if f.Repo != "" {
+		repo = f.Repo
+		offset = ""
+	}
+	if f.Offset != "" {
+		if f.Repo == "" {
+			return sous.SourceLocation{}, errors.Errorf("you specified -offset but not -repo")
+		}
+		offset = f.Offset
+	}
+	if repo == "" {
+		return sous.SourceLocation{}, errors.Errorf("no repo specified, please use -repo or run sous inside a git repo")
+	}
+	return sous.SourceLocation{
+		RepoURL:    sous.RepoURL(repo),
+		RepoOffset: sous.RepoOffset(offset),
+	}, nil
+}

--- a/cli/graph_sourcecontext.go
+++ b/cli/graph_sourcecontext.go
@@ -7,27 +7,31 @@ import (
 
 func newSourceContextFunc(g GitSourceContext, f *SourceFlags) SourceContextFunc {
 	c := g.SourceContext
+	if c == nil {
+		c = &sous.SourceContext{}
+	}
 	return func() (*sous.SourceContext, error) {
 		sl, err := resolveSourceLocation(f, c)
 		if err != nil {
 			return nil, errors.Wrap(err, "resolving source location")
 		}
-		if sl != g.SourceLocation() {
+		if sl != c.SourceLocation() {
 			// TODO: Clone the repository, and use the cloned dir as source context.
-			return nil, errors.Errorf("source location outside of current directory not yet supported")
+			return nil, errors.Errorf("source location %q is not the same as the remote %q",
+				sl, c.SourceLocation())
 		}
 		return c, nil
 	}
 }
 
-func resolveSourceLocation(f *SourceFlags, g *sous.SourceContext) (sous.SourceLocation, error) {
-	if g == nil {
-		g = &sous.SourceContext{}
+func resolveSourceLocation(f *SourceFlags, c *sous.SourceContext) (sous.SourceLocation, error) {
+	if c == nil {
+		c = &sous.SourceContext{}
 	}
 	if f == nil {
 		f = &SourceFlags{}
 	}
-	var repo, offset = g.PrimaryRemoteURL, g.OffsetDir
+	var repo, offset = c.PrimaryRemoteURL, c.OffsetDir
 	if f.Repo != "" {
 		repo = f.Repo
 	}

--- a/cli/graph_sourcecontext_test.go
+++ b/cli/graph_sourcecontext_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/opentable/sous/lib"
+)
+
+type resolveSourceLocationInput struct {
+	Flags   *SourceFlags
+	Context *sous.SourceContext
+}
+
+var badResolveSourceLocationCalls = map[string][]resolveSourceLocationInput{
+	"no repo specified, please use -repo or run sous inside a git repo": {
+		{Flags: &SourceFlags{}, Context: &sous.SourceContext{}},
+		{Flags: nil, Context: &sous.SourceContext{}},
+		{Flags: &SourceFlags{}, Context: nil},
+	},
+	"you specified -offset but not -repo": {
+		{Flags: &SourceFlags{Offset: "some/offset"}},
+	},
+}
+
+func TestResolveSourceLocation_failure(t *testing.T) {
+	for expected, inGroup := range badResolveSourceLocationCalls {
+		for _, in := range inGroup {
+			_, actualErr := resolveSourceLocation(in.Flags, in.Context)
+			if actualErr == nil {
+				t.Errorf("got nil; want error %q", expected)
+				continue
+			}
+			actual := actualErr.Error()
+			if actual != expected {
+				t.Errorf("got error %q; want error %q", actual, expected)
+			}
+		}
+	}
+}
+
+var goodResolveSourceLocationCalls = map[sous.SourceLocation][]resolveSourceLocationInput{
+	{RepoURL: "github.com/user/project", RepoOffset: ""}: {
+		{Flags: &SourceFlags{Repo: "github.com/user/project"}},
+		{Context: &sous.SourceContext{PrimaryRemoteURL: "github.com/user/project"}},
+	},
+	{RepoURL: "github.com/user/project", RepoOffset: "some/path"}: {
+		{Flags: &SourceFlags{Repo: "github.com/user/project", Offset: "some/path"}},
+		{Context: &sous.SourceContext{
+			PrimaryRemoteURL: "github.com/user/project",
+			OffsetDir:        "some/path",
+		}},
+	},
+	{RepoURL: "github.com/from/flags", RepoOffset: ""}: {
+		{
+			Context: &sous.SourceContext{
+				PrimaryRemoteURL: "github.com/original/context",
+				OffsetDir:        "the/detected/offset",
+			},
+			Flags: &SourceFlags{
+				Repo: "github.com/from/flags",
+			},
+		},
+	},
+}
+
+func TestResolveSourceLocation_success(t *testing.T) {
+	for expected, inGroup := range goodResolveSourceLocationCalls {
+		for _, in := range inGroup {
+			actual, err := resolveSourceLocation(in.Flags, in.Context)
+			if err != nil {
+				t.Error(err)
+				continue
+			}
+			if actual.RepoURL != expected.RepoURL {
+				t.Errorf("got repo %q; want %q", actual.RepoURL, expected.RepoURL)
+			}
+			if actual.RepoOffset != expected.RepoOffset {
+				t.Errorf("got offset %q; want %q", actual.RepoOffset, expected.RepoOffset)
+			}
+		}
+	}
+}

--- a/cli/graph_test.go
+++ b/cli/graph_test.go
@@ -8,11 +8,7 @@ import (
 
 func TestBuildGraph(t *testing.T) {
 
-	g, err := BuildGraph(&Sous{}, &cmdr.CLI{})
-
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
+	g := BuildGraph(&Sous{}, &cmdr.CLI{})
 
 	if err := g.Test(); err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/cli/sous_build.go
+++ b/cli/sous_build.go
@@ -1,22 +1,21 @@
 package cli
 
 import (
-	"flag"
-
 	"github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/cmdr"
+	"github.com/opentable/sous/util/firsterr"
 )
 
 // SousBuild is the command description for `sous build`
 // Implements cmdr.Command, cmdr.Executor and cmdr.AddFlags
 type SousBuild struct {
-	Sous         *Sous
-	Config       LocalSousConfig
-	BuildContext *sous.BuildContext
-	Builder      sous.Labeller
-	Registrar    sous.Registrar
-	Selector     sous.Selector
-	flags        struct {
+	Sous   *Sous
+	Config LocalSousConfig
+	BuildContextFunc
+	LabellerFunc
+	RegistrarFunc
+	Selector sous.Selector
+	flags    struct {
 		config              sous.BuildConfig
 		target              string
 		rebuild, rebuildAll bool
@@ -37,27 +36,24 @@ args: [path]
 // Help returns the help string for this command
 func (*SousBuild) Help() string { return sousBuildHelp }
 
-// AddFlags adds flags for sous build
-func (sb *SousBuild) AddFlags(fs *flag.FlagSet) {
-	fs.StringVar(&sb.flags.config.Repo, "repo", "",
-		"The authoritive repository for this project")
-	fs.StringVar(&sb.flags.config.Offset, "offset", "",
-		"The offset within repository for this project")
-	fs.StringVar(&sb.flags.config.Tag, "tag", "",
-		"The tag to build for this project - should conform to semver (e.g. 1.2.3-pre)")
-	fs.StringVar(&sb.flags.config.Repo, "revision", "",
-		"The revision of this project to build - a git digest")
-	fs.BoolVar(&sb.flags.config.Strict, "strict", false,
-		"If advisories would be added to the build, fail instead")
-	fs.BoolVar(&sb.flags.config.ForceClone, "force-clone", false,
-		"Ignore the current directory and work in a shallow clone of the project")
-}
-
 // Execute fulfills the cmdr.Executor interface
 func (sb *SousBuild) Execute(args []string) cmdr.Result {
+	var (
+		bc        *sous.BuildContext
+		labeller  sous.Labeller
+		registrar sous.Registrar
+	)
+	err := firsterr.Set(
+		func(err *error) { bc, *err = sb.BuildContextFunc() },
+		func(err *error) { labeller, *err = sb.LabellerFunc() },
+		func(err *error) { registrar, *err = sb.RegistrarFunc() },
+	)
+	if err != nil {
+		return EnsureErrorResult(err)
+	}
 	if len(args) != 0 {
 		path := args[0]
-		if err := sb.BuildContext.Sh.CD(path); err != nil {
+		if err := bc.Sh.CD(path); err != nil {
 			return cmdr.EnsureErrorResult(err)
 		}
 	}
@@ -65,10 +61,10 @@ func (sb *SousBuild) Execute(args []string) cmdr.Result {
 	mgr := &sous.BuildManager{
 		BuildConfig: &sb.flags.config,
 		Selector:    sb.Selector,
-		Labeller:    sb.Builder,
-		Registrar:   sb.Registrar,
+		Labeller:    labeller,
+		Registrar:   registrar,
 	}
-	mgr.BuildConfig.Context = sb.BuildContext
+	mgr.BuildConfig.Context = bc
 
 	result, err := mgr.Build()
 

--- a/cli/sous_build.go
+++ b/cli/sous_build.go
@@ -9,16 +9,12 @@ import (
 // SousBuild is the command description for `sous build`
 // Implements cmdr.Command, cmdr.Executor and cmdr.AddFlags
 type SousBuild struct {
-	Sous   *Sous
-	Config LocalSousConfig
 	BuildContextFunc
 	LabellerFunc
 	RegistrarFunc
 	Selector sous.Selector
 	flags    struct {
-		config              sous.BuildConfig
-		target              string
-		rebuild, rebuildAll bool
+		config sous.BuildConfig
 	}
 }
 

--- a/cli/sous_context.go
+++ b/cli/sous_context.go
@@ -7,8 +7,9 @@ import (
 	"github.com/opentable/sous/util/cmdr"
 )
 
+// SousContext is the 'sous context' command.
 type SousContext struct {
-	SourceContext *sous.SourceContext
+	SourceContext func() (*sous.SourceContext, error)
 }
 
 func init() { TopLevelCommands["context"] = &SousContext{} }
@@ -21,10 +22,16 @@ context prints out sous's view of your current context
 args:
 `
 
+// Help provides help for sous context.
 func (*SousContext) Help() string { return sousContextHelp }
 
+// Execute prints the detected sous context.
 func (sv *SousContext) Execute(args []string) cmdr.Result {
-	b, err := json.MarshalIndent(sv.SourceContext, "", "  ")
+	sc, err := sv.SourceContext()
+	if err != nil {
+		return EnsureErrorResult(err)
+	}
+	b, err := json.MarshalIndent(sc, "", "  ")
 	if err != nil {
 		return EnsureErrorResult(err)
 	}

--- a/cli/sous_context.go
+++ b/cli/sous_context.go
@@ -1,10 +1,6 @@
 package cli
 
-import (
-	"encoding/json"
-
-	"github.com/opentable/sous/util/cmdr"
-)
+import "github.com/opentable/sous/util/cmdr"
 
 // SousContext is the 'sous context' command.
 type SousContext struct {
@@ -30,9 +26,5 @@ func (sv *SousContext) Execute(args []string) cmdr.Result {
 	if err != nil {
 		return EnsureErrorResult(err)
 	}
-	b, err := json.MarshalIndent(sc, "", "  ")
-	if err != nil {
-		return EnsureErrorResult(err)
-	}
-	return Successf(string(b))
+	return SuccessYAML(sc)
 }

--- a/cli/sous_context.go
+++ b/cli/sous_context.go
@@ -3,13 +3,12 @@ package cli
 import (
 	"encoding/json"
 
-	sous "github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/cmdr"
 )
 
 // SousContext is the 'sous context' command.
 type SousContext struct {
-	SourceContext func() (*sous.SourceContext, error)
+	SourceContextFunc
 }
 
 func init() { TopLevelCommands["context"] = &SousContext{} }
@@ -27,7 +26,7 @@ func (*SousContext) Help() string { return sousContextHelp }
 
 // Execute prints the detected sous context.
 func (sv *SousContext) Execute(args []string) cmdr.Result {
-	sc, err := sv.SourceContext()
+	sc, err := sv.SourceContextFunc()
 	if err != nil {
 		return EnsureErrorResult(err)
 	}

--- a/cli/sous_deploy.go
+++ b/cli/sous_deploy.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/cmdr"
+	"github.com/opentable/sous/util/firsterr"
+	"github.com/samsalisbury/semv"
+)
+
+// SousDeploy is the command description for `sous init`
+type SousDeploy struct {
+	SourceContext *sous.SourceContext
+	WD            LocalWorkDirShell
+	GDM           CurrentGDM
+	StateWriter   LocalStateWriter
+
+	// Rectify fields
+	Config       LocalSousConfig
+	DockerClient LocalDockerClient
+	Deployer     sous.Deployer
+	Registry     sous.Registry
+
+	flags struct {
+		RepoURL, RepoOffset, Cluster, Version string
+	}
+}
+
+func init() { TopLevelCommands["deploy"] = &SousDeploy{} }
+
+const sousUpdateHelp = `
+deploy a new version
+
+usage: sous deploy -cluster <name> -version <semver>
+`
+
+// Help returns the help string for this command
+func (su *SousDeploy) Help() string { return sousInitHelp }
+
+// AddFlags adds the flags for sous init.
+func (su *SousDeploy) AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&su.flags.RepoURL, "repo-url", "",
+		"the source code repo for this project (e.g. github.com/user/project)")
+	fs.StringVar(&su.flags.RepoOffset, "repo-offset", "",
+		"the subdir within the repo where the source code lives (empty for root)")
+	fs.StringVar(&su.flags.Cluster, "cluster", "",
+		"which cluster to update the config in")
+	fs.StringVar(&su.flags.Version, "version", "",
+		"which version to deploy to this cluster")
+}
+
+// Execute fulfills the cmdr.Executor interface.
+func (su *SousDeploy) Execute(args []string) cmdr.Result {
+	var repoURL, repoOffset string
+	if err := firsterr.Parallel().Set(
+		func(e *error) { repoURL, *e = su.resolveRepoURL() },
+		func(e *error) { repoOffset, *e = su.resolveRepoOffset() },
+	); err != nil {
+		return EnsureErrorResult(err)
+	}
+
+	if su.flags.Cluster == "" {
+		return UsageErrorf("You must a cluster using the -cluster flag.")
+	}
+
+	sl := sous.NewSourceLocation(repoURL, repoOffset)
+
+	m := su.GDM.GetManifest(sl)
+	if m == nil {
+		return UsageErrorf("update failed: manifest %q does not exist", sl)
+	}
+
+	clusterName := su.flags.Cluster
+	cluster, ok := m.Deployments[clusterName]
+	if !ok {
+		return UsageErrorf("Cluster %q does not exist.")
+	}
+
+	versionStr := su.flags.Version
+	newVersion, err := semv.Parse(versionStr)
+	if err != nil {
+		return UsageErrorf("version not valid: %s", err)
+	}
+	cluster.Version = newVersion
+	m.Deployments[clusterName] = cluster
+
+	if err := su.StateWriter.WriteState(su.GDM.State); err != nil {
+		return EnsureErrorResult(err)
+	}
+
+	rectify := SousRectify{
+		Config:       su.Config,
+		DockerClient: su.DockerClient,
+		Deployer:     su.Deployer,
+		Registry:     su.Registry,
+		GDM:          su.GDM,
+		flags: rectifyFlags{
+			repo:    repoURL,
+			offset:  repoOffset,
+			cluster: clusterName,
+		},
+	}
+	return rectify.Execute(nil)
+}
+
+func (su *SousDeploy) resolveRepoURL() (string, error) {
+	repoURL := su.flags.RepoURL
+	if repoURL == "" {
+		repoURL = su.SourceContext.PossiblePrimaryRemoteURL
+		if repoURL == "" {
+			return "", fmt.Errorf("no repo URL found, please use -repo-url")
+		}
+		sous.Log.Info.Printf("using repo URL %q (from git remotes)", repoURL)
+	}
+	if !strings.HasPrefix(repoURL, "github.com/") {
+		return "", fmt.Errorf("repo URL must begin with github.com/")
+	}
+	return repoURL, nil
+}
+
+func (su *SousDeploy) resolveRepoOffset() (string, error) {
+	repoOffset := su.flags.RepoOffset
+	if repoOffset == "" {
+		repoOffset := su.SourceContext.OffsetDir
+		sous.Log.Info.Printf("using current workdir repo offset: %q", repoOffset)
+	}
+	if len(repoOffset) != 0 && repoOffset[:1] == "/" {
+		return "", fmt.Errorf("repo offset cannot begin with /, it is relative")
+	}
+	return repoOffset, nil
+}

--- a/cli/sous_deploy.go
+++ b/cli/sous_deploy.go
@@ -63,7 +63,7 @@ func (su *SousDeploy) Execute(args []string) cmdr.Result {
 	}
 
 	if su.flags.Cluster == "" {
-		return UsageErrorf("You must a cluster using the -cluster flag.")
+		return UsageErrorf("You must a select a cluster using the -cluster flag.")
 	}
 
 	sl := sous.NewSourceLocation(repoURL, repoOffset)

--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -38,6 +38,7 @@ flesh out some additional details.
 // Help returns the help string for this command
 func (si *SousInit) Help() string { return sousInitHelp }
 
+// AddFlags adds the flags for sous init.
 func (si *SousInit) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&si.flags.RepoURL, "repo-url", "",
 		"the source code repo for this project (e.g. github.com/user/project)")
@@ -53,8 +54,8 @@ func (si *SousInit) AddFlags(fs *flag.FlagSet) {
 func (si *SousInit) Execute(args []string) cmdr.Result {
 	var repoURL, repoOffset string
 	if err := firsterr.Parallel().Set(
-		func(e *error) { repoURL, *e = si.ResolveRepoURL() },
-		func(e *error) { repoOffset, *e = si.ResolveRepoOffset() },
+		func(e *error) { repoURL, *e = si.resolveRepoURL() },
+		func(e *error) { repoOffset, *e = si.resolveRepoOffset() },
 	); err != nil {
 		return EnsureErrorResult(err)
 	}
@@ -115,7 +116,7 @@ func defaultDeploySpecs() sous.DeploySpecs {
 	}
 }
 
-func (si *SousInit) ResolveRepoURL() (string, error) {
+func (si *SousInit) resolveRepoURL() (string, error) {
 	repoURL := si.flags.RepoURL
 	if repoURL == "" {
 		repoURL = si.SourceContext.PossiblePrimaryRemoteURL
@@ -130,7 +131,7 @@ func (si *SousInit) ResolveRepoURL() (string, error) {
 	return repoURL, nil
 }
 
-func (si *SousInit) ResolveRepoOffset() (string, error) {
+func (si *SousInit) resolveRepoOffset() (string, error) {
 	repoOffset := si.flags.RepoOffset
 	if repoOffset == "" {
 		repoOffset := si.SourceContext.OffsetDir

--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -119,7 +119,7 @@ func defaultDeploySpecs() sous.DeploySpecs {
 func (si *SousInit) resolveRepoURL(ctx *sous.SourceContext) (string, error) {
 	repoURL := si.flags.RepoURL
 	if repoURL == "" {
-		repoURL = ctx.PossiblePrimaryRemoteURL
+		repoURL = ctx.PrimaryRemoteURL
 		if repoURL == "" {
 			return "", fmt.Errorf("no repo URL found, please use -repo-url")
 		}

--- a/cli/tests/sous_test.go
+++ b/cli/tests/sous_test.go
@@ -31,7 +31,7 @@ func TestSousVersion(t *testing.T) {
 
 	term.CLI.Hooks.PreExecute = func(c cmdr.Command) error {
 		g := psyringe.New()
-		g.Fill(
+		g.Add(
 			&cli.Sous{Version: semv.MustParse("1.0.0-test")},
 		)
 		return g.Inject(c)

--- a/cli/tests/sous_test.go
+++ b/cli/tests/sous_test.go
@@ -19,7 +19,7 @@ func TestSous(t *testing.T) {
 
 	log.Print(term.Stderr)
 	term.Stdout.ShouldHaveNumLines(0)
-	term.Stderr.ShouldHaveNumLines(20)
+	term.Stderr.ShouldHaveNumLines(21)
 
 	term.Stderr.ShouldHaveExactLine("usage: sous <command>")
 	term.Stderr.ShouldHaveLineContaining("help     get help with sous")

--- a/cli/tests/terminal.go
+++ b/cli/tests/terminal.go
@@ -40,10 +40,7 @@ func NewTerminal(t *testing.T, root cmdr.Command) *Terminal {
 		Out:  cmdr.NewOutput(io.MultiWriter(out.Buffer, combined.Buffer)),
 		Err:  cmdr.NewOutput(io.MultiWriter(errout.Buffer, combined.Buffer)),
 	}
-	g, err := cli.BuildGraph(s, c)
-	if err != nil {
-		t.Fatal(err)
-	}
+	g := cli.BuildGraph(s, c)
 	c.Hooks.PreExecute = func(c cmdr.Command) error {
 		return g.Inject(c)
 	}

--- a/ext/docker/build_test.go
+++ b/ext/docker/build_test.go
@@ -8,9 +8,9 @@ import (
 
 func testSourceContext() *sous.SourceContext {
 	return &sous.SourceContext{
-		PossiblePrimaryRemoteURL: "github.com/opentable/awesomeproject",
-		NearestTagName:           "1.2.3",
-		Revision:                 "987654321987654312",
+		PrimaryRemoteURL: "github.com/opentable/awesomeproject",
+		NearestTagName:   "1.2.3",
+		Revision:         "987654321987654312",
 	}
 }
 

--- a/ext/git/context.go
+++ b/ext/git/context.go
@@ -18,7 +18,7 @@ func (r *Repo) SourceContext() (*sous.SourceContext, error) {
 		files, modifiedFiles, newFiles []string
 		allTags                        []sous.Tag
 		remotes                        Remotes
-		unpushedCommits                []string
+		//unpushedCommits                []string
 	)
 	c := r.Client
 	if err := firsterr.Parallel().Set(
@@ -50,26 +50,26 @@ func (r *Repo) SourceContext() (*sous.SourceContext, error) {
 		func(err *error) { modifiedFiles, *err = c.ModifiedFiles() },
 		func(err *error) { newFiles, *err = c.NewFiles() },
 		func(err *error) { remotes, *err = c.ListRemotes() },
-		func(err *error) { unpushedCommits, *err = c.ListUnpushedCommits() },
+		//func(err *error) { unpushedCommits, *err = c.ListUnpushedCommits() },
 	); err != nil {
 		return nil, err
 	}
 
 	primaryRemoteURL := guessPrimaryRemote(remotes)
 	return &sous.SourceContext{
-		RootDir:                  r.Root,
-		OffsetDir:                repoRelativeDir,
-		Branch:                   branch,
-		Revision:                 revision,
-		Files:                    files,
-		ModifiedFiles:            modifiedFiles,
-		NewFiles:                 newFiles,
-		Tags:                     allTags,
-		NearestTagName:           nearestTagName,
-		NearestTagRevision:       nearestTagRevision,
-		PossiblePrimaryRemoteURL: primaryRemoteURL,
-		RemoteURLs:               allFetchURLs(remotes),
-		DirtyWorkingTree:         len(modifiedFiles)+len(newFiles) != 0,
+		RootDir:            r.Root,
+		OffsetDir:          repoRelativeDir,
+		Branch:             branch,
+		Revision:           revision,
+		Files:              files,
+		ModifiedFiles:      modifiedFiles,
+		NewFiles:           newFiles,
+		Tags:               allTags,
+		NearestTagName:     nearestTagName,
+		NearestTagRevision: nearestTagRevision,
+		PrimaryRemoteURL:   primaryRemoteURL,
+		RemoteURLs:         allFetchURLs(remotes),
+		DirtyWorkingTree:   len(modifiedFiles)+len(newFiles) != 0,
 	}, nil
 }
 

--- a/lib/build_config.go
+++ b/lib/build_config.go
@@ -43,21 +43,21 @@ func (c *BuildConfig) NewContext() *BuildContext {
 		User:    ctx.User,
 		Changes: ctx.Changes,
 		Source: SourceContext{
-			RootDir:                  sc.RootDir,
-			OffsetDir:                c.chooseOffset(),
-			Branch:                   sc.Branch,
-			Revision:                 sc.Revision,
-			Files:                    sc.Files,
-			ModifiedFiles:            sc.ModifiedFiles,
-			NewFiles:                 sc.NewFiles,
-			Tags:                     sc.Tags,
-			NearestTagName:           c.chooseTag(),
-			NearestTagRevision:       sc.NearestTagRevision,
-			RemoteURL:                c.chooseRemoteURL(),
-			PossiblePrimaryRemoteURL: sc.PossiblePrimaryRemoteURL,
-			RemoteURLs:               sc.RemoteURLs,
-			DirtyWorkingTree:         sc.DirtyWorkingTree,
-			RevisionUnpushed:         sc.RevisionUnpushed,
+			RootDir:            sc.RootDir,
+			OffsetDir:          c.chooseOffset(),
+			Branch:             sc.Branch,
+			Revision:           sc.Revision,
+			Files:              sc.Files,
+			ModifiedFiles:      sc.ModifiedFiles,
+			NewFiles:           sc.NewFiles,
+			Tags:               sc.Tags,
+			NearestTagName:     c.chooseTag(),
+			NearestTagRevision: sc.NearestTagRevision,
+			RemoteURL:          c.chooseRemoteURL(),
+			PrimaryRemoteURL:   sc.PrimaryRemoteURL,
+			RemoteURLs:         sc.RemoteURLs,
+			DirtyWorkingTree:   sc.DirtyWorkingTree,
+			RevisionUnpushed:   sc.RevisionUnpushed,
 		},
 	}
 
@@ -68,8 +68,8 @@ func (c *BuildConfig) NewContext() *BuildContext {
 
 func (c *BuildConfig) chooseRemoteURL() string {
 	if c.Repo == "" {
-		Log.Debug.Printf("Using best guess: % #v", c.Context.Source.PossiblePrimaryRemoteURL)
-		return c.Context.Source.PossiblePrimaryRemoteURL
+		Log.Debug.Printf("Using best guess: % #v", c.Context.Source.PrimaryRemoteURL)
+		return c.Context.Source.PrimaryRemoteURL
 	}
 	return c.Repo
 }

--- a/lib/build_config_test.go
+++ b/lib/build_config_test.go
@@ -50,7 +50,7 @@ func TestMissingExplicitRepo(t *testing.T) {
 		Repo: "github.com/opentable/present",
 		Context: &BuildContext{
 			Source: SourceContext{
-				PossiblePrimaryRemoteURL: "github.com/guessed/upstream",
+				PrimaryRemoteURL: "github.com/guessed/upstream",
 				RemoteURLs: []string{
 					"github.com/opentable/also",
 				},
@@ -73,7 +73,7 @@ func TestAbsentRepoConfig(t *testing.T) {
 		Repo: "",
 		Context: &BuildContext{
 			Source: SourceContext{
-				PossiblePrimaryRemoteURL: "github.com/guessed/upstream",
+				PrimaryRemoteURL: "github.com/guessed/upstream",
 				RemoteURLs: []string{
 					"github.com/opentable/also",
 				},
@@ -94,7 +94,7 @@ func TestNoRepo(t *testing.T) {
 		Repo: "",
 		Context: &BuildContext{
 			Source: SourceContext{
-				PossiblePrimaryRemoteURL: "",
+				PrimaryRemoteURL: "",
 				RemoteURLs: []string{
 					"github.com/opentable/also",
 				},
@@ -188,10 +188,10 @@ func TestEphemeralTag(t *testing.T) {
 		Tag: "1.2.3",
 		Context: &BuildContext{
 			Source: SourceContext{
-				PossiblePrimaryRemoteURL: "github.com/opentable/present",
-				Revision:                 "abcd",
-				NearestTagName:           "1.2.0",
-				NearestTagRevision:       "abcd",
+				PrimaryRemoteURL:   "github.com/opentable/present",
+				Revision:           "abcd",
+				NearestTagName:     "1.2.0",
+				NearestTagRevision: "abcd",
 			},
 		},
 	}

--- a/lib/source_context.go
+++ b/lib/source_context.go
@@ -14,7 +14,7 @@ type (
 		Files, ModifiedFiles, NewFiles       []string
 		Tags                                 []Tag
 		NearestTagName, NearestTagRevision   string
-		PossiblePrimaryRemoteURL             string
+		PrimaryRemoteURL                     string
 		RemoteURL                            string
 		RemoteURLs                           []string
 		DirtyWorkingTree                     bool
@@ -26,6 +26,7 @@ type (
 	}
 )
 
+// Version returns the SourceID.
 func (sc *SourceContext) Version() SourceID {
 	v, err := semv.Parse(sc.NearestTagName)
 	if err != nil {
@@ -40,6 +41,14 @@ func (sc *SourceContext) Version() SourceID {
 	}
 	Log.Debug.Printf("Version: % #v", sv)
 	return sv
+}
+
+// SourceLocation returns the source location in this context.
+func (sc *SourceContext) SourceLocation() SourceLocation {
+	return SourceLocation{
+		RepoURL:    RepoURL(sc.RemoteURL),
+		RepoOffset: RepoOffset(sc.OffsetDir),
+	}
 }
 
 // AbsDir returns the absolute path of this source code.

--- a/lib/source_context.go
+++ b/lib/source_context.go
@@ -46,7 +46,7 @@ func (sc *SourceContext) Version() SourceID {
 // SourceLocation returns the source location in this context.
 func (sc *SourceContext) SourceLocation() SourceLocation {
 	return SourceLocation{
-		RepoURL:    RepoURL(sc.RemoteURL),
+		RepoURL:    RepoURL(sc.PrimaryRemoteURL),
 		RepoOffset: RepoOffset(sc.OffsetDir),
 	}
 }

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## Licence
+
+BSD-2-Clause

--- a/vendor/github.com/pkg/errors/appveyor.yml
+++ b/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,220 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// causer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface.
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// Where errors.StackTrace is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// stackTracer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// _error is an error implementation returned by New and Errorf
+// that implements its own fmt.Formatter.
+type _error struct {
+	msg string
+	*stack
+}
+
+func (e _error) Error() string { return e.msg }
+
+func (e _error) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, e.msg)
+			fmt.Fprintf(s, "%+v", e.StackTrace())
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, e.msg)
+	}
+}
+
+// New returns an error with the supplied message.
+func New(message string) error {
+	return _error{
+		message,
+		callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+func Errorf(format string, args ...interface{}) error {
+	return _error{
+		fmt.Sprintf(format, args...),
+		callers(),
+	}
+}
+
+type cause struct {
+	cause error
+	msg   string
+}
+
+func (c cause) Error() string { return fmt.Sprintf("%s: %v", c.msg, c.Cause()) }
+func (c cause) Cause() error  { return c.cause }
+
+// wrapper is an error implementation returned by Wrap and Wrapf
+// that implements its own fmt.Formatter.
+type wrapper struct {
+	cause
+	*stack
+}
+
+func (w wrapper) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			fmt.Fprintf(s, "%+v", w.StackTrace())
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return wrapper{
+		cause: cause{
+			cause: err,
+			msg:   message,
+		},
+		stack: callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return wrapper{
+		cause: cause{
+			cause: err,
+			msg:   fmt.Sprintf(format, args...),
+		},
+		stack: callers(),
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,165 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   path of source file relative to the compile time GOPATH
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}
+
+func trimGOPATH(name, file string) string {
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(name, sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file
+}

--- a/vendor/github.com/samsalisbury/psyringe/LICENSE
+++ b/vendor/github.com/samsalisbury/psyringe/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Sam Salisbury
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/samsalisbury/psyringe/README.md
+++ b/vendor/github.com/samsalisbury/psyringe/README.md
@@ -1,123 +1,92 @@
 # psyringe
 
-Psyringe is a fast, **p**arallel, [lazy], easy to use [dependency injector] for [Go].
+[![CircleCI](https://circleci.com/gh/samsalisbury/psyringe.svg?style=svg)](https://circleci.com/gh/samsalisbury/psyringe)
+[![codecov](https://codecov.io/gh/samsalisbury/psyringe/branch/master/graph/badge.svg)](https://codecov.io/gh/samsalisbury/psyringe)
+[![Go Report Card](https://goreportcard.com/badge/github.com/samsalisbury/psyringe)](https://goreportcard.com/report/github.com/samsalisbury/psyringe)
+[![GoDoc](https://godoc.org/github.com/samsalisbury/psyringe?status.svg)](https://godoc.org/github.com/samsalisbury/psyringe)
+[![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+Psyringe is a [fast], **p**arallel, [lazy], easy to use [dependency injector] for [Go].
 
 ```go
-psyringe.Fill(ValuesAndConstructors...)
-target := SomeThing{}
-psyringe.Inject(&target)
+//file: example_test.go
+
+type Speaker struct {
+	Message    string
+	MessageLen int
+}
+
+// Contrived example showing how to create a Psyringe with interdependent
+// constructors and then inject their values into a struct that depends on them.
+func Example() {
+	p := psyringe.New(
+		func() string { return "Hi!" },       // string constructor
+		func(s string) int { return len(s) }, // int constructor (needs string)
+	)
+	v := Speaker{}
+	if err := p.Inject(&v); err != nil {
+		panic(err) // a little drastic I'm sure
+	}
+	fmt.Printf("Speaker says %q in %d characters.", v.Message, v.MessageLen)
+	// output:
+	// Speaker says "Hi!" in 3 characters.
+}
 ```
 
-See a [simple usage example], below.
+[Fully documented at GoDoc.org].
 
 [lazy]: https://en.wikipedia.org/wiki/Lazy_initialization
 [dependency injector]: https://en.wikipedia.org/wiki/Dependency_injection
 [Go]: https://golang.org
 [simple usage example]: #simple-usage-example
+[Fully documented at GoDoc.org]: https://godoc.org/github.com/samsalisbury/psyringe
+[fast]: ./bench_test.go
 
 ## Features
 
-- **[Concurrent, lazy initialisation]:** with no extra work on your part.
+- **[Concurrent initialisation]:** with no extra work on your part.
 - **[No tags]:** keep your code clean and readable.
-- **[Simple API]:** usually only needs two calls: `psyringe.Fill()` and `psyringe.Inject()`
-- **[Supports advanced use cases]:** e.g. [scopes], [named instances], [debugging]
+- **[Simple API]:** usually only needs two calls: `p := psyringe.New()` and `p.Inject()`
+- **[Supports advanced use cases]:** e.g. [scopes] and [named instances].
 
-[Concurrent, lazy initialisation]: #concurrent-and-lazy
+[Concurrent initialisation]: #concurrent-initialisation
 [No tags]: #no-tags
 [Simple API]: #simple-api
 [Supports advanced use cases]: #advanced-uses
 
 [scopes]: #scopes
 [named instances]: #named-instances
-[debugging]: #debugging
 
-### Concurrent and lazy
+### Concurrent Initialisation
 
-Value graphs are populated recursively, and concurrently where the structure allows. For example, in the following code, both `NewRay` and `NewComb` will be run simultaneously when running `psyringe.Inject` since neither depends on the other. However `NewWhat` will not be run, since `NeedsWidget` does not have a `What` field.
-
-```go
-func NewLaser() Laser                 { return Laser{} }
-func NewCog() Cog                     { return Cog{} }
-func NewBanana() Banana               { panic("this won't be called") }
-func NewCannon(x Laser, y Cog) Widget { return Cannon{x, y} }
-
-type Cannon struct {
-	BeamGenerator Laser
-	Rotator       Cog
-}
-type FlyingSaucer struct { MainGun Cannon }
-
-psyringe.Fill(NewCannon, NewLaser, NewCog, NewBanana)
-ufo := FlyingSaucer{}
-psyringe.Inject(&ufo)
-```
+A dependency graph already contains enough information to know which parts can be run concurrently: Any two dependencies in the graph that do not have an edge between them can be generated at the same time. Psyringe uses channels internally to represent the edges in the graph, piping the results of each successful constructor to all the other constructors that need its generated value. The beauty of Go's channel primitives mean this graph is determined implicitly without heavy up-front analysis.
 
 ### No Tags
 
-Unlike most dependency injectors for Go, this one does not require you to litter your structs with tags. Instead, it relies on well-written Go code to perform injection based solely on the types of your struct fields.
+Unlike most dependency injectors for Go, this one does not require you to litter your structs with tags. Instead, it relies on well-written Go code to perform injection based solely on the types of your struct fields and constructor parameters.
 
 ### Simple API
 
-Psyringe follows through on its metaphor. You `Fill` the psyringe with things, then you `Inject` them into other things. Psyringe does not try to provide any other features, but instead makes it easy to implement more advanced features like dependency scoping yourself. For example, you can create multiple psyringes and have all of them inject different dependencies into the same struct.
+Psyringe follows through on its metaphor. You `Add` things to the psyringe, then you `Inject` them into other things. Psyringe does not try to provide any other features, but instead makes it easy to implement more advanced features like scoping yourself. For example, you can create multiple Psyringes and have each of them inject different dependencies into the same struct.
 
 ### Advanced Uses
 
-Although the API is simple, and doesn't explicitly support scopes or named instances, these things are trivial to implement yourself. For example, scopes can be created by using multiple psyringes, one at application level, and another within a http request, for example. See a complete example HTTP server using multiple scopes, below.
+Although the API is simple, and doesn't explicitly support scopes or named instances, these things are trivial to implement yourself. For example, scopes can be created by using multiple Psyringes, one at application level, and another within a http request, for example. See a complete example HTTP server using multiple scopes, below.
 
-Likewise, named instances (i.e. multiple different instances of the same type) can be created by aliasing the type name.
+Likewise, named instances (i.e. multiple different instances of the same type) can be created by aliasing the type name, or wrapping it in a struct.
 
 ### Why "psyringe"?
 
-psyringe is a _parallel syringe_ which automatically injects multiple values simultaneously, based on the needs of your interdependent constructors.
+Psyringe is a _parallel syringe_ which automatically injects values concurrently, based on the needs of your interdependent constructors.
 
 ## Usage
 
-Call `psyringe.Fill(...)` to add values and constructors to the psyringe. Then, call `psyringe.Inject(...)` to inject those values into structs which need them.
+Create a new psyringe with `p := psyringe.New` passing in constructors and other values.
+Then, call `p.Inject(...)` to inject those values into structs with correspondingly typed fields.
 
-### Simple Usage Example
+Please see [the documentation] for more usage examples.
 
-```go
-package psyringe_test
-
-import (
-	"fmt"
-	"log"
-
-	"github.com/samsalisbury/psyringe"
-)
-
-type (
-	Command struct {
-		User Username
-		Host Hostname
-		Load LoadAverage
-	}
-	Username    string
-	Hostname    string
-	LoadAverage float64
-)
-
-func NewUsername() Username       { return "bob" }
-func NewHostname() Hostname       { return Hostname("localhost") }
-func NewLoadAverage() LoadAverage { return 0.83 }
-
-func (c Command) Print() {
-	fmt.Printf("User: %s, Host: %s, Load average: %.2f", c.User, c.Host, c.Load)
-}
-
-func ExamplePsyringe_Simple() {
-	s := psyringe.Psyringe{}
-	if err := s.Fill(NewUsername, NewHostname, NewLoadAverage); err != nil {
-		log.Fatal(err)
-	}
-	command := Command{}
-	s.Inject(&command)
-	command.Print()
-	// output:
-	// User: bob, Host: localhost, Load average: 0.83
-}
-
-```
+[the documentation]: https://godoc.org/github.com/samsalisbury/psyringe
 
 ### Advanced usage
 
@@ -135,7 +104,7 @@ Sometimes, you may need to inject more than one value of the same type. For exam
 type Something struct { Name, Desc string }
 ```
 
-As it stands, psyringe would be unable to inject `Name` and `Desc` with different values, since a psyringe can only inject a single value of each type, and they are both `string`. However, by using an under-used feature of Go, [named types], it is possible to inject different values:
+As it stands, psyringe would be unable to inject `Name` and `Desc` with different values, since a psyringe can only inject a single value of each type, and they are both `string`. However, by using different [named types], it is possible to inject different values:
 
 ```go
 type Something struct {
@@ -153,14 +122,14 @@ Using these named types can also improve the readability of your code in many ca
 
 #### Scopes
 
-If you need values with different scopes (a.k.a. lifetimes), then you can use multiple psyringes, one for each scope. This allows you to preciesly control value lifetimes using normal Go code. There is one method added to support this use case: `Clone()`. The main use of `Clone` is to generate a fresh psyringe based on the constructors and values of one you've already defined. This is computationally cheaper than filling a blank psyringe from scratch. See this example HTTP server below:
+If you need values with different scopes, then you can use multiple Psyringes, one for each scope. This allows you to precisely control value lifetimes using normal Go code. There is one method which supports this use case: `Clone`. The main use of `Clone` is to generate a fresh psyringe based on the constructors and values of one you've already defined. This is cheaper than filling a blank psyringe from scratch. See this example HTTP server below:
 
 ```go
 var appScopedPsyringe, requestScopedPsyringe psyringe.Psyringe
 
 func main() {
-	appScopedPsyringe = psyringe.New().Fill(ApplicationScopedThings...)
-	requestPsyringe = psyringe.New().Fill(RequestScopedThings...)
+	appScopedPsyringe = psyringe.New(ApplicationScopedThings...)
+	requestPsyringe = psyringe.New(RequestScopedThings...)
 	http.HandleFunc("/", HandleHTTPRequest)
 	http.ListenAndServe(":8080")
 }
@@ -200,13 +169,15 @@ func HandleHTTPRequest(w http.ResponseWriter, r *http.Request) {
 
 ### How does it work?
 
-Each item you pass into `.Fill()` is analysed to see whether or not it is a [constructor]. If it is a constructor, then the type of its first return value is registered as its [injection type]. Otherwise the item is considered to be a _value_ and its own type is used as its injection type. Your psyringe knows how to inject values of each registered injection type.
+Each item you pass into `Add` or `New` is analysed to see whether or not it is a [constructor]. If it is a constructor, then the type of its first return value is registered as its [injection type]. Otherwise the item is considered to be a _value_ and its own type is used as its injection type. Your psyringe knows how to inject values of each registered injection type.
 
-When you call `.Inject(&someStruct)`, each field in someStruct is populated with an item of the corresponding injection type from the psyringe. For constructors, it will call that constructor exactly once to generate its value, if needed. For non-constructor values that were passed in to `Fill`, it will simply inject that value when called to.
+All the constructors together form a dependency graph, where each parameter in each constructor needs a corresponding constructor or value in the same psyringe in order for it to be successfully invoked. You can call `Psyringe.Test` to check that all constructor parameters are satisfied within a Psyringe.
 
-Each parameter in a constructor will need to also be available in the psyringe, in order for that constructor to be successfully invoked. If not, `.Inject` will return an error.
+When you call `p.Inject(&someStruct)`, each field in `someStruct` is populated with an item of the corresponding injection type from the `Psyringe` `p`. For constructors, it will call that constructor exactly once to generate its value, if needed. For non-constructor values that were passed in to `p`, it will simply inject that value when called to.
 
-Likewise, if the constructor is successfully invoked, but returns a non-nil error as its second return value, then `.Inject` will return the first such error encountered.
+For each constructor parameter in each constructor, you will need to `Add`, in order for that constructor to be successfully invoked. If not, `Inject` will return an error.
+
+Likewise, if the constructor is successfully _invoked_, but returns an error as its second return value, then `Inject` will return the first such error encountered. Thus you can return meaningful errors from your constructors, and handle them in one place in your app.
 
 [injection type]: #injection-types
 [constructor]: #constructors
@@ -214,29 +185,45 @@ Likewise, if the constructor is successfully invoked, but returns a non-nil erro
 
 #### Injection Types
 
-Values and constructors passed into a psyringe have an implicit **_injection type_** which is the type of value that thing represents. For non-constructor values, the injection type is the type of the value passed into the psyringe. For constructors, it is the type of the first output (return) value. It is important to understand this concept, since a single psyringe can have only one value or constructor per injection type. `Fill` will return an error if you try to register multiple values and/or constructors that resolve to the same injection type.
+Values and constructors passed into a psyringe have an implicit **_injection type_** which is the type of value that thing represents. For non-constructor values, the injection type is the type of the value passed into the psyringe. For constructors, it is the type of the first output (return) value. It is important to understand this concept, since a single psyringe can have only one value or constructor per injection type. `Add` will return an error if you try to register multiple values and/or constructors that resolve to the same injection type.
 
 #### Constructors
 
 Constructors can take 2 different forms:
 
-1. `func (...Anything) Anything`
-2. `func (...Anything) (Anything, error)`
+1. `func(...Anything) Anything`
+2. `func(...Anything) (Anything, error)`
 
 Just to clarify: `Anything` means literally any type, and in the signatures above can have a different value each time it is seen. For example, all of the following types are considered to be constructors:
 
-- func() int
-- func() (int, error)
-- func(int) int
-- func(int) (int, error) 
-- func (string, io.Reader, io.Writer) interface{}
-- func (string, io.Reader, io.Writer) (interface{}, error)
+    func() int
+    func() (int, error)
+    func(int) int
+    func(int) (int, error) 
+    func(string, io.Reader, io.Writer) interface{}
+    func(string, io.Reader, io.Writer) (interface{}, error)
 
-If you need to inject a function which has a constructor's signature, you'll need to create a constructor that returns that function. For example, for an value with injection type `func(int) (int, error)`, you would need to create a func to return that:
+If you need to inject a function which has a constructor's signature, you'll need to create a constructor that returns that function. For example, for a value with injection type `func(int) (int, error)`, you would need to create a func to return that func, otherwise psyringe will think it's a constructor for int.
 
 ```go
-newFunc() func(int) (int, error) {
+func newFunc() func(int) (int, error) {
 	return func(int) (int, error) { return 0, nil }
 }
 ```
 
+# TODO
+
+- Add examples for: New, Add, Clone, Inject
+- Add HTTP server example
+- Make injection more efficient.
+  (The benchmarks imply this is relatively expensive still, may be
+  worth caching injection plan per target type, for use in cloned
+  Psyringes.)
+- Add support for injection cancellation, maybe with golang.org/x/net/context 
+- Find other benchmarks to compare with.
+- Add Even Lazier TM injection using struct func fields.
+- Add Windows build with AppVeyor 
+- Never add tags! Never!
+
+===
+Copyright (c) 2016 Sam Salisbury; [License MIT](./LICENSE)

--- a/vendor/github.com/samsalisbury/psyringe/circle.yml
+++ b/vendor/github.com/samsalisbury/psyringe/circle.yml
@@ -1,0 +1,5 @@
+test:
+  override:
+    - go test -v -race -cover -covermode atomic -outputdir "$CIRCLE_ARTIFACTS" -coverprofile coverage.txt  
+  post:
+    - bash <(curl -s https://codecov.io/bash)

--- a/vendor/github.com/samsalisbury/psyringe/ctor.go
+++ b/vendor/github.com/samsalisbury/psyringe/ctor.go
@@ -1,0 +1,113 @@
+package psyringe
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+// ctor is a constructor for a single value.
+type ctor struct {
+	outType,
+	funcType reflect.Type
+	inTypes   []reflect.Type
+	construct func(in []reflect.Value) (reflect.Value, error)
+	errChan   chan error
+	once      *sync.Once
+	value     *reflect.Value
+}
+
+// terror is the type "error"
+var terror = reflect.TypeOf((*error)(nil)).Elem()
+
+func newCtor(t reflect.Type, v reflect.Value) *ctor {
+	if t.Kind() != reflect.Func || t.IsVariadic() {
+		return nil
+	}
+	numOut := t.NumOut()
+	if numOut == 0 || numOut > 2 || (numOut == 2 && t.Out(1) != terror) {
+		return nil
+	}
+	outType := t.Out(0)
+	numIn := t.NumIn()
+	inTypes := make([]reflect.Type, numIn)
+	for i := range inTypes {
+		inTypes[i] = t.In(i)
+	}
+	construct := func(in []reflect.Value) (reflect.Value, error) {
+		for i, arg := range in {
+			if !arg.IsValid() {
+				return reflect.Value{},
+					fmt.Errorf("unable to create arg %d (%s) of %s constructor",
+						i, inTypes[i], outType)
+			}
+		}
+		out := v.Call(in)
+		var err error
+		if len(out) == 2 && !out[1].IsNil() {
+			err = out[1].Interface().(error)
+		}
+		return out[0], err
+	}
+	return &ctor{
+		funcType:  t,
+		outType:   outType,
+		inTypes:   inTypes,
+		construct: construct,
+		errChan:   make(chan error),
+		once:      &sync.Once{},
+	}
+}
+
+func (c ctor) clone() *ctor {
+	c.once = &sync.Once{}
+	c.errChan = make(chan error)
+	return &c
+}
+
+func (c *ctor) testParametersAreRegisteredIn(s *Psyringe) error {
+	for paramIndex, paramType := range c.inTypes {
+		if err := s.testValueOrConstructorIsRegistered(paramType); err != nil {
+			return errors.Wrapf(err, "unable to satisfy param %d", paramIndex)
+		}
+	}
+	return nil
+}
+
+func (c *ctor) getValue(p *Psyringe) (reflect.Value, error) {
+	go c.once.Do(func() { c.manifest(p) })
+	if err := <-c.errChan; err != nil {
+		return reflect.Value{},
+			errors.Wrapf(err, "invoking %s constructor (%s) failed",
+				c.outType, c.funcType)
+	}
+	return *c.value, nil
+}
+
+// manifest is called exactly once for each constructor to generate its value.
+func (c *ctor) manifest(s *Psyringe) {
+	defer close(c.errChan)
+	wg := sync.WaitGroup{}
+	numArgs := len(c.inTypes)
+	wg.Add(numArgs)
+	args := make([]reflect.Value, numArgs)
+	for i, t := range c.inTypes {
+		s, c, i, t := s, c, i, t
+		go func() {
+			defer wg.Done()
+			v, err := s.getValueForConstructor(c, i, t)
+			if err != nil {
+				c.errChan <- err
+			}
+			args[i] = v
+		}()
+	}
+	wg.Wait()
+	v, err := c.construct(args)
+	if err != nil {
+		c.errChan <- err
+	}
+	c.value = &v
+}

--- a/vendor/github.com/samsalisbury/semv/range.go
+++ b/vendor/github.com/samsalisbury/semv/range.go
@@ -171,8 +171,9 @@ func (r Range) String() string {
 	return out
 }
 
-// Equals returns true if the version passed in has exactly the same
-// allowable version range as the version Equals was invoked on.
+// Equals returns true if the range passed in is semantically equivalent to the
+// range it is invoked on. (That is, if the same set of versions satisfies each
+// range.)
 func (r Range) Equals(other Range) bool {
 	return r.Min.ValueEquals(other.Min) &&
 		r.Max.ValueEquals(other.Max) &&

--- a/vendor/github.com/samsalisbury/semv/semv.go
+++ b/vendor/github.com/samsalisbury/semv/semv.go
@@ -1,0 +1,16 @@
+/*
+The semv package provides user-friendly, idiomatic Go semantic version parsing
+and range checking. It is based on the semantic versioning v2.0.0 specification
+at http://semver.org/spec/v2.0.0.html
+
+This library is designed to be conducive to common use-cases of semantic
+versioning, and follows the semver v2.0.0 spec closely, whilst being permissive
+to additional real-world usages of semver-like versions, for example partial
+versions like 1 or 5.3. Whilst not complete semver versions, these are commonly
+seen in the wild, and I think a good library should allow us to work with these
+kinds of versions as well.
+
+If you really care that only exact semver v2.0.0 versions are used, you can use
+ParseExactSemver2 which will error if the string does not follow the spec.
+*/
+package semv

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -182,9 +182,10 @@
 			"revision": "792786c7400a136282c1664665ae0a8db921c6c2"
 		},
 		{
-			"checksumSHA1": "vNLZL9W2JAyUxeU1kRfSHw2gQ2s=",
+			"checksumSHA1": "gkzEM1oht7y2Z0NBtRjvucWCWg8=",
 			"path": "github.com/samsalisbury/psyringe",
-			"revision": "ac33701d5b34cfa8726dfdea0ba91d981be098a9"
+			"revision": "2be630abc79d2541e3c890cc4b9eb7cdaf1e2352",
+			"revisionTime": "2016-08-05T08:38:32Z"
 		},
 		{
 			"checksumSHA1": "IRgb8yeKkWGY5gp1TLk9rpGitB0=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -177,6 +177,12 @@
 			"revisionTime": "2016-07-18T22:12:07Z"
 		},
 		{
+			"checksumSHA1": "2HSjyUZ4IMkCeA34TjJ0/f+Kk/k=",
+			"path": "github.com/pkg/errors",
+			"revision": "1d2e60385a13aaa66134984235061c2f9302520e",
+			"revisionTime": "2016-07-24T02:43:27Z"
+		},
+		{
 			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
 			"path": "github.com/pmezard/go-difflib/difflib",
 			"revision": "792786c7400a136282c1664665ae0a8db921c6c2"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -187,9 +187,10 @@
 			"revision": "ac33701d5b34cfa8726dfdea0ba91d981be098a9"
 		},
 		{
-			"checksumSHA1": "t/73GjySCNTBfBAI0eKYiCvzMUA=",
+			"checksumSHA1": "IRgb8yeKkWGY5gp1TLk9rpGitB0=",
 			"path": "github.com/samsalisbury/semv",
-			"revision": "dcfea12f0df0494785e2fdf4eb5426d4a1fbd92e"
+			"revision": "89e7c49965c4aaf21d4c4b27f4c69e2ddaaa9c86",
+			"revisionTime": "2016-08-03T15:34:45Z"
 		},
 		{
 			"checksumSHA1": "fV2uEKIgQJGaej5Yj0OnuOkmiM4=",


### PR DESCRIPTION
This update allows flags to take part in dependency injection.

In order to support this feature, any dependency that can be configured with flags is now injected indirectly via a function. The direct function dependency itself depends on the flags, which are thus registered for that cli invocation. Post-injection, consuming commands must call the injected function to obtain their dependency.

This has the consequence of making the commands themselves somewhat more verbose, which is we may be able to address later if it becomes an issue.