### PR TITLE
Fixes sous, sous build, sous rectify

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -61,9 +61,15 @@ func NewSousCLI(v semv.Version, out, errout io.Writer) (*cmdr.CLI, error) {
 		HelpCommand: os.Args[0] + " help",
 	}
 
-	g := BuildGraph(cli, out, errout)
-
+	var g *SousCLIGraph
 	var chain []cmdr.Command
+
+	cli.Hooks.Startup = func(*cmdr.CLI) error {
+		g = BuildGraph(cli, out, errout)
+		chain = make([]cmdr.Command, 0)
+		return nil
+	}
+
 	cli.Hooks.Parsed = func(cmd cmdr.Command) error {
 		chain = append(chain, cmd)
 		return nil

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -79,6 +79,6 @@ func TestInvokeBuildWithRepoSelector(t *testing.T) {
 
 	assert.NotNil(build.Labeller)
 	assert.NotNil(build.Registrar)
-	assert.Equal(build.DeploymentConfig.Repo, `github.com/opentable/sous`)
+	assert.Equal(build.DeployFilterFlags.Repo, `github.com/opentable/sous`)
 
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -2,12 +2,37 @@ package cli
 
 import (
 	"bytes"
+	"log"
 	"testing"
 
+	"github.com/opentable/sous/util/cmdr"
 	"github.com/samsalisbury/semv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestInvokeBareSous(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	c, err := NewSousCLI(semv.MustParse(`1.2.3`), stdout, stderr)
+	assert.NoError(err)
+
+	exe, err := c.Prepare([]string{`sous`})
+	assert.NoError(err)
+	assert.Len(exe.Args, 0)
+
+	var r cmdr.Result
+	require.NotPanics(func() {
+		r = c.InvokeWithoutPrinting([]string{"sous", "help"})
+	})
+	log.Printf("%T %v", r, r)
+	assert.IsType(cmdr.SuccessResult{}, r)
+
+}
 
 func TestInvokeRectifyWithDebugFlags(t *testing.T) {
 	assert := assert.New(t)
@@ -34,4 +59,26 @@ func TestInvokeRectifyWithDebugFlags(t *testing.T) {
 	assert.Equal(rect.SourceFlags.All, true)
 	assert.Regexp(`Verbose debugging`, stderr.String())
 	assert.Regexp(`Regular debugging`, stderr.String())
+}
+
+func TestInvokeBuildWithRepoSelector(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	c, err := NewSousCLI(semv.MustParse(`1.2.3`), stdout, stderr)
+	assert.NoError(err)
+
+	exe, err := c.Prepare([]string{`sous`, `build`, `-repo`, `github.com/opentable/sous`})
+	require.NoError(err)
+	assert.Len(exe.Args, 0)
+
+	build := exe.Cmd.(*SousBuild)
+
+	assert.NotNil(build.Labeller)
+	assert.NotNil(build.Registrar)
+	assert.Equal(build.DeploymentConfig.Repo, `github.com/opentable/sous`)
+
 }

--- a/cli/graph.go
+++ b/cli/graph.go
@@ -171,10 +171,10 @@ func newSourceContext(g GitSourceContext, f *DeployFilterFlags) (*sous.SourceCon
 	if err != nil {
 		return nil, errors.Wrap(err, "resolving source location")
 	}
-	if sl != c.SourceLocation() {
+	if sl.RepoURL != c.SourceLocation().RepoURL {
 		// TODO: Clone the repository, and use the cloned dir as source context.
 		return nil, errors.Errorf("source location %q is not the same as the remote %q",
-			sl, c.SourceLocation())
+			sl.RepoURL, c.SourceLocation().RepoURL)
 	}
 	return c, nil
 }

--- a/cli/graph.go
+++ b/cli/graph.go
@@ -97,6 +97,8 @@ func BuildGraph(c *cmdr.CLI, out, err io.Writer) *SousCLIGraph {
 		newGitSourceContext,
 		newSourceContext,
 		newBuildContext,
+		newBuildConfig,
+		newBuildManager,
 		newDockerClient,
 		newDockerBuilder,
 		newSelector,
@@ -138,7 +140,6 @@ func newLogSet(s *Sous, err ErrWriter) *sous.LogSet { // XXX temporary until we 
 
 	sous.Log.Vomit.Println("Verbose debugging enabled")
 	sous.Log.Debug.Println("Regular debugging enabled")
-	sous.Log.Info.Println("Informational messages enabled")
 	return &sous.Log
 }
 
@@ -181,6 +182,30 @@ func newSourceContext(g GitSourceContext, f *DeployFilterFlags) (*sous.SourceCon
 
 func newBuildContext(wd LocalWorkDirShell, c *sous.SourceContext) *sous.BuildContext {
 	return &sous.BuildContext{Sh: wd.Sh, Source: *c}
+}
+
+func newBuildConfig(f *DeployFilterFlags, p *PolicyFlags, bc *sous.BuildContext) *sous.BuildConfig {
+	cfg := sous.BuildConfig{
+		Repo:       f.Repo,
+		Offset:     f.Offset,
+		Tag:        f.Tag,
+		Revision:   f.Revision,
+		Strict:     p.Strict,
+		ForceClone: p.ForceClone,
+		Context:    bc,
+	}
+
+	return &cfg
+}
+
+func newBuildManager(bc *sous.BuildConfig, sl sous.Selector, lb sous.Labeller, rg sous.Registrar) *sous.BuildManager {
+	mgr := &sous.BuildManager{
+		BuildConfig: bc,
+		Selector:    sl,
+		Labeller:    lb,
+		Registrar:   rg,
+	}
+	return mgr
 }
 
 func newLocalUser() (v LocalUser, err error) {

--- a/cli/graph_test.go
+++ b/cli/graph_test.go
@@ -12,6 +12,7 @@ func TestBuildGraph(t *testing.T) {
 	g := BuildGraph(&cmdr.CLI{}, ioutil.Discard, ioutil.Discard)
 	g.Add(&Sous{})
 	g.Add(&DeployFilterFlags{})
+	g.Add(&PolicyFlags{}) //provided by Build
 
 	if err := g.Test(); err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/cli/sous_build.go
+++ b/cli/sous_build.go
@@ -44,7 +44,7 @@ func (*SousBuild) Help() string { return sousBuildHelp }
 // RegisterOn adds the DeploymentConfig to the psyringe to configure the
 // labeller and registrar
 func (sb *SousBuild) RegisterOn(psy Addable) {
-	psy.Add(sb.DeploymentConfig)
+	psy.Add(&sb.DeploymentConfig)
 }
 
 // Execute fulfills the cmdr.Executor interface

--- a/util/cmdr/cli.go
+++ b/util/cmdr/cli.go
@@ -37,6 +37,8 @@ type (
 	// Hooks is a collection of command hooks. If a hook returns a non-nil error
 	// it cancels execution and the error is displayed to the user.
 	Hooks struct {
+		// Startup is run at the beginning of every invocation
+		Startup func(*CLI) error
 		// Parsed is run on a command when it's found on the command line
 		Parsed func(Command) error
 		// PreExecute is run on a command before it executes.
@@ -120,6 +122,9 @@ func (c *CLI) InvokeAndExit(args []string) {
 // which subcommand a flag is applicable to.
 func (c *CLI) Prepare(args []string) (*PreparedExecution, error) {
 	base, ff := c.Root, c.GlobalFlagSetFuncs
+	if c.Hooks.Startup != nil {
+		c.Hooks.Startup(c)
+	}
 	return c.prepare(base, args, ff)
 }
 


### PR DESCRIPTION
I did notice but don't have time to fix: sous context is broken ATM.

Gist of the fixes:

`sous` was broken by the second invoke: when we invoked the second time on the same CLI,
the Sous command object got added again, which is how it got double-registered.

The address there was to add a new "Startup" hook, which actually creates a new
graph (and chain) for each invocation. I waffled on this for a bit, but the
ultimate argument I came to was that a sequence of invocations within a single
execution should work as much as possible as if the user had run them each from
the command line. I'd be open to re-examining this, but one key observation is
that we invoke commands in order to change the global state, so caching that at
the start of a command sequence is likely to have confusing results.

`sous build` was broken because the build context wasn't set up properly. The
neat solution I found was to migrate the contruction of the BuildManager into
the DI, which further reduced the tricky-to-test Execute method.

Also note that both of the above were added to `cli/cli_test.go` so that their
setup could be tested. `sous context` _et al_ should likewise get entries in
`cli_test.go` so that we can confirm that they at least parse and inject
properly.