### PR TITLE
Renames

### DIFF
--- a/cli/flags_source.go
+++ b/cli/flags_source.go
@@ -23,13 +23,13 @@ func (f *DeployFilterFlags) buildPredicate() sous.DeploymentPredicate {
 
 	if f.Repo != "" {
 		preds = append(preds, func(d *sous.Deployment) bool {
-			return d.SourceID.RepoURL == f.Repo
+			return d.SourceID.Repo == f.Repo
 		})
 	}
 
 	if f.Offset != "" {
 		preds = append(preds, func(d *sous.Deployment) bool {
-			return d.SourceID.RepoOffset == f.Offset
+			return d.SourceID.Offset == f.Offset
 		})
 	}
 

--- a/cli/flags_source.go
+++ b/cli/flags_source.go
@@ -29,7 +29,7 @@ func (f *DeployFilterFlags) buildPredicate() sous.DeploymentPredicate {
 
 	if f.Offset != "" {
 		preds = append(preds, func(d *sous.Deployment) bool {
-			return d.SourceID.Offset == f.Offset
+			return d.SourceID.Dir == f.Offset
 		})
 	}
 

--- a/cli/graph.go
+++ b/cli/graph.go
@@ -299,9 +299,8 @@ func newDockerClient() LocalDockerClient {
 	return LocalDockerClient{docker_registry.NewClient()}
 }
 
-func newLocalDiskStateManager(c LocalSousConfig) (*storage.DiskStateManager, error) {
-	sm, err := storage.NewDiskStateManager(c.StateLocation)
-	return sm, initErr(err, "initialising sous state")
+func newLocalDiskStateManager(c LocalSousConfig) *storage.DiskStateManager {
+	return storage.NewDiskStateManager(c.StateLocation)
 }
 
 func newLocalStateReader(sm *storage.DiskStateManager) LocalStateReader {

--- a/cli/graph.go
+++ b/cli/graph.go
@@ -178,10 +178,10 @@ func newSourceContext(g GitSourceContext, f *DeployFilterFlags) (*sous.SourceCon
 	if err != nil {
 		return nil, errors.Wrap(err, "resolving source location")
 	}
-	if sl.RepoURL != c.SourceLocation().RepoURL {
+	if sl.Repo != c.SourceLocation().Repo {
 		// TODO: Clone the repository, and use the cloned dir as source context.
 		return nil, errors.Errorf("source location %q is not the same as the remote %q",
-			sl.RepoURL, c.SourceLocation().RepoURL)
+			sl.Repo, c.SourceLocation().Repo)
 	}
 	return c, nil
 }

--- a/cli/graph_sourcecontext.go
+++ b/cli/graph_sourcecontext.go
@@ -30,7 +30,7 @@ func resolveSourceLocation(f *DeployFilterFlags, c *sous.SourceContext) (sous.So
 		return sous.SourceLocation{}, errors.Errorf("no repo specified, please use -repo or run sous inside a git repo")
 	}
 	return sous.SourceLocation{
-		RepoURL:    repo,
-		RepoOffset: offset,
+		Repo:   repo,
+		Offset: offset,
 	}, nil
 }

--- a/cli/graph_sourcecontext.go
+++ b/cli/graph_sourcecontext.go
@@ -30,7 +30,7 @@ func resolveSourceLocation(f *DeployFilterFlags, c *sous.SourceContext) (sous.So
 		return sous.SourceLocation{}, errors.Errorf("no repo specified, please use -repo or run sous inside a git repo")
 	}
 	return sous.SourceLocation{
-		Repo:   repo,
-		Offset: offset,
+		Repo: repo,
+		Dir:  offset,
 	}, nil
 }

--- a/cli/graph_sourcecontext_test.go
+++ b/cli/graph_sourcecontext_test.go
@@ -39,18 +39,18 @@ func TestResolveSourceLocation_failure(t *testing.T) {
 }
 
 var goodResolveSourceLocationCalls = map[sous.SourceLocation][]resolveSourceLocationInput{
-	{Repo: "github.com/user/project", Offset: ""}: {
+	{Repo: "github.com/user/project", Dir: ""}: {
 		{Flags: &DeployFilterFlags{Repo: "github.com/user/project"}},
 		{Context: &sous.SourceContext{PrimaryRemoteURL: "github.com/user/project"}},
 	},
-	{Repo: "github.com/user/project", Offset: "some/path"}: {
+	{Repo: "github.com/user/project", Dir: "some/path"}: {
 		{Flags: &DeployFilterFlags{Repo: "github.com/user/project", Offset: "some/path"}},
 		{Context: &sous.SourceContext{
 			PrimaryRemoteURL: "github.com/user/project",
 			OffsetDir:        "some/path",
 		}},
 	},
-	{Repo: "github.com/from/flags", Offset: ""}: {
+	{Repo: "github.com/from/flags", Dir: ""}: {
 		{
 			Context: &sous.SourceContext{
 				PrimaryRemoteURL: "github.com/original/context",
@@ -74,8 +74,8 @@ func TestResolveSourceLocation_success(t *testing.T) {
 			if actual.Repo != expected.Repo {
 				t.Errorf("got repo %q; want %q", actual.Repo, expected.Repo)
 			}
-			if actual.Offset != expected.Offset {
-				t.Errorf("got offset %q; want %q", actual.Offset, expected.Offset)
+			if actual.Dir != expected.Dir {
+				t.Errorf("got offset %q; want %q", actual.Dir, expected.Dir)
 			}
 		}
 	}

--- a/cli/graph_sourcecontext_test.go
+++ b/cli/graph_sourcecontext_test.go
@@ -39,18 +39,18 @@ func TestResolveSourceLocation_failure(t *testing.T) {
 }
 
 var goodResolveSourceLocationCalls = map[sous.SourceLocation][]resolveSourceLocationInput{
-	{RepoURL: "github.com/user/project", RepoOffset: ""}: {
+	{Repo: "github.com/user/project", Offset: ""}: {
 		{Flags: &DeployFilterFlags{Repo: "github.com/user/project"}},
 		{Context: &sous.SourceContext{PrimaryRemoteURL: "github.com/user/project"}},
 	},
-	{RepoURL: "github.com/user/project", RepoOffset: "some/path"}: {
+	{Repo: "github.com/user/project", Offset: "some/path"}: {
 		{Flags: &DeployFilterFlags{Repo: "github.com/user/project", Offset: "some/path"}},
 		{Context: &sous.SourceContext{
 			PrimaryRemoteURL: "github.com/user/project",
 			OffsetDir:        "some/path",
 		}},
 	},
-	{RepoURL: "github.com/from/flags", RepoOffset: ""}: {
+	{Repo: "github.com/from/flags", Offset: ""}: {
 		{
 			Context: &sous.SourceContext{
 				PrimaryRemoteURL: "github.com/original/context",
@@ -71,11 +71,11 @@ func TestResolveSourceLocation_success(t *testing.T) {
 				t.Error(err)
 				continue
 			}
-			if actual.RepoURL != expected.RepoURL {
-				t.Errorf("got repo %q; want %q", actual.RepoURL, expected.RepoURL)
+			if actual.Repo != expected.Repo {
+				t.Errorf("got repo %q; want %q", actual.Repo, expected.Repo)
 			}
-			if actual.RepoOffset != expected.RepoOffset {
-				t.Errorf("got offset %q; want %q", actual.RepoOffset, expected.RepoOffset)
+			if actual.Offset != expected.Offset {
+				t.Errorf("got offset %q; want %q", actual.Offset, expected.Offset)
 			}
 		}
 	}

--- a/cli/rectify_test.go
+++ b/cli/rectify_test.go
@@ -21,8 +21,8 @@ func TestPredicateBuilder(t *testing.T) {
 				ds = append(ds, &sous.Deployment{
 					ClusterNickname: c,
 					SourceID: sous.SourceID{
-						Repo:   r,
-						Offset: o,
+						Repo: r,
+						Dir:  o,
 					},
 				})
 			}

--- a/cli/rectify_test.go
+++ b/cli/rectify_test.go
@@ -21,8 +21,8 @@ func TestPredicateBuilder(t *testing.T) {
 				ds = append(ds, &sous.Deployment{
 					ClusterNickname: c,
 					SourceID: sous.SourceID{
-						RepoURL:    r,
-						RepoOffset: o,
+						Repo:   r,
+						Offset: o,
 					},
 				})
 			}

--- a/ext/docker/builder_test.go
+++ b/ext/docker/builder_test.go
@@ -44,7 +44,7 @@ func TestTagStrings(t *testing.T) {
 
 	sid := sous.SourceID{
 		Repo:    "github.com/opentable/sous",
-		Offset:  "docker",
+		Dir:     "docker",
 		Version: semv.MustParse("1.2.3+deadbeef"),
 	}
 

--- a/ext/docker/builder_test.go
+++ b/ext/docker/builder_test.go
@@ -43,9 +43,9 @@ func TestTagStrings(t *testing.T) {
 	assert := assert.New(t)
 
 	sid := sous.SourceID{
-		RepoURL:    "github.com/opentable/sous",
-		RepoOffset: "docker",
-		Version:    semv.MustParse("1.2.3+deadbeef"),
+		Repo:    "github.com/opentable/sous",
+		Offset:  "docker",
+		Version: semv.MustParse("1.2.3+deadbeef"),
 	}
 
 	assert.Equal("/sous/docker:1.2.3", versionName(sid))

--- a/ext/docker/image_mapping.go
+++ b/ext/docker/image_mapping.go
@@ -329,7 +329,7 @@ func (nc *NameCache) dbInsert(sid sous.SourceID, in, etag string) error {
 
 	res, err := nc.DB.Exec("insert into docker_search_location "+
 		"(repo, offset) values ($1, $2);",
-		string(sid.Repo), string(sid.Offset))
+		string(sid.Repo), string(sid.Dir))
 
 	if err != nil {
 		return err
@@ -417,7 +417,7 @@ func (nc *NameCache) dbQueryOnSL(sl sous.SourceLocation) (rs []string, err error
 		"where "+
 		"docker_search_location.repo = $1 and "+
 		"docker_search_location.offset = $2",
-		string(sl.Repo), string(sl.Offset))
+		string(sl.Repo), string(sl.Dir))
 
 	if err == sql.ErrNoRows {
 		return []string{}, err
@@ -450,7 +450,7 @@ func (nc *NameCache) dbQueryAllSourceIds() (ids []sous.SourceID, err error) {
 	for rows.Next() {
 		var r, o, v string
 		rows.Scan(&r, &o, &v)
-		ids = append(ids, sous.SourceID{Repo: r, Offset: o, Version: semv.MustParse(v)})
+		ids = append(ids, sous.SourceID{Repo: r, Dir: o, Version: semv.MustParse(v)})
 	}
 	err = rows.Err()
 	return
@@ -467,7 +467,7 @@ func (nc *NameCache) dbQueryOnSourceID(sid sous.SourceID) (cn string, ins []stri
 		"docker_search_location.repo = $1 and "+
 		"docker_search_location.offset = $2 and "+
 		"docker_search_metadata.version = $3",
-		string(sid.Repo), string(sid.Offset), sid.Version.String())
+		string(sid.Repo), string(sid.Dir), sid.Version.String())
 
 	if err == sql.ErrNoRows {
 		err = NoImageNameFound{sid}
@@ -496,6 +496,6 @@ func makeSourceID(repo, offset, version string) (sous.SourceID, error) {
 		return sous.SourceID{}, err
 	}
 	return sous.SourceID{
-		Repo: repo, Version: v, Offset: offset,
+		Repo: repo, Version: v, Dir: offset,
 	}, nil
 }

--- a/ext/docker/image_mapping.go
+++ b/ext/docker/image_mapping.go
@@ -329,7 +329,7 @@ func (nc *NameCache) dbInsert(sid sous.SourceID, in, etag string) error {
 
 	res, err := nc.DB.Exec("insert into docker_search_location "+
 		"(repo, offset) values ($1, $2);",
-		string(sid.RepoURL), string(sid.RepoOffset))
+		string(sid.Repo), string(sid.Offset))
 
 	if err != nil {
 		return err
@@ -417,7 +417,7 @@ func (nc *NameCache) dbQueryOnSL(sl sous.SourceLocation) (rs []string, err error
 		"where "+
 		"docker_search_location.repo = $1 and "+
 		"docker_search_location.offset = $2",
-		string(sl.RepoURL), string(sl.RepoOffset))
+		string(sl.Repo), string(sl.Offset))
 
 	if err == sql.ErrNoRows {
 		return []string{}, err
@@ -450,7 +450,7 @@ func (nc *NameCache) dbQueryAllSourceIds() (ids []sous.SourceID, err error) {
 	for rows.Next() {
 		var r, o, v string
 		rows.Scan(&r, &o, &v)
-		ids = append(ids, sous.SourceID{RepoURL: r, RepoOffset: o, Version: semv.MustParse(v)})
+		ids = append(ids, sous.SourceID{Repo: r, Offset: o, Version: semv.MustParse(v)})
 	}
 	err = rows.Err()
 	return
@@ -467,7 +467,7 @@ func (nc *NameCache) dbQueryOnSourceID(sid sous.SourceID) (cn string, ins []stri
 		"docker_search_location.repo = $1 and "+
 		"docker_search_location.offset = $2 and "+
 		"docker_search_metadata.version = $3",
-		string(sid.RepoURL), string(sid.RepoOffset), sid.Version.String())
+		string(sid.Repo), string(sid.Offset), sid.Version.String())
 
 	if err == sql.ErrNoRows {
 		err = NoImageNameFound{sid}
@@ -496,6 +496,6 @@ func makeSourceID(repo, offset, version string) (sous.SourceID, error) {
 		return sous.SourceID{}, err
 	}
 	return sous.SourceID{
-		RepoURL: repo, Version: v, RepoOffset: offset,
+		Repo: repo, Version: v, Offset: offset,
 	}, nil
 }

--- a/ext/docker/image_mapping_test.go
+++ b/ext/docker/image_mapping_test.go
@@ -36,7 +36,7 @@ func TestRoundTrip(t *testing.T) {
 	sv := sous.SourceID{
 		Version: v,
 		Repo:    "https://github.com/opentable/wackadoo",
-		Offset:  "nested/there",
+		Dir:     "nested/there",
 	}
 	host := "docker.repo.io"
 	base := "ot/wackadoo"
@@ -58,7 +58,7 @@ func TestRoundTrip(t *testing.T) {
 	newSV := sous.SourceID{
 		Version: newV,
 		Repo:    "https://github.com/opentable/wackadoo",
-		Offset:  "nested/there",
+		Dir:     "nested/there",
 	}
 
 	cn = base + "@" + digest
@@ -90,14 +90,14 @@ func TestHarvesting(t *testing.T) {
 	sv := sous.SourceID{
 		Version: v,
 		Repo:    "https://github.com/opentable/wackadoo",
-		Offset:  "nested/there",
+		Dir:     "nested/there",
 	}
 
 	v2 := semv.MustParse("2.3.4")
 	sisterSV := sous.SourceID{
 		Version: v2,
 		Repo:    "https://github.com/opentable/wackadoo",
-		Offset:  "nested/there",
+		Dir:     "nested/there",
 	}
 
 	host := "docker.repo.io"
@@ -147,7 +147,7 @@ func TestMissingName(t *testing.T) {
 	sv := sous.SourceID{
 		Version: v,
 		Repo:    "https://github.com/opentable/brand-new-idea",
-		Offset:  "nested/there",
+		Dir:     "nested/there",
 	}
 
 	name, err := nc.getImageName(sv)

--- a/ext/docker/image_mapping_test.go
+++ b/ext/docker/image_mapping_test.go
@@ -34,9 +34,9 @@ func TestRoundTrip(t *testing.T) {
 
 	v := semv.MustParse("1.2.3")
 	sv := sous.SourceID{
-		Version:    v,
-		RepoURL:    "https://github.com/opentable/wackadoo",
-		RepoOffset: "nested/there",
+		Version: v,
+		Repo:    "https://github.com/opentable/wackadoo",
+		Offset:  "nested/there",
 	}
 	host := "docker.repo.io"
 	base := "ot/wackadoo"
@@ -56,9 +56,9 @@ func TestRoundTrip(t *testing.T) {
 
 	newV := semv.MustParse("1.2.42")
 	newSV := sous.SourceID{
-		Version:    newV,
-		RepoURL:    "https://github.com/opentable/wackadoo",
-		RepoOffset: "nested/there",
+		Version: newV,
+		Repo:    "https://github.com/opentable/wackadoo",
+		Offset:  "nested/there",
 	}
 
 	cn = base + "@" + digest
@@ -88,16 +88,16 @@ func TestHarvesting(t *testing.T) {
 
 	v := semv.MustParse("1.2.3")
 	sv := sous.SourceID{
-		Version:    v,
-		RepoURL:    "https://github.com/opentable/wackadoo",
-		RepoOffset: "nested/there",
+		Version: v,
+		Repo:    "https://github.com/opentable/wackadoo",
+		Offset:  "nested/there",
 	}
 
 	v2 := semv.MustParse("2.3.4")
 	sisterSV := sous.SourceID{
-		Version:    v2,
-		RepoURL:    "https://github.com/opentable/wackadoo",
-		RepoOffset: "nested/there",
+		Version: v2,
+		Repo:    "https://github.com/opentable/wackadoo",
+		Offset:  "nested/there",
 	}
 
 	host := "docker.repo.io"
@@ -145,9 +145,9 @@ func TestMissingName(t *testing.T) {
 
 	v := semv.MustParse("4.5.6")
 	sv := sous.SourceID{
-		Version:    v,
-		RepoURL:    "https://github.com/opentable/brand-new-idea",
-		RepoOffset: "nested/there",
+		Version: v,
+		Repo:    "https://github.com/opentable/brand-new-idea",
+		Offset:  "nested/there",
 	}
 
 	name, err := nc.getImageName(sv)

--- a/ext/docker/names.go
+++ b/ext/docker/names.go
@@ -44,7 +44,7 @@ func SourceIDFromLabels(labels map[string]string) (sous.SourceID, error) {
 	return sous.SourceID{
 		Repo:    repo,
 		Version: version,
-		Offset:  path,
+		Dir:     path,
 	}, err
 }
 
@@ -56,7 +56,7 @@ func Labels(sid sous.SourceID) map[string]string {
 	labels := make(map[string]string)
 	labels[DockerVersionLabel] = sid.Version.Format(`M.m.p-?`)
 	labels[DockerRevisionLabel] = sid.RevID()
-	labels[DockerPathLabel] = string(sid.Offset)
+	labels[DockerPathLabel] = string(sid.Dir)
 	labels[DockerRepoLabel] = string(sid.Repo)
 	return labels
 }
@@ -65,8 +65,8 @@ func imageNameBase(sid sous.SourceID) string {
 	name := string(sid.Repo)
 
 	name = stripRE.ReplaceAllString(name, "")
-	if string(sid.Offset) != "" {
-		name = strings.Join([]string{name, string(sid.Offset)}, "/")
+	if string(sid.Dir) != "" {
+		name = strings.Join([]string{name, string(sid.Dir)}, "/")
 	}
 	return name
 }

--- a/ext/docker/names.go
+++ b/ext/docker/names.go
@@ -42,9 +42,9 @@ func SourceIDFromLabels(labels map[string]string) (sous.SourceID, error) {
 	version.Meta = revision
 
 	return sous.SourceID{
-		RepoURL:    repo,
-		Version:    version,
-		RepoOffset: path,
+		Repo:    repo,
+		Version: version,
+		Offset:  path,
 	}, err
 }
 
@@ -56,17 +56,17 @@ func Labels(sid sous.SourceID) map[string]string {
 	labels := make(map[string]string)
 	labels[DockerVersionLabel] = sid.Version.Format(`M.m.p-?`)
 	labels[DockerRevisionLabel] = sid.RevID()
-	labels[DockerPathLabel] = string(sid.RepoOffset)
-	labels[DockerRepoLabel] = string(sid.RepoURL)
+	labels[DockerPathLabel] = string(sid.Offset)
+	labels[DockerRepoLabel] = string(sid.Repo)
 	return labels
 }
 
 func imageNameBase(sid sous.SourceID) string {
-	name := string(sid.RepoURL)
+	name := string(sid.Repo)
 
 	name = stripRE.ReplaceAllString(name, "")
-	if string(sid.RepoOffset) != "" {
-		name = strings.Join([]string{name, string(sid.RepoOffset)}, "/")
+	if string(sid.Offset) != "" {
+		name = strings.Join([]string{name, string(sid.Offset)}, "/")
 	}
 	return name
 }

--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -36,7 +36,7 @@ func TestModifyScale(t *testing.T) {
 	pair := &sous.DeploymentPair{
 		Prior: &sous.Deployment{
 			SourceID: sous.SourceID{
-				RepoURL: "reqid",
+				Repo: "reqid",
 			},
 			DeployConfig: sous.DeployConfig{
 				NumInstances: 12,
@@ -45,7 +45,7 @@ func TestModifyScale(t *testing.T) {
 		},
 		Post: &sous.Deployment{
 			SourceID: sous.SourceID{
-				RepoURL: "reqid",
+				Repo: "reqid",
 			},
 			DeployConfig: sous.DeployConfig{
 				NumInstances: 24,
@@ -86,7 +86,7 @@ func TestModifyImage(t *testing.T) {
 	pair := &sous.DeploymentPair{
 		Prior: &sous.Deployment{
 			SourceID: sous.SourceID{
-				RepoURL: "reqid",
+				Repo:    "reqid",
 				Version: before,
 			},
 			DeployConfig: sous.DeployConfig{
@@ -96,7 +96,7 @@ func TestModifyImage(t *testing.T) {
 		},
 		Post: &sous.Deployment{
 			SourceID: sous.SourceID{
-				RepoURL: "reqid",
+				Repo:    "reqid",
 				Version: after,
 			},
 			DeployConfig: sous.DeployConfig{
@@ -136,7 +136,7 @@ func TestModifyResources(t *testing.T) {
 	pair := &sous.DeploymentPair{
 		Prior: &sous.Deployment{
 			SourceID: sous.SourceID{
-				RepoURL: "reqid",
+				Repo:    "reqid",
 				Version: version,
 			},
 			DeployConfig: sous.DeployConfig{
@@ -149,7 +149,7 @@ func TestModifyResources(t *testing.T) {
 		},
 		Post: &sous.Deployment{
 			SourceID: sous.SourceID{
-				RepoURL: "reqid",
+				Repo:    "reqid",
 				Version: version,
 			},
 			DeployConfig: sous.DeployConfig{
@@ -195,7 +195,7 @@ func TestModify(t *testing.T) {
 	pair := &sous.DeploymentPair{
 		Prior: &sous.Deployment{
 			SourceID: sous.SourceID{
-				RepoURL: "reqid",
+				Repo:    "reqid",
 				Version: before,
 			},
 			DeployConfig: sous.DeployConfig{
@@ -208,7 +208,7 @@ func TestModify(t *testing.T) {
 		},
 		Post: &sous.Deployment{
 			SourceID: sous.SourceID{
-				RepoURL: "reqid",
+				Repo:    "reqid",
 				Version: after,
 			},
 			DeployConfig: sous.DeployConfig{
@@ -255,7 +255,7 @@ func TestDeletes(t *testing.T) {
 
 	deleted := &sous.Deployment{
 		SourceID: sous.SourceID{
-			RepoURL: "reqid",
+			Repo: "reqid",
 		},
 		DeployConfig: sous.DeployConfig{
 			NumInstances: 12,
@@ -294,7 +294,7 @@ func TestCreates(t *testing.T) {
 
 	created := &sous.Deployment{
 		SourceID: sous.SourceID{
-			RepoURL: "reqid",
+			Repo: "reqid",
 		},
 		DeployConfig: sous.DeployConfig{
 			NumInstances: 12,

--- a/ext/storage/disk_state_manager.go
+++ b/ext/storage/disk_state_manager.go
@@ -48,7 +48,7 @@ func NewDiskStateManager(baseDir string) *DiskStateManager {
 
 // ReadState loads the entire intended state of the world from a dir.
 func (dsm *DiskStateManager) ReadState() (*sous.State, error) {
-	s := &sous.State{}
+	s := sous.NewState()
 	return s, dsm.Codec.Read(dsm.baseDir, s)
 }
 

--- a/ext/storage/disk_state_manager.go
+++ b/ext/storage/disk_state_manager.go
@@ -37,13 +37,13 @@ type (
 
 // NewDiskStateManager returns a new DiskStateManager configured to read and
 // write from a filesystem tree containing YAML files.
-func NewDiskStateManager(baseDir string) (*DiskStateManager, error) {
+func NewDiskStateManager(baseDir string) *DiskStateManager {
 	c := hy.NewCodec(func(c *hy.Codec) {
 		c.FileExtension = "yaml"
 		c.MarshalFunc = yaml.Marshal
 		c.UnmarshalFunc = yaml.Unmarshal
 	})
-	return &DiskStateManager{Codec: c, baseDir: baseDir}, nil
+	return &DiskStateManager{Codec: c, baseDir: baseDir}
 }
 
 // ReadState loads the entire intended state of the world from a dir.

--- a/ext/storage/disk_state_manager_test.go
+++ b/ext/storage/disk_state_manager_test.go
@@ -81,10 +81,10 @@ func TestReadState_empty(t *testing.T) {
 
 func exampleState() *sous.State {
 	sl := sous.SourceLocation{
-		RepoURL: "github.com/opentable/sous",
+		Repo: "github.com/opentable/sous",
 	}
 	sl2 := sous.SourceLocation{
-		RepoURL: "github.com/user/project",
+		Repo: "github.com/user/project",
 	}
 	return &sous.State{
 		Manifests: sous.NewManifests(

--- a/ext/storage/disk_state_manager_test.go
+++ b/ext/storage/disk_state_manager_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/yaml"
+	"github.com/pkg/errors"
 	"github.com/samsalisbury/semv"
 )
 
@@ -18,10 +19,7 @@ func TestWriteState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dsm, err := NewDiskStateManager("testdata/out")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dsm := NewDiskStateManager("testdata/out")
 
 	if err := dsm.WriteState(s); err != nil {
 		t.Fatal(err)
@@ -38,10 +36,7 @@ func TestWriteState(t *testing.T) {
 
 func TestReadState(t *testing.T) {
 
-	dsm, err := NewDiskStateManager("testdata/in")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dsm := NewDiskStateManager("testdata/in")
 
 	actual, err := dsm.ReadState()
 	if err != nil {
@@ -66,6 +61,21 @@ func TestReadState(t *testing.T) {
 		t.Log("Got >>>>>>>>>>>>>>>>>>>>>>")
 		t.Logf("\n% +v", string(actualYAML))
 		t.Fatal("")
+	}
+}
+
+func TestReadState_empty(t *testing.T) {
+	dsm := NewDiskStateManager("testdata/nonexistent")
+	actual, err := dsm.ReadState()
+	if err != nil && !os.IsNotExist(errors.Cause(err)) {
+		t.Fatal(err)
+	}
+	d, err := actual.Deployments()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Len() != 0 {
+		t.Errorf("got len %d; want %d", d.Len(), 0)
 	}
 }
 

--- a/integration/deployment_builder_test.go
+++ b/integration/deployment_builder_test.go
@@ -99,7 +99,7 @@ func TestBuildDeployments(t *testing.T) {
 			if assert.Len(dep.DeployConfig.Volumes, 1) {
 				assert.Equal(dep.DeployConfig.Volumes[0].Host, "/tmp")
 			}
-			assert.Equal("https://github.com/docker/dockercloud-hello-world.git", string(dep.SourceID.RepoURL))
+			assert.Equal("https://github.com/docker/dockercloud-hello-world.git", string(dep.SourceID.Repo))
 		}
 	}
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -263,7 +263,7 @@ func deploymentWithRepo(assert *assert.Assertions, sc sous.Deployer, repo string
 func findRepo(deps sous.Deployments, repo string) sous.DeployID {
 	for i, d := range deps.Snapshot() {
 		if d != nil {
-			if d.SourceID.RepoURL == repo {
+			if d.SourceID.Repo == repo {
 				return i
 			}
 		}
@@ -279,7 +279,7 @@ func manifest(nc sous.Registry, drepo, containerDir, sourceURL, version string) 
 
 	return &sous.Manifest{
 		Source: sous.SourceLocation{
-			RepoURL: sourceURL,
+			Repo: sourceURL,
 		},
 		Owners: []string{`xyz`},
 		Kind:   sous.ManifestKindService,

--- a/lib/assemble_test.go
+++ b/lib/assemble_test.go
@@ -12,7 +12,7 @@ func TestInheritingFromGlobal(t *testing.T) {
 
 	m := &Manifest{
 		Source: SourceLocation{
-			RepoURL: "github.com/opentable/sms-continual-test",
+			Repo: "github.com/opentable/sms-continual-test",
 		},
 		Owners: []string{
 			"Connect Services",

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -130,9 +130,9 @@ func (d *Deployment) Tabbed() string {
 			"%s\t"+ //"Resources\t" +
 			"%s", //"Env"
 		d.Cluster,
-		string(d.SourceID.RepoURL),
+		string(d.SourceID.Repo),
 		d.SourceID.Version.String(),
-		string(d.SourceID.RepoOffset),
+		string(d.SourceID.Offset),
 		d.NumInstances,
 		o,
 		strings.Join(rs, ", "),

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -132,7 +132,7 @@ func (d *Deployment) Tabbed() string {
 		d.Cluster,
 		string(d.SourceID.Repo),
 		d.SourceID.Version.String(),
-		string(d.SourceID.Offset),
+		string(d.SourceID.Dir),
 		d.NumInstances,
 		o,
 		strings.Join(rs, ", "),

--- a/lib/deployment_diff_test.go
+++ b/lib/deployment_diff_test.go
@@ -36,7 +36,7 @@ func makeDepl(repo string, num int) *Deployment {
 	owners.Add("judson")
 	return &Deployment{
 		SourceID: SourceID{
-			RepoURL: repo,
+			Repo:    repo,
 			Version: version,
 		},
 		DeployConfig: DeployConfig{
@@ -86,9 +86,9 @@ func TestRealDiff(t *testing.T) {
 	}
 
 	if assert.Len(ds.Changed, 1, "Should have one modified item.") {
-		assert.Equal(repoThree, string(ds.Changed[0].name.Source.RepoURL))
-		assert.Equal(repoThree, string(ds.Changed[0].Prior.SourceID.RepoURL))
-		assert.Equal(repoThree, string(ds.Changed[0].Post.SourceID.RepoURL))
+		assert.Equal(repoThree, string(ds.Changed[0].name.Source.Repo))
+		assert.Equal(repoThree, string(ds.Changed[0].Prior.SourceID.Repo))
+		assert.Equal(repoThree, string(ds.Changed[0].Post.SourceID.Repo))
 		assert.Equal(ds.Changed[0].Post.NumInstances, 1)
 		assert.Equal(ds.Changed[0].Prior.NumInstances, 2)
 	}

--- a/lib/deployment_test.go
+++ b/lib/deployment_test.go
@@ -28,7 +28,7 @@ func TestCanonName(t *testing.T) {
 	dep := Deployment{
 		SourceID: SourceID{
 			Repo:    "one",
-			Offset:  "two",
+			Dir:     "two",
 			Version: vers,
 		},
 	}

--- a/lib/deployment_test.go
+++ b/lib/deployment_test.go
@@ -27,9 +27,9 @@ func TestCanonName(t *testing.T) {
 	vers, _ := semv.Parse("1.2.3-test+thing")
 	dep := Deployment{
 		SourceID: SourceID{
-			RepoURL:    "one",
-			RepoOffset: "two",
-			Version:    vers,
+			Repo:    "one",
+			Offset:  "two",
+			Version: vers,
 		},
 	}
 	str := dep.SourceID.Location().String()

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -41,7 +41,7 @@ func (m *Manifest) ID() SourceLocation {
 
 // FileLocation returns the path that the manifest should be saved to.
 func (m *Manifest) FileLocation() string {
-	return filepath.Join(string(m.Source.Repo), string(m.Source.Offset))
+	return filepath.Join(string(m.Source.Repo), string(m.Source.Dir))
 }
 
 const (

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -41,7 +41,7 @@ func (m *Manifest) ID() SourceLocation {
 
 // FileLocation returns the path that the manifest should be saved to.
 func (m *Manifest) FileLocation() string {
-	return filepath.Join(string(m.Source.RepoURL), string(m.Source.RepoOffset))
+	return filepath.Join(string(m.Source.Repo), string(m.Source.Offset))
 }
 
 const (

--- a/lib/map_state_to_deployments_test.go
+++ b/lib/map_state_to_deployments_test.go
@@ -3,7 +3,7 @@ package sous
 import "testing"
 
 func makeTestState() *State {
-	project1 := SourceLocation{RepoURL: "github.com/user/project"}
+	project1 := SourceLocation{Repo: "github.com/user/project"}
 	return &State{
 		Defs: Defs{
 			DockerRepo: "some.docker.repo",

--- a/lib/registry_dumper.go
+++ b/lib/registry_dumper.go
@@ -69,5 +69,5 @@ func (rd *RegistryDumper) Entries() (de []DumperEntry, err error) {
 
 // Tabbed emits a tab-delimited string representing the entry
 func (de *DumperEntry) Tabbed() string {
-	return fmt.Sprintf("%s\t%s\t%s\t%s\t%s", de.Repo, de.Offset, de.Version.Format(semv.MajorMinorPatch), de.Name, de.Type)
+	return fmt.Sprintf("%s\t%s\t%s\t%s\t%s", de.Repo, de.Dir, de.Version.Format(semv.MajorMinorPatch), de.Name, de.Type)
 }

--- a/lib/registry_dumper.go
+++ b/lib/registry_dumper.go
@@ -69,5 +69,5 @@ func (rd *RegistryDumper) Entries() (de []DumperEntry, err error) {
 
 // Tabbed emits a tab-delimited string representing the entry
 func (de *DumperEntry) Tabbed() string {
-	return fmt.Sprintf("%s\t%s\t%s\t%s\t%s", de.RepoURL, de.RepoOffset, de.Version.Format(semv.MajorMinorPatch), de.Name, de.Type)
+	return fmt.Sprintf("%s\t%s\t%s\t%s\t%s", de.Repo, de.Offset, de.Version.Format(semv.MajorMinorPatch), de.Name, de.Type)
 }

--- a/lib/source_context.go
+++ b/lib/source_context.go
@@ -35,9 +35,9 @@ func (sc *SourceContext) Version() SourceID {
 	// Append revision ID.
 	v = semv.MustParse(v.Format("M.m.p-?") + "+" + sc.Revision)
 	sv := SourceID{
-		RepoURL:    sc.RemoteURL,
-		Version:    v,
-		RepoOffset: sc.OffsetDir,
+		Repo:    sc.RemoteURL,
+		Version: v,
+		Offset:  sc.OffsetDir,
 	}
 	Log.Debug.Printf("Version: % #v", sv)
 	return sv
@@ -46,8 +46,8 @@ func (sc *SourceContext) Version() SourceID {
 // SourceLocation returns the source location in this context.
 func (sc *SourceContext) SourceLocation() SourceLocation {
 	return SourceLocation{
-		RepoURL:    sc.PrimaryRemoteURL,
-		RepoOffset: sc.OffsetDir,
+		Repo:   sc.PrimaryRemoteURL,
+		Offset: sc.OffsetDir,
 	}
 }
 

--- a/lib/source_context.go
+++ b/lib/source_context.go
@@ -37,7 +37,7 @@ func (sc *SourceContext) Version() SourceID {
 	sv := SourceID{
 		Repo:    sc.RemoteURL,
 		Version: v,
-		Offset:  sc.OffsetDir,
+		Dir:     sc.OffsetDir,
 	}
 	Log.Debug.Printf("Version: % #v", sv)
 	return sv
@@ -46,8 +46,8 @@ func (sc *SourceContext) Version() SourceID {
 // SourceLocation returns the source location in this context.
 func (sc *SourceContext) SourceLocation() SourceLocation {
 	return SourceLocation{
-		Repo:   sc.PrimaryRemoteURL,
-		Offset: sc.OffsetDir,
+		Repo: sc.PrimaryRemoteURL,
+		Dir:  sc.OffsetDir,
 	}
 }
 

--- a/lib/source_context_test.go
+++ b/lib/source_context_test.go
@@ -15,7 +15,7 @@ func TestVersion(t *testing.T) {
 		NearestTagName: "1.2.3",
 	}
 	id := sc.Version()
-	assert.Equal("github.com/opentable/test", string(id.RepoURL))
-	assert.Equal("sub", string(id.RepoOffset))
+	assert.Equal("github.com/opentable/test", string(id.Repo))
+	assert.Equal("sub", string(id.Offset))
 	assert.Equal("1.2.3", id.Version.String())
 }

--- a/lib/source_context_test.go
+++ b/lib/source_context_test.go
@@ -16,6 +16,6 @@ func TestVersion(t *testing.T) {
 	}
 	id := sc.Version()
 	assert.Equal("github.com/opentable/test", string(id.Repo))
-	assert.Equal("sub", string(id.Offset))
+	assert.Equal("sub", string(id.Dir))
 	assert.Equal("1.2.3", id.Version.String())
 }

--- a/lib/source_id.go
+++ b/lib/source_id.go
@@ -122,29 +122,8 @@ func sourceIDFromChunks(source string, chunks []string) (SourceID, error) {
 	}, nil
 }
 
-func sourceLocationFromChunks(source string, chunks []string) (SourceLocation, error) {
-	if len(chunks) > 2 {
-		return SourceLocation{}, &IncludesVersion{source}
-	}
-	if len(chunks[0]) == 0 {
-		return SourceLocation{}, &MissingRepo{source}
-	}
-	repoURL := chunks[0]
-	repoOffset := ""
-	if len(chunks) > 1 {
-		repoOffset = chunks[1]
-	}
-	return SourceLocation{RepoURL: repoURL, RepoOffset: repoOffset}, nil
-}
-
 // ParseSourceID parses an entire SourceID.
 func ParseSourceID(s string) (SourceID, error) {
 	chunks := parseChunks(s)
 	return sourceIDFromChunks(s, chunks)
-}
-
-// ParseSourceLocation parses an entire SourceLocation.
-func ParseSourceLocation(s string) (SourceLocation, error) {
-	chunks := parseChunks(s)
-	return sourceLocationFromChunks(s, chunks)
 }

--- a/lib/source_id.go
+++ b/lib/source_id.go
@@ -12,9 +12,12 @@ type (
 	// SourceID identifies a specific snapshot of a body of source code,
 	// including its location and version.
 	SourceID struct {
-		Repo    string
+		// Repo: see SourceLocation.Repo.
+		Repo string
+		// Version identifies a specific version of the source code at Repo/Dir.
 		Version semv.Version
-		Offset  string `yaml:",omitempty"`
+		// Dir: See SourceLocation.Dir.
+		Dir string `yaml:",omitempty"`
 	}
 
 	//MissingRepo indicates that Sous couldn't determine which repo was intended for this SL
@@ -45,10 +48,10 @@ type (
 const DefaultDelim = ","
 
 func (sid SourceID) String() string {
-	if sid.Offset == "" {
+	if sid.Dir == "" {
 		return fmt.Sprintf("%s %s", sid.Repo, sid.Version)
 	}
-	return fmt.Sprintf("%s:%s %s", sid.Repo, sid.Offset, sid.Version)
+	return fmt.Sprintf("%s:%s %s", sid.Repo, sid.Dir, sid.Version)
 }
 
 // Tag returns the version tag for this source ID.
@@ -64,8 +67,8 @@ func (sid SourceID) RevID() string {
 // Location returns the location component of this SourceID.
 func (sid SourceID) Location() SourceLocation {
 	return SourceLocation{
-		Repo:   sid.Repo,
-		Offset: sid.Offset,
+		Repo: sid.Repo,
+		Dir:  sid.Dir,
 	}
 }
 
@@ -118,7 +121,7 @@ func sourceIDFromChunks(source string, chunks []string) (SourceID, error) {
 	return SourceID{
 		Version: version,
 		Repo:    repoURL,
-		Offset:  repoOffset,
+		Dir:     repoOffset,
 	}, nil
 }
 

--- a/lib/source_id.go
+++ b/lib/source_id.go
@@ -12,9 +12,9 @@ type (
 	// SourceID identifies a specific snapshot of a body of source code,
 	// including its location and version.
 	SourceID struct {
-		RepoURL    string
-		Version    semv.Version
-		RepoOffset string `yaml:",omitempty"`
+		Repo    string
+		Version semv.Version
+		Offset  string `yaml:",omitempty"`
 	}
 
 	//MissingRepo indicates that Sous couldn't determine which repo was intended for this SL
@@ -45,10 +45,10 @@ type (
 const DefaultDelim = ","
 
 func (sid SourceID) String() string {
-	if sid.RepoOffset == "" {
-		return fmt.Sprintf("%s %s", sid.RepoURL, sid.Version)
+	if sid.Offset == "" {
+		return fmt.Sprintf("%s %s", sid.Repo, sid.Version)
 	}
-	return fmt.Sprintf("%s:%s %s", sid.RepoURL, sid.RepoOffset, sid.Version)
+	return fmt.Sprintf("%s:%s %s", sid.Repo, sid.Offset, sid.Version)
 }
 
 // Tag returns the version tag for this source ID.
@@ -64,8 +64,8 @@ func (sid SourceID) RevID() string {
 // Location returns the location component of this SourceID.
 func (sid SourceID) Location() SourceLocation {
 	return SourceLocation{
-		RepoURL:    sid.RepoURL,
-		RepoOffset: sid.RepoOffset,
+		Repo:   sid.Repo,
+		Offset: sid.Offset,
 	}
 }
 
@@ -116,9 +116,9 @@ func sourceIDFromChunks(source string, chunks []string) (SourceID, error) {
 		repoOffset = chunks[2]
 	}
 	return SourceID{
-		Version:    version,
-		RepoURL:    repoURL,
-		RepoOffset: repoOffset,
+		Version: version,
+		Repo:    repoURL,
+		Offset:  repoOffset,
 	}, nil
 }
 

--- a/lib/source_id_test.go
+++ b/lib/source_id_test.go
@@ -8,36 +8,36 @@ import (
 
 var parseSourceIDTests = map[string]SourceID{
 	"github.com/opentable/sous,1,": {
-		RepoURL: "github.com/opentable/sous",
+		Repo:    "github.com/opentable/sous",
 		Version: semv.MustParse("1"),
 	},
 	":github.com/opentable/sous:1:": {
-		RepoURL: "github.com/opentable/sous",
+		Repo:    "github.com/opentable/sous",
 		Version: semv.MustParse("1"),
 	},
 	"github.com/opentable/sous,1": {
-		RepoURL: "github.com/opentable/sous",
+		Repo:    "github.com/opentable/sous",
 		Version: semv.MustParse("1"),
 	},
 	",github.com/opentable/sous,1,util": {
-		RepoURL:    "github.com/opentable/sous",
-		Version:    semv.MustParse("1"),
-		RepoOffset: "util",
+		Repo:    "github.com/opentable/sous",
+		Version: semv.MustParse("1"),
+		Offset:  "util",
 	},
 	"github.com/opentable/sous,1,util": {
-		RepoURL:    "github.com/opentable/sous",
-		Version:    semv.MustParse("1"),
-		RepoOffset: "util",
+		Repo:    "github.com/opentable/sous",
+		Version: semv.MustParse("1"),
+		Offset:  "util",
 	},
 	":github.com/opentable/sous:1:util": {
-		RepoURL:    "github.com/opentable/sous",
-		Version:    semv.MustParse("1"),
-		RepoOffset: "util",
+		Repo:    "github.com/opentable/sous",
+		Version: semv.MustParse("1"),
+		Offset:  "util",
 	},
 	"git+ssh://github.com/opentable/sous,1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3,sous": {
-		RepoURL:    "git+ssh://github.com/opentable/sous",
-		Version:    semv.MustParse("1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3"),
-		RepoOffset: "sous",
+		Repo:    "git+ssh://github.com/opentable/sous",
+		Version: semv.MustParse("1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3"),
+		Offset:  "sous",
 	},
 }
 

--- a/lib/source_id_test.go
+++ b/lib/source_id_test.go
@@ -22,22 +22,22 @@ var parseSourceIDTests = map[string]SourceID{
 	",github.com/opentable/sous,1,util": {
 		Repo:    "github.com/opentable/sous",
 		Version: semv.MustParse("1"),
-		Offset:  "util",
+		Dir:     "util",
 	},
 	"github.com/opentable/sous,1,util": {
 		Repo:    "github.com/opentable/sous",
 		Version: semv.MustParse("1"),
-		Offset:  "util",
+		Dir:     "util",
 	},
 	":github.com/opentable/sous:1:util": {
 		Repo:    "github.com/opentable/sous",
 		Version: semv.MustParse("1"),
-		Offset:  "util",
+		Dir:     "util",
 	},
 	"git+ssh://github.com/opentable/sous,1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3,sous": {
 		Repo:    "git+ssh://github.com/opentable/sous",
 		Version: semv.MustParse("1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3"),
-		Offset:  "sous",
+		Dir:     "sous",
 	},
 }
 

--- a/lib/source_id_test.go
+++ b/lib/source_id_test.go
@@ -4,27 +4,52 @@ import (
 	"testing"
 
 	"github.com/samsalisbury/semv"
-	"github.com/stretchr/testify/assert"
 )
 
+var parseSourceIDTests = map[string]SourceID{
+	"github.com/opentable/sous,1,": {
+		RepoURL: "github.com/opentable/sous",
+		Version: semv.MustParse("1"),
+	},
+	":github.com/opentable/sous:1:": {
+		RepoURL: "github.com/opentable/sous",
+		Version: semv.MustParse("1"),
+	},
+	"github.com/opentable/sous,1": {
+		RepoURL: "github.com/opentable/sous",
+		Version: semv.MustParse("1"),
+	},
+	",github.com/opentable/sous,1,util": {
+		RepoURL:    "github.com/opentable/sous",
+		Version:    semv.MustParse("1"),
+		RepoOffset: "util",
+	},
+	"github.com/opentable/sous,1,util": {
+		RepoURL:    "github.com/opentable/sous",
+		Version:    semv.MustParse("1"),
+		RepoOffset: "util",
+	},
+	":github.com/opentable/sous:1:util": {
+		RepoURL:    "github.com/opentable/sous",
+		Version:    semv.MustParse("1"),
+		RepoOffset: "util",
+	},
+	"git+ssh://github.com/opentable/sous,1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3,sous": {
+		RepoURL:    "git+ssh://github.com/opentable/sous",
+		Version:    semv.MustParse("1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3"),
+		RepoOffset: "sous",
+	},
+}
+
 func TestParseSourceID(t *testing.T) {
-	assert := assert.New(t)
-	mustParse := func(str string) SourceID {
-		sv, err := ParseSourceID(str)
+	for in, expected := range parseSourceIDTests {
+		actual, err := ParseSourceID(in)
 		if err != nil {
-			t.Errorf("unexpected error %q while parsing %q", err, str)
+			t.Error(err)
+			continue
 		}
-		return sv
+		if actual != expected {
+			t.Errorf("got %v; want %v", actual, expected)
+		}
 	}
-
-	assert.Equal(SourceID{"git+ssh://github.com/opentable/sous", semv.MustParse("1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3"), "sous"},
-		mustParse("git+ssh://github.com/opentable/sous,1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3,sous"))
-
-	assert.Equal(SourceID{"github.com/opentable/sous", semv.MustParse("1"), "util"}, mustParse(",github.com/opentable/sous,1,util"))
-	assert.Equal(SourceID{"github.com/opentable/sous", semv.MustParse("1"), "util"}, mustParse("github.com/opentable/sous,1,util"))
-	assert.Equal(SourceID{"github.com/opentable/sous", semv.MustParse("1"), "util"}, mustParse(":github.com/opentable/sous:1:util"))
-
-	assert.Equal(SourceID{"github.com/opentable/sous", semv.MustParse("1"), ""}, mustParse("github.com/opentable/sous,1,"))
-	assert.Equal(SourceID{"github.com/opentable/sous", semv.MustParse("1"), ""}, mustParse(":github.com/opentable/sous:1:"))
-	assert.Equal(SourceID{"github.com/opentable/sous", semv.MustParse("1"), ""}, mustParse("github.com/opentable/sous,1"))
 }

--- a/lib/source_location.go
+++ b/lib/source_location.go
@@ -28,6 +28,27 @@ func NewSourceLocation(repoURL, repoOffset string) SourceLocation {
 	return SourceLocation{repoURL, repoOffset}
 }
 
+// ParseSourceLocation parses an entire SourceLocation.
+func ParseSourceLocation(s string) (SourceLocation, error) {
+	chunks := parseChunks(s)
+	return sourceLocationFromChunks(s, chunks)
+}
+
+func sourceLocationFromChunks(source string, chunks []string) (SourceLocation, error) {
+	if len(chunks) > 2 {
+		return SourceLocation{}, &IncludesVersion{source}
+	}
+	if len(chunks[0]) == 0 {
+		return SourceLocation{}, &MissingRepo{source}
+	}
+	repoURL := chunks[0]
+	repoOffset := ""
+	if len(chunks) > 1 {
+		repoOffset = chunks[1]
+	}
+	return SourceLocation{RepoURL: repoURL, RepoOffset: repoOffset}, nil
+}
+
 // MarshalYAML serializes this SourceLocation to a YAML document.
 func (sl SourceLocation) MarshalYAML() (interface{}, error) {
 	return sl.String(), nil

--- a/lib/source_location.go
+++ b/lib/source_location.go
@@ -15,11 +15,10 @@ type (
 	// logical grouping of deploys of different versions of a particular
 	// service.
 	SourceLocation struct {
-		// RepoURL is the URL of a source code repository.
-		RepoURL string
-		// RepoOffset is a relative path to a directory within the repository
-		// at RepoURL
-		RepoOffset string `yaml:",omitempty"`
+		// Repo is the name of a source code repository.
+		Repo,
+		// Offset is a relative path within Repo.
+		Offset string `yaml:",omitempty"`
 	}
 )
 
@@ -56,7 +55,7 @@ func sourceLocationFromChunks(source string, chunks []string) (SourceLocation, e
 	if len(chunks) > 1 {
 		repoOffset = chunks[1]
 	}
-	return SourceLocation{RepoURL: repoURL, RepoOffset: repoOffset}, nil
+	return SourceLocation{Repo: repoURL, Offset: repoOffset}, nil
 }
 
 // MarshalYAML serializes this SourceLocation to a YAML document.
@@ -72,7 +71,7 @@ func (sl SourceLocation) MarshalText() ([]byte, error) {
 // UnmarshalText implements encoding.TextMarshaler.
 func (sl *SourceLocation) UnmarshalText(b []byte) error {
 	s := string(b)
-	n, err := fmt.Sscanf(s, "%s %s", &sl.RepoURL, &sl.RepoOffset)
+	n, err := fmt.Sscanf(s, "%s %s", &sl.Repo, &sl.Offset)
 	if err != nil && err != io.EOF {
 		return errors.Wrapf(err, "unable to unmarshal source location %q", s)
 	}
@@ -94,22 +93,17 @@ func (sl *SourceLocation) UnmarshalYAML(unmarshal func(interface{}) error) error
 }
 
 func (sl SourceLocation) String() string {
-	if sl.RepoOffset == "" {
-		return fmt.Sprintf("%s", sl.RepoURL)
+	if sl.Offset == "" {
+		return fmt.Sprintf("%s", sl.Repo)
 	}
-	return fmt.Sprintf("%s:%s", sl.RepoURL, sl.RepoOffset)
-}
-
-// Repo return the repository URL for this SourceLocation
-func (sl SourceLocation) Repo() string {
-	return sl.RepoURL
+	return fmt.Sprintf("%s:%s", sl.Repo, sl.Offset)
 }
 
 // SourceID returns a SourceID built from this location with the addition of a version.
 func (sl *SourceLocation) SourceID(version semv.Version) SourceID {
 	return SourceID{
-		RepoURL:    sl.RepoURL,
-		RepoOffset: sl.RepoOffset,
-		Version:    version,
+		Repo:    sl.Repo,
+		Offset:  sl.Offset,
+		Version: version,
 	}
 }

--- a/lib/source_location.go
+++ b/lib/source_location.go
@@ -34,6 +34,16 @@ func ParseSourceLocation(s string) (SourceLocation, error) {
 	return sourceLocationFromChunks(s, chunks)
 }
 
+// MustParseSourceLocation wraps ParseSourceLocation but panics instead of
+// returning a non-nil error.
+func MustParseSourceLocation(s string) SourceLocation {
+	sl, err := ParseSourceLocation(s)
+	if err != nil {
+		panic(err)
+	}
+	return sl
+}
+
 func sourceLocationFromChunks(source string, chunks []string) (SourceLocation, error) {
 	if len(chunks) > 2 {
 		return SourceLocation{}, &IncludesVersion{source}

--- a/lib/source_location.go
+++ b/lib/source_location.go
@@ -9,16 +9,17 @@ import (
 )
 
 type (
-	// SourceLocation identifies a directory inside a specific source code repo.
-	// Note that the directory has no meaning without the addition of a revision
+	// SourceLocation identifies a directory inside a source code repository.
+	// Note that the directory is ambiguous without the addition of a revision
 	// ID. This type is used as a shorthand for deploy manifests, enabling the
 	// logical grouping of deploys of different versions of a particular
 	// service.
 	SourceLocation struct {
-		// Repo is the name of a source code repository.
+		// Repo identifies a source code repository.
 		Repo,
-		// Offset is a relative path within Repo.
-		Offset string `yaml:",omitempty"`
+		// Dir is a directory within the repository at Repo containing the
+		// source code for one piece of software.
+		Dir string `yaml:",omitempty"`
 	}
 )
 
@@ -55,7 +56,7 @@ func sourceLocationFromChunks(source string, chunks []string) (SourceLocation, e
 	if len(chunks) > 1 {
 		repoOffset = chunks[1]
 	}
-	return SourceLocation{Repo: repoURL, Offset: repoOffset}, nil
+	return SourceLocation{Repo: repoURL, Dir: repoOffset}, nil
 }
 
 // MarshalYAML serializes this SourceLocation to a YAML document.
@@ -71,7 +72,7 @@ func (sl SourceLocation) MarshalText() ([]byte, error) {
 // UnmarshalText implements encoding.TextMarshaler.
 func (sl *SourceLocation) UnmarshalText(b []byte) error {
 	s := string(b)
-	n, err := fmt.Sscanf(s, "%s %s", &sl.Repo, &sl.Offset)
+	n, err := fmt.Sscanf(s, "%s %s", &sl.Repo, &sl.Dir)
 	if err != nil && err != io.EOF {
 		return errors.Wrapf(err, "unable to unmarshal source location %q", s)
 	}
@@ -93,17 +94,17 @@ func (sl *SourceLocation) UnmarshalYAML(unmarshal func(interface{}) error) error
 }
 
 func (sl SourceLocation) String() string {
-	if sl.Offset == "" {
+	if sl.Dir == "" {
 		return fmt.Sprintf("%s", sl.Repo)
 	}
-	return fmt.Sprintf("%s:%s", sl.Repo, sl.Offset)
+	return fmt.Sprintf("%s:%s", sl.Repo, sl.Dir)
 }
 
 // SourceID returns a SourceID built from this location with the addition of a version.
 func (sl *SourceLocation) SourceID(version semv.Version) SourceID {
 	return SourceID{
 		Repo:    sl.Repo,
-		Offset:  sl.Offset,
+		Dir:     sl.Dir,
 		Version: version,
 	}
 }

--- a/lib/source_location_test.go
+++ b/lib/source_location_test.go
@@ -3,6 +3,32 @@ package sous
 import "testing"
 
 var parseSourceLocationTests = map[string]SourceLocation{
+	"github.com/opentable/sous,": {
+		RepoURL: "github.com/opentable/sous",
+	},
+	":github.com/opentable/sous": {
+		RepoURL: "github.com/opentable/sous",
+	},
+	"github.com/opentable/sous,,": {
+		RepoURL: "github.com/opentable/sous",
+	},
+	",github.com/opentable/sous,util": {
+		RepoURL:    "github.com/opentable/sous",
+		RepoOffset: "util",
+	},
+	"github.com/opentable/sous,,util": {
+		RepoURL:    "github.com/opentable/sous",
+		RepoOffset: "util",
+	},
+	":github.com/opentable/sous:util": {
+		RepoURL:    "github.com/opentable/sous",
+		RepoOffset: "util",
+	},
+	"git+ssh://github.com/opentable/sous,sous": {
+		RepoURL:    "git+ssh://github.com/opentable/sous",
+		RepoOffset: "sous",
+	},
+	// ParseSourceLocation ignores embedded versions.
 	"github.com/opentable/sous,1,": {
 		RepoURL: "github.com/opentable/sous",
 	},

--- a/lib/source_location_test.go
+++ b/lib/source_location_test.go
@@ -4,22 +4,22 @@ import "testing"
 
 var parseSourceLocationTests = map[string]SourceLocation{
 	"github.com/opentable/sous,": {
-		RepoURL: "github.com/opentable/sous",
+		Repo: "github.com/opentable/sous",
 	},
 	":github.com/opentable/sous": {
-		RepoURL: "github.com/opentable/sous",
+		Repo: "github.com/opentable/sous",
 	},
 	",github.com/opentable/sous,util": {
-		RepoURL:    "github.com/opentable/sous",
-		RepoOffset: "util",
+		Repo:   "github.com/opentable/sous",
+		Offset: "util",
 	},
 	":github.com/opentable/sous:util": {
-		RepoURL:    "github.com/opentable/sous",
-		RepoOffset: "util",
+		Repo:   "github.com/opentable/sous",
+		Offset: "util",
 	},
 	"git+ssh://github.com/opentable/sous,sous": {
-		RepoURL:    "git+ssh://github.com/opentable/sous",
-		RepoOffset: "sous",
+		Repo:   "git+ssh://github.com/opentable/sous",
+		Offset: "sous",
 	},
 }
 

--- a/lib/source_location_test.go
+++ b/lib/source_location_test.go
@@ -1,0 +1,44 @@
+package sous
+
+import "testing"
+
+var parseSourceLocationTests = map[string]SourceLocation{
+	"github.com/opentable/sous,1,": {
+		RepoURL: "github.com/opentable/sous",
+	},
+	":github.com/opentable/sous:1:": {
+		RepoURL: "github.com/opentable/sous",
+	},
+	"github.com/opentable/sous,1": {
+		RepoURL: "github.com/opentable/sous",
+	},
+	",github.com/opentable/sous,1,util": {
+		RepoURL:    "github.com/opentable/sous",
+		RepoOffset: "util",
+	},
+	"github.com/opentable/sous,1,util": {
+		RepoURL:    "github.com/opentable/sous",
+		RepoOffset: "util",
+	},
+	":github.com/opentable/sous:1:util": {
+		RepoURL:    "github.com/opentable/sous",
+		RepoOffset: "util",
+	},
+	"git+ssh://github.com/opentable/sous,1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3,sous": {
+		RepoURL:    "git+ssh://github.com/opentable/sous",
+		RepoOffset: "sous",
+	},
+}
+
+func TestParseSourceVersion(t *testing.T) {
+	for in, expected := range parseSourceIDTests {
+		actual, err := ParseSourceID(in)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if actual != expected {
+			t.Errorf("got %v; want %v", actual, expected)
+		}
+	}
+}

--- a/lib/source_location_test.go
+++ b/lib/source_location_test.go
@@ -10,16 +10,16 @@ var parseSourceLocationTests = map[string]SourceLocation{
 		Repo: "github.com/opentable/sous",
 	},
 	",github.com/opentable/sous,util": {
-		Repo:   "github.com/opentable/sous",
-		Offset: "util",
+		Repo: "github.com/opentable/sous",
+		Dir:  "util",
 	},
 	":github.com/opentable/sous:util": {
-		Repo:   "github.com/opentable/sous",
-		Offset: "util",
+		Repo: "github.com/opentable/sous",
+		Dir:  "util",
 	},
 	"git+ssh://github.com/opentable/sous,sous": {
-		Repo:   "git+ssh://github.com/opentable/sous",
-		Offset: "sous",
+		Repo: "git+ssh://github.com/opentable/sous",
+		Dir:  "sous",
 	},
 }
 

--- a/lib/source_location_test.go
+++ b/lib/source_location_test.go
@@ -9,14 +9,7 @@ var parseSourceLocationTests = map[string]SourceLocation{
 	":github.com/opentable/sous": {
 		RepoURL: "github.com/opentable/sous",
 	},
-	"github.com/opentable/sous,,": {
-		RepoURL: "github.com/opentable/sous",
-	},
 	",github.com/opentable/sous,util": {
-		RepoURL:    "github.com/opentable/sous",
-		RepoOffset: "util",
-	},
-	"github.com/opentable/sous,,util": {
 		RepoURL:    "github.com/opentable/sous",
 		RepoOffset: "util",
 	},
@@ -28,41 +21,24 @@ var parseSourceLocationTests = map[string]SourceLocation{
 		RepoURL:    "git+ssh://github.com/opentable/sous",
 		RepoOffset: "sous",
 	},
-	// ParseSourceLocation ignores embedded versions.
-	"github.com/opentable/sous,1,": {
-		RepoURL: "github.com/opentable/sous",
-	},
-	":github.com/opentable/sous:1:": {
-		RepoURL: "github.com/opentable/sous",
-	},
-	"github.com/opentable/sous,1": {
-		RepoURL: "github.com/opentable/sous",
-	},
-	",github.com/opentable/sous,1,util": {
-		RepoURL:    "github.com/opentable/sous",
-		RepoOffset: "util",
-	},
-	"github.com/opentable/sous,1,util": {
-		RepoURL:    "github.com/opentable/sous",
-		RepoOffset: "util",
-	},
-	":github.com/opentable/sous:1:util": {
-		RepoURL:    "github.com/opentable/sous",
-		RepoOffset: "util",
-	},
-	"git+ssh://github.com/opentable/sous,1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3,sous": {
-		RepoURL:    "git+ssh://github.com/opentable/sous",
-		RepoOffset: "sous",
-	},
 }
 
-func TestParseSourceVersion(t *testing.T) {
-	for in, expected := range parseSourceIDTests {
-		actual, err := ParseSourceID(in)
+func TestParseSourceLocation(t *testing.T) {
+	for in, expected := range parseSourceLocationTests {
+		actual, err := ParseSourceLocation(in)
 		if err != nil {
 			t.Error(err)
 			continue
 		}
+		if actual != expected {
+			t.Errorf("got %v; want %v", actual, expected)
+		}
+	}
+}
+
+func TestMustParseSourceLocation(t *testing.T) {
+	for in, expected := range parseSourceLocationTests {
+		actual := MustParseSourceLocation(in)
 		if actual != expected {
 			t.Errorf("got %v; want %v", actual, expected)
 		}

--- a/util/blueprints/cmap/cmap.go
+++ b/util/blueprints/cmap/cmap.go
@@ -5,21 +5,6 @@ import (
 	"sync"
 )
 
-// masterCMapInitMutex is global state allows us to use &CMap{} rather than
-// having to call a constructor.
-var masterCMapInitMutex = &sync.Mutex{}
-
-func initCMap(m *CMap) {
-	masterCMapInitMutex.Lock()
-	defer masterCMapInitMutex.Unlock()
-	if m.m == nil {
-		m.m = map[CMKey]Value{}
-	}
-	if m.mu == nil {
-		m.mu = &sync.RWMutex{}
-	}
-}
-
 // CMap is a wrapper around map[CMKey]Value
 // which is safe for concurrent read and write.
 type CMap struct {
@@ -34,11 +19,29 @@ type CMKey string
 type Value string
 
 // MakeCMap creates a new CMap with capacity set.
-func MakeCMap(capacity int) *CMap {
-	return &CMap{
+func MakeCMap(capacity int) CMap {
+	return CMap{
 		mu: &sync.RWMutex{},
 		m:  make(map[CMKey]Value, capacity),
 	}
+}
+
+func (m CMap) write(f func()) {
+	if m.m == nil || m.mu == nil {
+		panic("uninitialised CMap (you should use NewCMap)")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	f()
+}
+
+func (m CMap) read(f func()) {
+	if m.m == nil || m.mu == nil {
+		panic("uninitialised CMap (you should use NewCMap)")
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	f()
 }
 
 // NewCMapFromMap creates a new CMap.
@@ -46,8 +49,8 @@ func MakeCMap(capacity int) *CMap {
 // map[CMKey]Values,
 // which will be merged key-wise into the new CMap,
 // with keys from the right-most map taking precedence.
-func NewCMapFromMap(from ...map[CMKey]Value) *CMap {
-	cm := &CMap{
+func NewCMapFromMap(from ...map[CMKey]Value) CMap {
+	cm := CMap{
 		mu: &sync.RWMutex{},
 		m:  map[CMKey]Value{},
 	}
@@ -62,8 +65,8 @@ func NewCMapFromMap(from ...map[CMKey]Value) *CMap {
 // NewCMap creates a new CMap.
 // You may optionally pass any number of Values,
 // which will be added to this map.
-func NewCMap(from ...Value) *CMap {
-	m := &CMap{
+func NewCMap(from ...Value) CMap {
+	m := CMap{
 		mu: &sync.RWMutex{},
 		m:  map[CMKey]Value{},
 	}
@@ -77,38 +80,35 @@ func NewCMap(from ...Value) *CMap {
 
 // Get returns (value, true) if k is in the map, or (zero value, false)
 // otherwise.
-func (m *CMap) Get(key CMKey) (Value, bool) {
-	initCMap(m)
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	v, ok := m.m[key]
-	return v, ok
+func (m CMap) Get(key CMKey) (v Value, ok bool) {
+	m.read(func() {
+		v, ok = m.m[key]
+	})
+	return
 }
 
 // Set sets the value of index k to v.
-func (m *CMap) Set(key CMKey, value Value) {
-	initCMap(m)
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.m[key] = value
+func (m CMap) Set(key CMKey, value Value) {
+	m.write(func() {
+		m.m[key] = value
+	})
 }
 
 // Filter returns a new CMap containing only the entries
 // where the predicate returns true for the given value.
 // A nil predicate is equivalent to calling Clone.
-func (m *CMap) Filter(predicate func(Value) bool) *CMap {
+func (m CMap) Filter(predicate func(Value) bool) CMap {
 	if predicate == nil {
 		return m.Clone()
 	}
 	out := map[CMKey]Value{}
-	initCMap(m)
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	for k, v := range m.m {
-		if predicate(v) {
-			out[k] = v
+	m.read(func() {
+		for k, v := range m.m {
+			if predicate(v) {
+				out[k] = v
+			}
 		}
-	}
+	})
 	return NewCMapFromMap(out)
 }
 
@@ -116,7 +116,7 @@ func (m *CMap) Filter(predicate func(Value) bool) *CMap {
 // (the single Value satisfying predicate, true),
 // if there is exactly one Value satisfying predicate in
 // CMap. Otherwise, returns (zero Value, false).
-func (m *CMap) Single(predicate func(Value) bool) (Value, bool) {
+func (m CMap) Single(predicate func(Value) bool) (Value, bool) {
 	f := m.FilteredSnapshot(predicate)
 	if len(f) == 1 {
 		for _, v := range f {
@@ -131,7 +131,7 @@ func (m *CMap) Single(predicate func(Value) bool) (Value, bool) {
 // (a single Value matching predicate, true),
 // if there are any Values matching predicate in
 // CMap. Otherwise returns (zero Value, false).
-func (m *CMap) Any(predicate func(Value) bool) (Value, bool) {
+func (m CMap) Any(predicate func(Value) bool) (Value, bool) {
 	f := m.Filter(predicate)
 	for _, v := range f.Snapshot() {
 		return v, true
@@ -141,7 +141,7 @@ func (m *CMap) Any(predicate func(Value) bool) (Value, bool) {
 }
 
 // Clone returns a pairwise copy of CMap.
-func (m *CMap) Clone() *CMap {
+func (m CMap) Clone() CMap {
 	return NewCMapFromMap(m.Snapshot())
 }
 
@@ -150,26 +150,26 @@ func (m *CMap) Clone() *CMap {
 // If any keys in other match keys in this *CMap,
 // keys from other will appear in the returned
 // *CMap.
-func (m *CMap) Merge(other *CMap) *CMap {
+func (m CMap) Merge(other CMap) CMap {
 	return NewCMapFromMap(m.Snapshot(), other.Snapshot())
 }
 
 // Add adds a (k, v) pair into a map if it is not already there. Returns true if
 // the value was added, false if not.
-func (m *CMap) Add(v Value) bool {
-	initCMap(m)
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	k := v.ID()
-	if _, exists := m.m[k]; exists {
-		return false
-	}
-	m.m[k] = v
-	return true
+func (m CMap) Add(v Value) (ok bool) {
+	m.write(func() {
+		k := v.ID()
+		if _, exists := m.m[k]; exists {
+			return
+		}
+		m.m[k] = v
+		ok = true
+	})
+	return
 }
 
 // MustAdd is a wrapper around Add which panics whenever Add returns false.
-func (m *CMap) MustAdd(v Value) {
+func (m CMap) MustAdd(v Value) {
 	if !m.Add(v) {
 		panic(fmt.Sprintf("item with ID %v already in the graph", v.ID()))
 	}
@@ -179,93 +179,92 @@ func (m *CMap) MustAdd(v Value) {
 // CMap have different keys and all are added to this CMap.
 // If any of the keys conflict, nothing will be added to this
 // CMap and AddAll will return the conflicting CMKey and false.
-func (m *CMap) AddAll(from *CMap) (conflicting CMKey, success bool) {
+func (m CMap) AddAll(from CMap) (conflicting CMKey, success bool) {
 	ss := from.Snapshot()
-	initCMap(m)
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	for k := range ss {
-		if _, exists := m.m[k]; exists {
-			m.mu.RUnlock()
-			return k, false
+	var exists bool
+	m.write(func() {
+		for k := range ss {
+			if _, exists = m.m[k]; exists {
+				conflicting = k
+				return
+			}
 		}
-	}
-	for k, v := range ss {
-		m.m[k] = v
-	}
-	return conflicting, true
+		for k, v := range ss {
+			m.m[k] = v
+		}
+	})
+	return conflicting, !exists
 }
 
 // Remove value for a key k if present, a no-op otherwise.
-func (m *CMap) Remove(key CMKey) {
-	initCMap(m)
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	delete(m.m, key)
+func (m CMap) Remove(key CMKey) {
+	m.write(func() {
+		delete(m.m, key)
+	})
 }
 
 // Len returns number of elements in a map.
-func (m *CMap) Len() int {
-	initCMap(m)
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return len(m.m)
+func (m CMap) Len() int {
+	var l int
+	m.read(func() {
+		l = len(m.m)
+	})
+	return l
 }
 
 // Keys returns a slice containing all the keys in the map.
-func (m *CMap) Keys() []CMKey {
-	initCMap(m)
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	keys := make([]CMKey, len(m.m))
-	i := 0
-	for k := range m.m {
-		keys[i] = k
-		i++
-	}
+func (m CMap) Keys() []CMKey {
+	var keys []CMKey
+	m.read(func() {
+		keys = make([]CMKey, len(m.m))
+		i := 0
+		for k := range m.m {
+			keys[i] = k
+			i++
+		}
+	})
 	return keys
 }
 
 // Snapshot returns a moment-in-time copy of the current underlying
 // map[CMKey]Value.
-func (m *CMap) Snapshot() map[CMKey]Value {
-	initCMap(m)
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	clone := make(map[CMKey]Value, len(m.m))
-	for k, v := range m.m {
-		clone[k] = v
-	}
-	return clone
+func (m CMap) Snapshot() map[CMKey]Value {
+	var ss map[CMKey]Value
+	m.read(func() {
+		ss = make(map[CMKey]Value, len(m.m))
+		for k, v := range m.m {
+			ss[k] = v
+		}
+	})
+	return ss
 }
 
 // FilteredSnapshot returns a moment-in-time filtered copy of the current
 // underlying map[CMKey]Value.
 // (CMKey, Value) pairs are included
 // if they satisfy predicate.
-func (m *CMap) FilteredSnapshot(predicate func(Value) bool) map[CMKey]Value {
-	initCMap(m)
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+func (m CMap) FilteredSnapshot(predicate func(Value) bool) map[CMKey]Value {
 	clone := map[CMKey]Value{}
-	for k, v := range m.m {
-		if predicate(v) {
-			clone[k] = v
+	m.read(func() {
+		for k, v := range m.m {
+			if predicate(v) {
+				clone[k] = v
+			}
 		}
-	}
+	})
 	return clone
 }
 
 // GetAll returns SnapShot (it allows hy to marshal CMap).
-func (m *CMap) GetAll() map[CMKey]Value {
+func (m CMap) GetAll() map[CMKey]Value {
 	return m.Snapshot()
 }
 
 // SetAll sets the internal map (it allows hy to unmarshal CMap).
+// Note: SetAll is the only method that is not safe for concurrent access.
 func (m *CMap) SetAll(v map[CMKey]Value) {
-	initCMap(m)
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.m = nil
+	if m.mu == nil {
+		m.mu = &sync.RWMutex{}
+	}
 	m.m = v
 }

--- a/util/blueprints/cmap/cmap_test.go
+++ b/util/blueprints/cmap/cmap_test.go
@@ -3,23 +3,23 @@ package cmap
 import "testing"
 
 type CMapTest struct {
-	CMap     *CMap
+	CMap     CMap
 	Do       func(c *CMap)
 	Expected map[CMKey]Value
 }
 
 var cmapTests = []CMapTest{
 	{
-		CMap:     &CMap{},
+		CMap:     NewCMap(),
 		Expected: map[CMKey]Value{},
 	},
 	{
 		CMap:     MakeCMap(999),
-		Expected: (&CMap{}).Snapshot(),
+		Expected: NewCMap().Snapshot(),
 	},
 	{
 		CMap:     NewCMap(),
-		Expected: (&CMap{}).Snapshot(),
+		Expected: NewCMap().Snapshot(),
 	},
 	{
 		CMap:     NewCMap("one"),
@@ -36,21 +36,21 @@ var cmapTests = []CMapTest{
 	{
 		CMap: NewCMapFromMap(map[CMKey]Value{"one": "one"}),
 		Do: func(c *CMap) {
-			*c = *c.Filter(func(v Value) bool { return v.ID() == "one" })
+			*c = c.Filter(func(v Value) bool { return v.ID() == "one" })
 		},
 		Expected: map[CMKey]Value{"one": "one"},
 	},
 	{
 		CMap: NewCMapFromMap(map[CMKey]Value{"one": "one"}),
 		Do: func(c *CMap) {
-			*c = *c.Filter(nil)
+			*c = c.Filter(nil)
 		},
 		Expected: map[CMKey]Value{"one": "one"},
 	},
 	{
 		CMap: NewCMapFromMap(map[CMKey]Value{"one": "one"}),
 		Do: func(c *CMap) {
-			*c = *c.Filter(func(v Value) bool { return v.ID() == "two" })
+			*c = c.Filter(func(v Value) bool { return v.ID() == "two" })
 		},
 		Expected: map[CMKey]Value{},
 	},
@@ -99,14 +99,14 @@ var cmapTests = []CMapTest{
 	{
 		CMap: NewCMapFromMap(map[CMKey]Value{"one": "one"}),
 		Do: func(c *CMap) {
-			*c = *NewCMapFromMap(c.FilteredSnapshot(func(v Value) bool {
+			*c = NewCMapFromMap(c.FilteredSnapshot(func(v Value) bool {
 				return v == "two"
 			}))
 		},
 		Expected: map[CMKey]Value{},
 	},
 	{
-		CMap: &CMap{},
+		CMap: NewCMap(),
 		Do: func(c *CMap) {
 			c.SetAll(map[CMKey]Value{"set": "set", "all": "all"})
 		},
@@ -115,14 +115,14 @@ var cmapTests = []CMapTest{
 	{
 		CMap: NewCMapFromMap(map[CMKey]Value{"set": "set", "all": "all"}),
 		Do: func(c *CMap) {
-			*c = *NewCMapFromMap(c.GetAll())
+			*c = NewCMapFromMap(c.GetAll())
 		},
 		Expected: map[CMKey]Value{"set": "set", "all": "all"},
 	},
 	{
 		CMap: NewCMapFromMap(map[CMKey]Value{"set": "set", "all": "all"}),
 		Do: func(c *CMap) {
-			*c = *c.Clone()
+			*c = c.Clone()
 		},
 		Expected: map[CMKey]Value{"set": "set", "all": "all"},
 	},
@@ -133,7 +133,7 @@ var cmapTests = []CMapTest{
 			if !ok {
 				panic("missing key two")
 			}
-			*c = *NewCMap(v)
+			*c = NewCMap(v)
 		},
 		Expected: map[CMKey]Value{"two": "two"},
 	},
@@ -153,7 +153,7 @@ var cmapTests = []CMapTest{
 			if !ok {
 				panic("no single value two")
 			}
-			*c = *NewCMap(v)
+			*c = NewCMap(v)
 		},
 		Expected: map[CMKey]Value{"two": "two"},
 	},
@@ -166,7 +166,7 @@ var cmapTests = []CMapTest{
 			if ok {
 				panic("found nonexistent value")
 			}
-			*c = *NewCMap(v)
+			*c = NewCMap(v)
 		},
 		Expected: map[CMKey]Value{"": ""},
 	},
@@ -179,7 +179,7 @@ var cmapTests = []CMapTest{
 			if !ok {
 				panic("no value two")
 			}
-			*c = *NewCMap(v)
+			*c = NewCMap(v)
 		},
 		Expected: map[CMKey]Value{"two": "two"},
 	},
@@ -192,7 +192,7 @@ var cmapTests = []CMapTest{
 			if ok {
 				panic("found value; should not have")
 			}
-			*c = *NewCMap(v)
+			*c = NewCMap(v)
 		},
 		Expected: map[CMKey]Value{"": ""},
 	},
@@ -200,7 +200,7 @@ var cmapTests = []CMapTest{
 		CMap: NewCMapFromMap(map[CMKey]Value{"one": "one"}),
 		Do: func(c *CMap) {
 			other := NewCMapFromMap(map[CMKey]Value{"two": "two"})
-			*c = *c.Merge(other)
+			*c = c.Merge(other)
 		},
 		Expected: map[CMKey]Value{"one": "one", "two": "two"},
 	},
@@ -212,7 +212,7 @@ var cmapTests = []CMapTest{
 				vals = append(vals, Value(string(k)))
 			}
 			other := NewCMap(vals...)
-			*c = *c.Merge(other)
+			*c = c.Merge(other)
 		},
 		Expected: map[CMKey]Value{"one": "one"},
 	},
@@ -222,7 +222,7 @@ func TestCMap(t *testing.T) {
 
 	for _, test := range cmapTests {
 		if test.Do != nil {
-			test.Do(test.CMap)
+			test.Do(&test.CMap)
 		}
 		actual := test.CMap.Snapshot()
 		expected := test.Expected

--- a/util/firsterr/firsterr.go
+++ b/util/firsterr/firsterr.go
@@ -160,11 +160,11 @@ func (P) Set(fs ...func(*error)) error {
 	for _, f := range fs {
 		f := f
 		go func() {
+			defer wg.Done()
 			var err error
 			if f(&err); err != nil {
 				errs <- err
 			}
-			wg.Done()
 		}()
 	}
 	return <-errs

--- a/util/firsterr/firsterr_test.go
+++ b/util/firsterr/firsterr_test.go
@@ -1,6 +1,9 @@
 package firsterr
 
-import "testing"
+import (
+	"sync/atomic"
+	"testing"
+)
 
 type Error string
 
@@ -131,8 +134,8 @@ func TestParallel_Set_Err(t *testing.T) {
 	}
 
 	// Check functions are actually run...
-	callCount := 0
-	spy := func(*error) { callCount++ }
+	callCount := int64(0)
+	spy := func(*error) { atomic.AddInt64(&callCount, 1) }
 	p.Set(spy, spy, spy, spy, spy)
 	if callCount != 5 {
 		t.Fatalf("spy called %d times; want 5", callCount)

--- a/vendor/github.com/opentable/hy/codec.go
+++ b/vendor/github.com/opentable/hy/codec.go
@@ -107,7 +107,7 @@ func (c *Codec) Read(prefix string, root interface{}) error {
 		return errors.Wrapf(err, "reading tree at %q", prefix)
 	}
 	rc := NewReadContext(prefix, targets, c.reader)
-	rootVal := rootNode.NewVal()
+	rootVal := rootNode.NewValFrom(reflect.ValueOf(root))
 	if err := rootNode.Read(rc, rootVal); err != nil {
 		return errors.Wrapf(err, "reading root")
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -140,10 +140,10 @@
 			"revisionTime": "2016-08-09T08:42:26Z"
 		},
 		{
-			"checksumSHA1": "HqlQXXJY/RYOZgVf13JJIdYTcFk=",
+			"checksumSHA1": "z3U11i7w1A1tq1++lLAPwRxFRLc=",
 			"path": "github.com/opentable/hy",
-			"revision": "0f460f33acd44344f93831b974089f63db5bb801",
-			"revisionTime": "2016-08-16T23:47:25Z"
+			"revision": "d5ab537fd7fd925b822aabf6dad30fa68532bd15",
+			"revisionTime": "2016-08-18T09:23:33Z"
 		},
 		{
 			"checksumSHA1": "5GnAp0RETgoWf+Asq2DCw3ceE+w=",


### PR DESCRIPTION
Includes #114 

- Shortens SourceID and SourceLocation field names.
- "RepoURL" was a misnomer, renamed to the more ambiguous "Repo".
- "RepoOffset" was a long way of saying "Directory", renamed "Dir".
