### PR TITLE
Bugfix: too paranoid

### DIFF
--- a/ext/docker/names.go
+++ b/ext/docker/names.go
@@ -1,11 +1,11 @@
 package docker
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/opentable/sous/lib"
+	"github.com/pkg/errors"
 	"github.com/samsalisbury/semv"
 )
 
@@ -34,7 +34,7 @@ func SourceIDFromLabels(labels map[string]string) (sous.SourceID, error) {
 	}
 
 	if len(missingLabels) > 0 {
-		err := fmt.Errorf("Missing labels on manifest for %v", missingLabels)
+		err := errors.Errorf("Missing labels: %v", missingLabels)
 		return sous.SourceID{}, err
 	}
 

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -9,6 +9,7 @@ import (
 	"github.com/opentable/sous/ext/docker"
 	"github.com/opentable/sous/lib"
 	"github.com/opentable/swaggering"
+	"github.com/pkg/errors"
 	"github.com/satori/go.uuid"
 )
 
@@ -156,7 +157,7 @@ func (ra *RectiAgent) ImageLabels(in string) (map[string]string, error) {
 	a := docker.NewBuildArtifact(in)
 	sv, err := ra.nameCache.GetSourceID(a)
 	if err != nil {
-		return map[string]string{}, err
+		return map[string]string{}, errors.Wrapf(err, "Image name: %s", in)
 	}
 
 	return docker.Labels(sv), nil

--- a/lib/logging.go
+++ b/lib/logging.go
@@ -31,14 +31,17 @@ type (
 
 var (
 	// Log collects various loggers to use for different levels of logging
-	Log = LogSet{
-		// Debug is a logger - use log.SetOutput to get output from
-		Vomit:  log.New(ioutil.Discard, "vomit: ", log.Lshortfile),
-		Debug:  log.New(ioutil.Discard, "debug: ", log.Lshortfile),
-		Info:   log.New(ioutil.Discard, "info: ", 0),
-		Notice: log.New(ioutil.Discard, "notice: ", 0),
-		Warn:   log.New(os.Stderr, "warn: ", 0),
-	}
+	Log = func() LogSet {
+		warnLogger := log.New(os.Stderr, "warn: ", 0)
+		return LogSet{
+			// Debug is a logger - use log.SetOutput to get output from
+			Vomit:  log.New(ioutil.Discard, "vomit: ", log.Lshortfile),
+			Debug:  log.New(ioutil.Discard, "debug: ", log.Lshortfile),
+			Info:   warnLogger, // XXX deprecate Info
+			Notice: warnLogger, // XXX deprecate Notice
+			Warn:   warnLogger,
+		}
+	}()
 )
 
 // SetupLogging sets up an ILogger to log into the Sous logging regime


### PR DESCRIPTION
This is the actual address to Wil Wade's issue
In starting to use pkg/errors, we broke a test of an error type
The root fix is to use errors.Cause() to get the error back out.

There's also some tuning to the ADS code to improve its error reporting