### PR TITLE
Fix firsterr test race

### DIFF
--- a/cli/graph.go
+++ b/cli/graph.go
@@ -299,9 +299,8 @@ func newDockerClient() LocalDockerClient {
 	return LocalDockerClient{docker_registry.NewClient()}
 }
 
-func newLocalDiskStateManager(c LocalSousConfig) (*storage.DiskStateManager, error) {
-	sm, err := storage.NewDiskStateManager(c.StateLocation)
-	return sm, initErr(err, "initialising sous state")
+func newLocalDiskStateManager(c LocalSousConfig) *storage.DiskStateManager {
+	return storage.NewDiskStateManager(c.StateLocation)
 }
 
 func newLocalStateReader(sm *storage.DiskStateManager) LocalStateReader {

--- a/ext/storage/disk_state_manager.go
+++ b/ext/storage/disk_state_manager.go
@@ -48,7 +48,7 @@ func NewDiskStateManager(baseDir string) *DiskStateManager {
 
 // ReadState loads the entire intended state of the world from a dir.
 func (dsm *DiskStateManager) ReadState() (*sous.State, error) {
-	s := &sous.State{}
+	s := sous.NewState()
 	return s, dsm.Codec.Read(dsm.baseDir, s)
 }
 

--- a/ext/storage/disk_state_manager.go
+++ b/ext/storage/disk_state_manager.go
@@ -37,13 +37,13 @@ type (
 
 // NewDiskStateManager returns a new DiskStateManager configured to read and
 // write from a filesystem tree containing YAML files.
-func NewDiskStateManager(baseDir string) (*DiskStateManager, error) {
+func NewDiskStateManager(baseDir string) *DiskStateManager {
 	c := hy.NewCodec(func(c *hy.Codec) {
 		c.FileExtension = "yaml"
 		c.MarshalFunc = yaml.Marshal
 		c.UnmarshalFunc = yaml.Unmarshal
 	})
-	return &DiskStateManager{Codec: c, baseDir: baseDir}, nil
+	return &DiskStateManager{Codec: c, baseDir: baseDir}
 }
 
 // ReadState loads the entire intended state of the world from a dir.

--- a/ext/storage/disk_state_manager_test.go
+++ b/ext/storage/disk_state_manager_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/yaml"
+	"github.com/pkg/errors"
 	"github.com/samsalisbury/semv"
 )
 
@@ -18,10 +19,7 @@ func TestWriteState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dsm, err := NewDiskStateManager("testdata/out")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dsm := NewDiskStateManager("testdata/out")
 
 	if err := dsm.WriteState(s); err != nil {
 		t.Fatal(err)
@@ -38,10 +36,7 @@ func TestWriteState(t *testing.T) {
 
 func TestReadState(t *testing.T) {
 
-	dsm, err := NewDiskStateManager("testdata/in")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dsm := NewDiskStateManager("testdata/in")
 
 	actual, err := dsm.ReadState()
 	if err != nil {
@@ -66,6 +61,21 @@ func TestReadState(t *testing.T) {
 		t.Log("Got >>>>>>>>>>>>>>>>>>>>>>")
 		t.Logf("\n% +v", string(actualYAML))
 		t.Fatal("")
+	}
+}
+
+func TestReadState_empty(t *testing.T) {
+	dsm := NewDiskStateManager("testdata/nonexistent")
+	actual, err := dsm.ReadState()
+	if err != nil && !os.IsNotExist(errors.Cause(err)) {
+		t.Fatal(err)
+	}
+	d, err := actual.Deployments()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Len() != 0 {
+		t.Errorf("got len %d; want %d", d.Len(), 0)
 	}
 }
 

--- a/util/blueprints/cmap/cmap.go
+++ b/util/blueprints/cmap/cmap.go
@@ -5,21 +5,6 @@ import (
 	"sync"
 )
 
-// masterCMapInitMutex is global state allows us to use &CMap{} rather than
-// having to call a constructor.
-var masterCMapInitMutex = &sync.Mutex{}
-
-func initCMap(m *CMap) {
-	masterCMapInitMutex.Lock()
-	defer masterCMapInitMutex.Unlock()
-	if m.m == nil {
-		m.m = map[CMKey]Value{}
-	}
-	if m.mu == nil {
-		m.mu = &sync.RWMutex{}
-	}
-}
-
 // CMap is a wrapper around map[CMKey]Value
 // which is safe for concurrent read and write.
 type CMap struct {
@@ -34,11 +19,29 @@ type CMKey string
 type Value string
 
 // MakeCMap creates a new CMap with capacity set.
-func MakeCMap(capacity int) *CMap {
-	return &CMap{
+func MakeCMap(capacity int) CMap {
+	return CMap{
 		mu: &sync.RWMutex{},
 		m:  make(map[CMKey]Value, capacity),
 	}
+}
+
+func (m CMap) write(f func()) {
+	if m.m == nil || m.mu == nil {
+		panic("uninitialised CMap (you should use NewCMap)")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	f()
+}
+
+func (m CMap) read(f func()) {
+	if m.m == nil || m.mu == nil {
+		panic("uninitialised CMap (you should use NewCMap)")
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	f()
 }
 
 // NewCMapFromMap creates a new CMap.
@@ -46,8 +49,8 @@ func MakeCMap(capacity int) *CMap {
 // map[CMKey]Values,
 // which will be merged key-wise into the new CMap,
 // with keys from the right-most map taking precedence.
-func NewCMapFromMap(from ...map[CMKey]Value) *CMap {
-	cm := &CMap{
+func NewCMapFromMap(from ...map[CMKey]Value) CMap {
+	cm := CMap{
 		mu: &sync.RWMutex{},
 		m:  map[CMKey]Value{},
 	}
@@ -62,8 +65,8 @@ func NewCMapFromMap(from ...map[CMKey]Value) *CMap {
 // NewCMap creates a new CMap.
 // You may optionally pass any number of Values,
 // which will be added to this map.
-func NewCMap(from ...Value) *CMap {
-	m := &CMap{
+func NewCMap(from ...Value) CMap {
+	m := CMap{
 		mu: &sync.RWMutex{},
 		m:  map[CMKey]Value{},
 	}
@@ -77,38 +80,35 @@ func NewCMap(from ...Value) *CMap {
 
 // Get returns (value, true) if k is in the map, or (zero value, false)
 // otherwise.
-func (m *CMap) Get(key CMKey) (Value, bool) {
-	initCMap(m)
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	v, ok := m.m[key]
-	return v, ok
+func (m CMap) Get(key CMKey) (v Value, ok bool) {
+	m.read(func() {
+		v, ok = m.m[key]
+	})
+	return
 }
 
 // Set sets the value of index k to v.
-func (m *CMap) Set(key CMKey, value Value) {
-	initCMap(m)
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.m[key] = value
+func (m CMap) Set(key CMKey, value Value) {
+	m.write(func() {
+		m.m[key] = value
+	})
 }
 
 // Filter returns a new CMap containing only the entries
 // where the predicate returns true for the given value.
 // A nil predicate is equivalent to calling Clone.
-func (m *CMap) Filter(predicate func(Value) bool) *CMap {
+func (m CMap) Filter(predicate func(Value) bool) CMap {
 	if predicate == nil {
 		return m.Clone()
 	}
 	out := map[CMKey]Value{}
-	initCMap(m)
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	for k, v := range m.m {
-		if predicate(v) {
-			out[k] = v
+	m.read(func() {
+		for k, v := range m.m {
+			if predicate(v) {
+				out[k] = v
+			}
 		}
-	}
+	})
 	return NewCMapFromMap(out)
 }
 
@@ -116,7 +116,7 @@ func (m *CMap) Filter(predicate func(Value) bool) *CMap {
 // (the single Value satisfying predicate, true),
 // if there is exactly one Value satisfying predicate in
 // CMap. Otherwise, returns (zero Value, false).
-func (m *CMap) Single(predicate func(Value) bool) (Value, bool) {
+func (m CMap) Single(predicate func(Value) bool) (Value, bool) {
 	f := m.FilteredSnapshot(predicate)
 	if len(f) == 1 {
 		for _, v := range f {
@@ -131,7 +131,7 @@ func (m *CMap) Single(predicate func(Value) bool) (Value, bool) {
 // (a single Value matching predicate, true),
 // if there are any Values matching predicate in
 // CMap. Otherwise returns (zero Value, false).
-func (m *CMap) Any(predicate func(Value) bool) (Value, bool) {
+func (m CMap) Any(predicate func(Value) bool) (Value, bool) {
 	f := m.Filter(predicate)
 	for _, v := range f.Snapshot() {
 		return v, true
@@ -141,7 +141,7 @@ func (m *CMap) Any(predicate func(Value) bool) (Value, bool) {
 }
 
 // Clone returns a pairwise copy of CMap.
-func (m *CMap) Clone() *CMap {
+func (m CMap) Clone() CMap {
 	return NewCMapFromMap(m.Snapshot())
 }
 
@@ -150,26 +150,26 @@ func (m *CMap) Clone() *CMap {
 // If any keys in other match keys in this *CMap,
 // keys from other will appear in the returned
 // *CMap.
-func (m *CMap) Merge(other *CMap) *CMap {
+func (m CMap) Merge(other CMap) CMap {
 	return NewCMapFromMap(m.Snapshot(), other.Snapshot())
 }
 
 // Add adds a (k, v) pair into a map if it is not already there. Returns true if
 // the value was added, false if not.
-func (m *CMap) Add(v Value) bool {
-	initCMap(m)
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	k := v.ID()
-	if _, exists := m.m[k]; exists {
-		return false
-	}
-	m.m[k] = v
-	return true
+func (m CMap) Add(v Value) (ok bool) {
+	m.write(func() {
+		k := v.ID()
+		if _, exists := m.m[k]; exists {
+			return
+		}
+		m.m[k] = v
+		ok = true
+	})
+	return
 }
 
 // MustAdd is a wrapper around Add which panics whenever Add returns false.
-func (m *CMap) MustAdd(v Value) {
+func (m CMap) MustAdd(v Value) {
 	if !m.Add(v) {
 		panic(fmt.Sprintf("item with ID %v already in the graph", v.ID()))
 	}
@@ -179,93 +179,92 @@ func (m *CMap) MustAdd(v Value) {
 // CMap have different keys and all are added to this CMap.
 // If any of the keys conflict, nothing will be added to this
 // CMap and AddAll will return the conflicting CMKey and false.
-func (m *CMap) AddAll(from *CMap) (conflicting CMKey, success bool) {
+func (m CMap) AddAll(from CMap) (conflicting CMKey, success bool) {
 	ss := from.Snapshot()
-	initCMap(m)
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	for k := range ss {
-		if _, exists := m.m[k]; exists {
-			m.mu.RUnlock()
-			return k, false
+	var exists bool
+	m.write(func() {
+		for k := range ss {
+			if _, exists = m.m[k]; exists {
+				conflicting = k
+				return
+			}
 		}
-	}
-	for k, v := range ss {
-		m.m[k] = v
-	}
-	return conflicting, true
+		for k, v := range ss {
+			m.m[k] = v
+		}
+	})
+	return conflicting, !exists
 }
 
 // Remove value for a key k if present, a no-op otherwise.
-func (m *CMap) Remove(key CMKey) {
-	initCMap(m)
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	delete(m.m, key)
+func (m CMap) Remove(key CMKey) {
+	m.write(func() {
+		delete(m.m, key)
+	})
 }
 
 // Len returns number of elements in a map.
-func (m *CMap) Len() int {
-	initCMap(m)
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return len(m.m)
+func (m CMap) Len() int {
+	var l int
+	m.read(func() {
+		l = len(m.m)
+	})
+	return l
 }
 
 // Keys returns a slice containing all the keys in the map.
-func (m *CMap) Keys() []CMKey {
-	initCMap(m)
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	keys := make([]CMKey, len(m.m))
-	i := 0
-	for k := range m.m {
-		keys[i] = k
-		i++
-	}
+func (m CMap) Keys() []CMKey {
+	var keys []CMKey
+	m.read(func() {
+		keys = make([]CMKey, len(m.m))
+		i := 0
+		for k := range m.m {
+			keys[i] = k
+			i++
+		}
+	})
 	return keys
 }
 
 // Snapshot returns a moment-in-time copy of the current underlying
 // map[CMKey]Value.
-func (m *CMap) Snapshot() map[CMKey]Value {
-	initCMap(m)
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	clone := make(map[CMKey]Value, len(m.m))
-	for k, v := range m.m {
-		clone[k] = v
-	}
-	return clone
+func (m CMap) Snapshot() map[CMKey]Value {
+	var ss map[CMKey]Value
+	m.read(func() {
+		ss = make(map[CMKey]Value, len(m.m))
+		for k, v := range m.m {
+			ss[k] = v
+		}
+	})
+	return ss
 }
 
 // FilteredSnapshot returns a moment-in-time filtered copy of the current
 // underlying map[CMKey]Value.
 // (CMKey, Value) pairs are included
 // if they satisfy predicate.
-func (m *CMap) FilteredSnapshot(predicate func(Value) bool) map[CMKey]Value {
-	initCMap(m)
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+func (m CMap) FilteredSnapshot(predicate func(Value) bool) map[CMKey]Value {
 	clone := map[CMKey]Value{}
-	for k, v := range m.m {
-		if predicate(v) {
-			clone[k] = v
+	m.read(func() {
+		for k, v := range m.m {
+			if predicate(v) {
+				clone[k] = v
+			}
 		}
-	}
+	})
 	return clone
 }
 
 // GetAll returns SnapShot (it allows hy to marshal CMap).
-func (m *CMap) GetAll() map[CMKey]Value {
+func (m CMap) GetAll() map[CMKey]Value {
 	return m.Snapshot()
 }
 
 // SetAll sets the internal map (it allows hy to unmarshal CMap).
+// Note: SetAll is the only method that is not safe for concurrent access.
 func (m *CMap) SetAll(v map[CMKey]Value) {
-	initCMap(m)
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.m = nil
+	if m.mu == nil {
+		m.mu = &sync.RWMutex{}
+	}
 	m.m = v
 }

--- a/util/blueprints/cmap/cmap_test.go
+++ b/util/blueprints/cmap/cmap_test.go
@@ -3,23 +3,23 @@ package cmap
 import "testing"
 
 type CMapTest struct {
-	CMap     *CMap
+	CMap     CMap
 	Do       func(c *CMap)
 	Expected map[CMKey]Value
 }
 
 var cmapTests = []CMapTest{
 	{
-		CMap:     &CMap{},
+		CMap:     NewCMap(),
 		Expected: map[CMKey]Value{},
 	},
 	{
 		CMap:     MakeCMap(999),
-		Expected: (&CMap{}).Snapshot(),
+		Expected: NewCMap().Snapshot(),
 	},
 	{
 		CMap:     NewCMap(),
-		Expected: (&CMap{}).Snapshot(),
+		Expected: NewCMap().Snapshot(),
 	},
 	{
 		CMap:     NewCMap("one"),
@@ -36,21 +36,21 @@ var cmapTests = []CMapTest{
 	{
 		CMap: NewCMapFromMap(map[CMKey]Value{"one": "one"}),
 		Do: func(c *CMap) {
-			*c = *c.Filter(func(v Value) bool { return v.ID() == "one" })
+			*c = c.Filter(func(v Value) bool { return v.ID() == "one" })
 		},
 		Expected: map[CMKey]Value{"one": "one"},
 	},
 	{
 		CMap: NewCMapFromMap(map[CMKey]Value{"one": "one"}),
 		Do: func(c *CMap) {
-			*c = *c.Filter(nil)
+			*c = c.Filter(nil)
 		},
 		Expected: map[CMKey]Value{"one": "one"},
 	},
 	{
 		CMap: NewCMapFromMap(map[CMKey]Value{"one": "one"}),
 		Do: func(c *CMap) {
-			*c = *c.Filter(func(v Value) bool { return v.ID() == "two" })
+			*c = c.Filter(func(v Value) bool { return v.ID() == "two" })
 		},
 		Expected: map[CMKey]Value{},
 	},
@@ -99,14 +99,14 @@ var cmapTests = []CMapTest{
 	{
 		CMap: NewCMapFromMap(map[CMKey]Value{"one": "one"}),
 		Do: func(c *CMap) {
-			*c = *NewCMapFromMap(c.FilteredSnapshot(func(v Value) bool {
+			*c = NewCMapFromMap(c.FilteredSnapshot(func(v Value) bool {
 				return v == "two"
 			}))
 		},
 		Expected: map[CMKey]Value{},
 	},
 	{
-		CMap: &CMap{},
+		CMap: NewCMap(),
 		Do: func(c *CMap) {
 			c.SetAll(map[CMKey]Value{"set": "set", "all": "all"})
 		},
@@ -115,14 +115,14 @@ var cmapTests = []CMapTest{
 	{
 		CMap: NewCMapFromMap(map[CMKey]Value{"set": "set", "all": "all"}),
 		Do: func(c *CMap) {
-			*c = *NewCMapFromMap(c.GetAll())
+			*c = NewCMapFromMap(c.GetAll())
 		},
 		Expected: map[CMKey]Value{"set": "set", "all": "all"},
 	},
 	{
 		CMap: NewCMapFromMap(map[CMKey]Value{"set": "set", "all": "all"}),
 		Do: func(c *CMap) {
-			*c = *c.Clone()
+			*c = c.Clone()
 		},
 		Expected: map[CMKey]Value{"set": "set", "all": "all"},
 	},
@@ -133,7 +133,7 @@ var cmapTests = []CMapTest{
 			if !ok {
 				panic("missing key two")
 			}
-			*c = *NewCMap(v)
+			*c = NewCMap(v)
 		},
 		Expected: map[CMKey]Value{"two": "two"},
 	},
@@ -153,7 +153,7 @@ var cmapTests = []CMapTest{
 			if !ok {
 				panic("no single value two")
 			}
-			*c = *NewCMap(v)
+			*c = NewCMap(v)
 		},
 		Expected: map[CMKey]Value{"two": "two"},
 	},
@@ -166,7 +166,7 @@ var cmapTests = []CMapTest{
 			if ok {
 				panic("found nonexistent value")
 			}
-			*c = *NewCMap(v)
+			*c = NewCMap(v)
 		},
 		Expected: map[CMKey]Value{"": ""},
 	},
@@ -179,7 +179,7 @@ var cmapTests = []CMapTest{
 			if !ok {
 				panic("no value two")
 			}
-			*c = *NewCMap(v)
+			*c = NewCMap(v)
 		},
 		Expected: map[CMKey]Value{"two": "two"},
 	},
@@ -192,7 +192,7 @@ var cmapTests = []CMapTest{
 			if ok {
 				panic("found value; should not have")
 			}
-			*c = *NewCMap(v)
+			*c = NewCMap(v)
 		},
 		Expected: map[CMKey]Value{"": ""},
 	},
@@ -200,7 +200,7 @@ var cmapTests = []CMapTest{
 		CMap: NewCMapFromMap(map[CMKey]Value{"one": "one"}),
 		Do: func(c *CMap) {
 			other := NewCMapFromMap(map[CMKey]Value{"two": "two"})
-			*c = *c.Merge(other)
+			*c = c.Merge(other)
 		},
 		Expected: map[CMKey]Value{"one": "one", "two": "two"},
 	},
@@ -212,7 +212,7 @@ var cmapTests = []CMapTest{
 				vals = append(vals, Value(string(k)))
 			}
 			other := NewCMap(vals...)
-			*c = *c.Merge(other)
+			*c = c.Merge(other)
 		},
 		Expected: map[CMKey]Value{"one": "one"},
 	},
@@ -222,7 +222,7 @@ func TestCMap(t *testing.T) {
 
 	for _, test := range cmapTests {
 		if test.Do != nil {
-			test.Do(test.CMap)
+			test.Do(&test.CMap)
 		}
 		actual := test.CMap.Snapshot()
 		expected := test.Expected

--- a/util/firsterr/firsterr.go
+++ b/util/firsterr/firsterr.go
@@ -160,11 +160,11 @@ func (P) Set(fs ...func(*error)) error {
 	for _, f := range fs {
 		f := f
 		go func() {
+			defer wg.Done()
 			var err error
 			if f(&err); err != nil {
 				errs <- err
 			}
-			wg.Done()
 		}()
 	}
 	return <-errs

--- a/util/firsterr/firsterr_test.go
+++ b/util/firsterr/firsterr_test.go
@@ -1,6 +1,9 @@
 package firsterr
 
-import "testing"
+import (
+	"sync/atomic"
+	"testing"
+)
 
 type Error string
 
@@ -131,8 +134,8 @@ func TestParallel_Set_Err(t *testing.T) {
 	}
 
 	// Check functions are actually run...
-	callCount := 0
-	spy := func(*error) { callCount++ }
+	callCount := int64(0)
+	spy := func(*error) { atomic.AddInt64(&callCount, 1) }
 	p.Set(spy, spy, spy, spy, spy)
 	if callCount != 5 {
 		t.Fatalf("spy called %d times; want 5", callCount)

--- a/vendor/github.com/opentable/hy/codec.go
+++ b/vendor/github.com/opentable/hy/codec.go
@@ -107,7 +107,7 @@ func (c *Codec) Read(prefix string, root interface{}) error {
 		return errors.Wrapf(err, "reading tree at %q", prefix)
 	}
 	rc := NewReadContext(prefix, targets, c.reader)
-	rootVal := rootNode.NewVal()
+	rootVal := rootNode.NewValFrom(reflect.ValueOf(root))
 	if err := rootNode.Read(rc, rootVal); err != nil {
 		return errors.Wrapf(err, "reading root")
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -140,10 +140,10 @@
 			"revisionTime": "2016-08-09T08:42:26Z"
 		},
 		{
-			"checksumSHA1": "HqlQXXJY/RYOZgVf13JJIdYTcFk=",
+			"checksumSHA1": "z3U11i7w1A1tq1++lLAPwRxFRLc=",
 			"path": "github.com/opentable/hy",
-			"revision": "0f460f33acd44344f93831b974089f63db5bb801",
-			"revisionTime": "2016-08-16T23:47:25Z"
+			"revision": "d5ab537fd7fd925b822aabf6dad30fa68532bd15",
+			"revisionTime": "2016-08-18T09:23:33Z"
 		},
 		{
 			"checksumSHA1": "5GnAp0RETgoWf+Asq2DCw3ceE+w=",


### PR DESCRIPTION
Includes #111 

first err test had a daft data race where a counter was being updated from multiple goroutines at once without any synchronisation. Addressed with atomic.AddInt64.