### PR TITLE
Sous init fix

### DIFF
--- a/cli/graph.go
+++ b/cli/graph.go
@@ -321,19 +321,9 @@ func newCurrentState(sr LocalStateReader) (*sous.State, error) {
 }
 
 func newCurrentGDM(state *sous.State) (CurrentGDM, error) {
-	log.Println("#", state.Manifests.Len(), "MANIFESTS")
 	deployments, err := state.Deployments()
 	if err != nil {
 		return CurrentGDM{}, initErr(err, "expanding state")
-	}
-	if deployments.Len() == 0 {
-		log.Println("ZERO DEPLOYMENTS")
-	}
-	for k, d := range deployments.Snapshot() {
-		if d.Cluster == nil {
-			return CurrentGDM{}, errors.Errorf("CLUSTER IS NIL IN DEPLOYMENT %q", k)
-		}
-		log.Println("GOT CLUSTER:", k)
 	}
 	return CurrentGDM{deployments}, initErr(err, "expanding state")
 }

--- a/cli/sous.go
+++ b/cli/sous.go
@@ -54,8 +54,10 @@ Please report any issue with sous to https://github.com/opentable/sous/issues
 pull requests are welcome.
 `
 
+// Help returns the top-level help for Sous.
 func (*Sous) Help() string { return sousHelp }
 
+// AddFlags adds sous' flags.
 func (s *Sous) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&s.flags.Verbosity.Silent, "s", false,
 		"silent: silence all non-essential output")
@@ -72,6 +74,8 @@ func (s *Sous) RegisterOn(psy Addable) {
 	psy.Add(s)
 }
 
+// Execute exists to present a helpful error to the user, in the case they just
+// run 'sous' with not subcommand.
 func (s *Sous) Execute(args []string) cmdr.Result {
 	r := s.CLI.InvokeWithoutPrinting([]string{"sous", "help"})
 	success, ok := r.(cmdr.SuccessResult)
@@ -87,6 +91,7 @@ func (s *Sous) usage() cmdr.ErrorResult {
 	return err
 }
 
+// Subcommands returns all the top-level sous subcommands.
 func (s *Sous) Subcommands() cmdr.Commands {
 	//s.CLI.SetVerbosity(s.Verbosity())
 	return TopLevelCommands

--- a/cli/sous_deploy_test.go
+++ b/cli/sous_deploy_test.go
@@ -74,7 +74,7 @@ var updateStateTests = []struct {
 	{
 		State:       sous.NewState(),
 		GDM:         CurrentGDM{sous.NewDeployments()},
-		ExpectedErr: `cluster "" does not exist`,
+		ExpectedErr: "invalid deploy ID (no cluster name)",
 	},
 	{
 		State: sous.NewState(),

--- a/cli/sous_deploy_test.go
+++ b/cli/sous_deploy_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	sous "github.com/opentable/sous/lib"
+	"github.com/samsalisbury/semv"
 )
 
 var getIDsTests = []struct {
@@ -66,7 +67,6 @@ func TestGetIDs(t *testing.T) {
 var updateStateTests = []struct {
 	State                *sous.State
 	GDM                  CurrentGDM
-	SID                  sous.SourceID
 	DID                  sous.DeployID
 	ExpectedErr          string
 	ExpectedNumManifests int
@@ -77,9 +77,12 @@ var updateStateTests = []struct {
 		ExpectedErr: `cluster "" does not exist`,
 	},
 	{
-		State:       sous.NewState(),
-		GDM:         CurrentGDM{sous.NewDeployments()},
-		DID:         sous.DeployID{Cluster: "blah"},
+		State: sous.NewState(),
+		GDM:   CurrentGDM{sous.NewDeployments()},
+		DID: sous.DeployID{
+			Cluster: "blah",
+			Source:  sous.MustParseSourceLocation("github.com/user/project"),
+		},
 		ExpectedErr: `cluster "blah" does not exist`,
 	},
 	{
@@ -88,15 +91,23 @@ var updateStateTests = []struct {
 				"blah": &sous.Cluster{Name: "blah"},
 			}},
 		},
-		GDM:                  CurrentGDM{sous.NewDeployments()},
-		DID:                  sous.DeployID{Cluster: "blah"},
+		GDM: CurrentGDM{sous.NewDeployments()},
+		DID: sous.DeployID{
+			Cluster: "blah",
+			Source:  sous.MustParseSourceLocation("github.com/user/project"),
+		},
 		ExpectedNumManifests: 1,
 	},
 }
 
 func TestUpdateState(t *testing.T) {
 	for _, test := range updateStateTests {
-		err := updateState(test.State, test.GDM, test.SID, test.DID)
+		sid := sous.SourceID{
+			Repo:    test.DID.Source.Repo,
+			Dir:     test.DID.Source.Dir,
+			Version: semv.MustParse("1.0.0"),
+		}
+		err := updateState(test.State, test.GDM, sid, test.DID)
 		if err != nil {
 			if test.ExpectedErr == "" {
 				t.Error(err)
@@ -114,6 +125,16 @@ func TestUpdateState(t *testing.T) {
 		actualNumManifests := test.State.Manifests.Len()
 		if actualNumManifests != test.ExpectedNumManifests {
 			t.Errorf("got %d manifests; want %d", actualNumManifests, test.ExpectedNumManifests)
+		}
+		if (test.DID != sous.DeployID{}) {
+			m, ok := test.State.Manifests.Get(sid.Location())
+			if !ok {
+				t.Errorf("manifest %q not found", sid.Location())
+			}
+			_, ok = m.Deployments[test.DID.Cluster]
+			if !ok {
+				t.Errorf("missing deployment %q", test.DID)
+			}
 		}
 	}
 }

--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"flag"
+	"log"
 
 	"github.com/opentable/sous/ext/otpl"
 	"github.com/opentable/sous/lib"
@@ -74,7 +75,14 @@ func (si *SousInit) Execute(args []string) cmdr.Result {
 		if len(otplDeploySpecs) == 0 {
 			return UsageErrorf("you specified -use-otpl-deploy, but no valid deployments were found in config/")
 		}
-		deploySpecs = otplDeploySpecs
+		deploySpecs = sous.DeploySpecs{}
+		for clusterName, spec := range otplDeploySpecs {
+			if _, ok := si.State.Defs.Clusters[clusterName]; !ok {
+				log.Printf("otpl-deploy config for cluster %q ignored", clusterName)
+				continue
+			}
+			deploySpecs[clusterName] = spec
+		}
 	}
 	if len(deploySpecs) == 0 {
 		deploySpecs = defaultDeploySpecs()

--- a/lib/map_state_to_deployments.go
+++ b/lib/map_state_to_deployments.go
@@ -2,7 +2,6 @@ package sous
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/pkg/errors"
 	"github.com/samsalisbury/semv"
@@ -11,16 +10,11 @@ import (
 // Deployments returns all deployments described by the state.
 func (s *State) Deployments() (Deployments, error) {
 	ds := NewDeployments()
-	if s == nil {
-		panic("NIL STATE")
-	}
-	for k, m := range s.Manifests.Snapshot() {
-		log.Println("GETTING DEPLOYMENTS FOR:", k)
+	for _, m := range s.Manifests.Snapshot() {
 		deployments, err := s.DeploymentsFromManifest(m)
 		if err != nil {
 			return ds, err
 		}
-		log.Println("GOT:", deployments.Len())
 		conflict, ok := ds.AddAll(deployments)
 		if !ok {
 			return ds, fmt.Errorf("conflicting deploys: %s", conflict)
@@ -53,7 +47,7 @@ func (ds Deployments) Manifests(defs Defs) (Manifests, error) {
 	for _, k := range ds.Keys() {
 		d, _ := ds.Get(k)
 		if d.ClusterName == "" {
-			return ms, fmt.Errorf("no cluster name set for %q", k)
+			return ms, errors.Errorf("invalid deploy ID (no cluster name)")
 		}
 		if d.Cluster == nil {
 			cluster, ok := defs.Clusters[d.ClusterName]


### PR DESCRIPTION
Includes #123 

'sous init' now ignores any clusters defined in otpl-deploy config that aren't known to sous