### PR TITLE
Sous deploy

### DIFF
--- a/cli/add_flags.go
+++ b/cli/add_flags.go
@@ -33,8 +33,7 @@ func AddFlags(fs *flag.FlagSet, target interface{}, help string) error {
 		ft := f.Type
 		fp := v.Field(i).Addr().Interface()
 		name := strings.ToLower(f.Name)
-		tag, ok := f.Tag.Lookup("flag")
-		if ok {
+		if tag := f.Tag.Get("flag"); tag != "" {
 			name = tag
 		}
 		u, ok := usage[name]

--- a/cli/add_flags.go
+++ b/cli/add_flags.go
@@ -33,6 +33,10 @@ func AddFlags(fs *flag.FlagSet, target interface{}, help string) error {
 		ft := f.Type
 		fp := v.Field(i).Addr().Interface()
 		name := strings.ToLower(f.Name)
+		tag, ok := f.Tag.Lookup("flag")
+		if ok {
+			name = tag
+		}
 		u, ok := usage[name]
 		if !ok {
 			continue

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -3,11 +3,14 @@
 package cli
 
 import (
+	"fmt"
 	"io"
 	"os"
 
+	sous "github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/cmdr"
 	"github.com/opentable/sous/util/yaml"
+	"github.com/pkg/errors"
 	"github.com/samsalisbury/semv"
 )
 
@@ -101,6 +104,18 @@ func NewSousCLI(v semv.Version, out, errout io.Writer) (*cmdr.CLI, error) {
 			}
 		}
 		return nil
+	}
+
+	cli.Hooks.PreFail = func(err error) cmdr.ErrorResult {
+		if err != nil {
+			originalErr := fmt.Sprint(err)
+			err = errors.Cause(err)
+			causeStr := err.Error()
+			if originalErr != causeStr {
+				sous.Log.Debug.Println(originalErr)
+			}
+		}
+		return EnsureErrorResult(err)
 	}
 
 	return cli, nil

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -56,10 +56,10 @@ func TestInvokeConfig(t *testing.T) {
 
 }
 
-func TestInvokeDeploy(t *testing.T) {
+func TestInvokeUpdate(t *testing.T) {
 	assert := assert.New(t)
 
-	exe := justCommand(t, []string{`sous`, `deploy`})
+	exe := justCommand(t, []string{`sous`, `update`})
 	assert.NotNil(exe)
 	assert.Len(exe.Args, 0)
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"testing"
 
 	"github.com/nyarly/testify/assert"
@@ -203,7 +202,6 @@ func TestInvokeBareSous(t *testing.T) {
 	require.NotPanics(func() {
 		r = c.InvokeWithoutPrinting([]string{"sous", "help"})
 	})
-	log.Printf("%T %v", r, r)
 	assert.IsType(cmdr.SuccessResult{}, r)
 }
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -99,18 +99,6 @@ func TestInvokeInit(t *testing.T) {
 	assert.NotNil(init)
 	assert.False(init.Flags.IgnoreOTPLDeploy)
 	assert.False(init.Flags.IgnoreOTPLDeploy)
-
-	exe = justCommand(t, []string{`sous`, `init`, `-use-otpl-deploy`})
-	init = exe.Cmd.(*SousInit)
-	assert.NotNil(init)
-	assert.False(init.Flags.IgnoreOTPLDeploy)
-	assert.True(init.Flags.UseOTPLDeploy)
-
-	exe = justCommand(t, []string{`sous`, `init`, `-ignore-otpl-deploy`})
-	init = exe.Cmd.(*SousInit)
-	assert.NotNil(init)
-	assert.True(init.Flags.IgnoreOTPLDeploy)
-	assert.False(init.Flags.UseOTPLDeploy)
 }
 
 /*

--- a/cli/flags_otpl.go
+++ b/cli/flags_otpl.go
@@ -1,0 +1,17 @@
+package cli
+
+// OTPLFlags set options for sniffing otpl-deploy configuration during manifest
+// initialisation.
+type OTPLFlags struct {
+	UseOTPLDeploy    bool `flag:"use-otpl-deploy"`
+	IgnoreOTPLDeploy bool `flag:"ignore-otpl-deploy"`
+}
+
+const otplFlagsHelp = `
+	-use-otpl-deploy
+		use existing otpl config in ./config/<cluster>/...
+	
+	-ignore-otpl-deploy
+		ignore existing otpl config in ./config/<cluster>/...
+
+`

--- a/cli/graph.go
+++ b/cli/graph.go
@@ -77,9 +77,6 @@ type (
 	// TargetManifest is a specific manifest for the current SourceLocation.
 	// If the named manifest does not exist, it is created.
 	TargetManifest struct{ *sous.Manifest }
-	// NewManifest is like TargetManifest, except its constructor returns an
-	// error if the manifest already existed.
-	NewManifest struct{ *sous.Manifest }
 	// DetectedOTPLDeploySpecs is a set of otpl-deploy configured deployments
 	// that have been detected.
 	DetectedOTPLDeploySpecs struct{ sous.DeploySpecs }
@@ -127,7 +124,6 @@ func BuildGraph(c *cmdr.CLI, out, err io.Writer) *SousCLIGraph {
 		newCurrentGDM,
 		newCurrentState,
 		newTargetManifest,
-		newNewManifest,
 		newDetectedOTPLConfig,
 		newUserSelectedOTPLDeploySpecs,
 		newTargetSourceLocation,

--- a/cli/graph.go
+++ b/cli/graph.go
@@ -127,6 +127,7 @@ func BuildGraph(c *cmdr.CLI, out, err io.Writer) *SousCLIGraph {
 		newCurrentGDM,
 		newCurrentState,
 		newTargetManifest,
+		newNewManifest,
 		newDetectedOTPLConfig,
 		newUserSelectedOTPLDeploySpecs,
 		newTargetSourceLocation,

--- a/cli/graph.go
+++ b/cli/graph.go
@@ -74,6 +74,21 @@ type (
 	// CurrentGDM is a snapshot of the GDM at application start. In a CLI
 	// context, which this is, that is all we need to simply read the GDM.
 	CurrentGDM struct{ sous.Deployments }
+	// TargetManifest is a specific manifest for the current SourceLocation.
+	// If the named manifest does not exist, it is created.
+	TargetManifest struct{ *sous.Manifest }
+	// NewManifest is like TargetManifest, except its constructor returns an
+	// error if the manifest already existed.
+	NewManifest struct{ *sous.Manifest }
+	// DetectedOTPLDeploySpecs is a set of otpl-deploy configured deployments
+	// that have been detected.
+	DetectedOTPLDeploySpecs struct{ sous.DeploySpecs }
+	// UserSelectedOTPLDeploySpecs is a set of otpl-deploy configured deploy
+	// specs that the user has explicitly selected. (May be empty.)
+	UserSelectedOTPLDeploySpecs struct{ sous.DeploySpecs }
+	// TargetSourceLocation is the source location being targeted, after
+	// resolving all context and flags.
+	TargetSourceLocation sous.SourceLocation
 )
 
 // BuildGraph builds the dependency injection graph, used to populate commands
@@ -111,6 +126,10 @@ func BuildGraph(c *cmdr.CLI, out, err io.Writer) *SousCLIGraph {
 		newLocalStateWriter,
 		newCurrentGDM,
 		newCurrentState,
+		newTargetManifest,
+		newDetectedOTPLConfig,
+		newUserSelectedOTPLDeploySpecs,
+		newTargetSourceLocation,
 	)}
 }
 
@@ -148,35 +167,21 @@ func newLogSet(s *Sous, err ErrWriter) *sous.LogSet { // XXX temporary until we 
 	return &sous.Log
 }
 
-/*
-func newSourceFlags(c *cmdr.CLI) (*DeployFilterFlags, error) {
-	sourceFlags := &DeployFilterFlags{}
-	var err error
-	c.AddGlobalFlagSetFunc(func(fs *flag.FlagSet) {
-		err = AddFlags(fs, sourceFlags, sourceFlagsHelp)
-		if err != nil {
-			panic(err)
-		}
-	})
-	return sourceFlags, err
-}
-*/
-
 func newGitSourceContext(g LocalGitRepo) (GitSourceContext, error) {
 	c, err := g.SourceContext()
 	return GitSourceContext{c}, initErr(err, "getting local git context")
 }
 
-func newSourceContext(g GitSourceContext, f *DeployFilterFlags) (*sous.SourceContext, error) {
+func newSourceContext(f *DeployFilterFlags, g GitSourceContext) (*sous.SourceContext, error) {
 	c := g.SourceContext
 	if c == nil {
 		c = &sous.SourceContext{}
 	}
-
-	sl, err := resolveSourceLocation(f, c)
+	tsl, err := newTargetSourceLocation(f, c)
 	if err != nil {
-		return nil, errors.Wrap(err, "resolving source location")
+		return nil, errors.Wrapf(err, "getting source location")
 	}
+	sl := sous.SourceLocation(tsl)
 	if sl.Repo != c.SourceLocation().Repo {
 		// TODO: Clone the repository, and use the cloned dir as source context.
 		return nil, errors.Errorf("source location %q is not the same as the remote %q",

--- a/cli/graph.go
+++ b/cli/graph.go
@@ -42,6 +42,17 @@ type (
 )
 
 type (
+	// StateReader knows how to read state.
+	StateReader interface {
+		ReadState() (*sous.State, error)
+	}
+	// StateWriter know how to write state.
+	StateWriter interface {
+		WriteState(*sous.State) error
+	}
+)
+
+type (
 	// Version represents a version of Sous.
 	Version struct{ semv.Version }
 	// LocalUser is the currently logged in user.
@@ -67,10 +78,10 @@ type (
 	LocalDockerClient struct{ docker_registry.Client }
 	// LocalStateReader wraps a storage.StateReader, and should be configured
 	// to use the current user's local storage.
-	LocalStateReader struct{ storage.StateReader }
+	LocalStateReader struct{ StateReader }
 	// LocalStateWriter wraps a storage.StateWriter, and should be configured to
 	// use the current user's local storage.
-	LocalStateWriter struct{ storage.StateWriter }
+	LocalStateWriter struct{ StateWriter }
 	// CurrentGDM is a snapshot of the GDM at application start. In a CLI
 	// context, which this is, that is all we need to simply read the GDM.
 	CurrentGDM struct{ sous.Deployments }

--- a/cli/graph_sourcecontext.go
+++ b/cli/graph_sourcecontext.go
@@ -5,7 +5,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func resolveSourceLocation(f *DeployFilterFlags, c *sous.SourceContext) (sous.SourceLocation, error) {
+func newTargetSourceLocation(f *DeployFilterFlags, c *sous.SourceContext) (TargetSourceLocation, error) {
 	if c == nil {
 		c = &sous.SourceContext{}
 	}
@@ -22,14 +22,14 @@ func resolveSourceLocation(f *DeployFilterFlags, c *sous.SourceContext) (sous.So
 	}
 	if f.Offset != "" {
 		if f.Repo == "" {
-			return sous.SourceLocation{}, errors.Errorf("you specified -offset but not -repo")
+			return TargetSourceLocation{}, errors.Errorf("you specified -offset but not -repo")
 		}
 		offset = f.Offset
 	}
 	if repo == "" {
-		return sous.SourceLocation{}, errors.Errorf("no repo specified, please use -repo or run sous inside a git repo")
+		return TargetSourceLocation{}, errors.Errorf("no repo specified, please use -repo or run sous inside a git repo")
 	}
-	return sous.SourceLocation{
+	return TargetSourceLocation{
 		Repo: repo,
 		Dir:  offset,
 	}, nil

--- a/cli/graph_sourcecontext_test.go
+++ b/cli/graph_sourcecontext_test.go
@@ -25,7 +25,7 @@ var badResolveSourceLocationCalls = map[string][]resolveSourceLocationInput{
 func TestResolveSourceLocation_failure(t *testing.T) {
 	for expected, inGroup := range badResolveSourceLocationCalls {
 		for _, in := range inGroup {
-			_, actualErr := resolveSourceLocation(in.Flags, in.Context)
+			_, actualErr := newTargetSourceLocation(in.Flags, in.Context)
 			if actualErr == nil {
 				t.Errorf("got nil; want error %q", expected)
 				continue
@@ -66,7 +66,7 @@ var goodResolveSourceLocationCalls = map[sous.SourceLocation][]resolveSourceLoca
 func TestResolveSourceLocation_success(t *testing.T) {
 	for expected, inGroup := range goodResolveSourceLocationCalls {
 		for _, in := range inGroup {
-			actual, err := resolveSourceLocation(in.Flags, in.Context)
+			actual, err := newTargetSourceLocation(in.Flags, in.Context)
 			if err != nil {
 				t.Error(err)
 				continue

--- a/cli/graph_targetmanifest.go
+++ b/cli/graph_targetmanifest.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"github.com/opentable/sous/ext/otpl"
+	sous "github.com/opentable/sous/lib"
+)
+
+func newDetectedOTPLConfig(wd LocalWorkDirShell, otplFlags *OTPLFlags) (DetectedOTPLDeploySpecs, error) {
+	if otplFlags.IgnoreOTPLDeploy {
+		return DetectedOTPLDeploySpecs{}, nil
+	}
+	otplParser := otpl.NewDeploySpecParser()
+	otplDeploySpecs := otplParser.GetDeploySpecs(wd.Sh)
+	return DetectedOTPLDeploySpecs{otplDeploySpecs}, nil
+}
+
+func newUserSelectedOTPLDeploySpecs(detected DetectedOTPLDeploySpecs, flags *OTPLFlags, state *sous.State) (UserSelectedOTPLDeploySpecs, error) {
+	var nowt UserSelectedOTPLDeploySpecs
+	if !flags.UseOTPLDeploy && !flags.IgnoreOTPLDeploy && len(detected.DeploySpecs) != 0 {
+		return nowt, UsageErrorf("otpl-deploy detected in config/, please specify either -use-otpl-deploy, or -ignore-otpl-deploy to proceed")
+	}
+	if !flags.UseOTPLDeploy {
+		return nowt, nil
+	}
+	if len(detected.DeploySpecs) == 0 {
+		return nowt, UsageErrorf("you specified -use-otpl-deploy, but no valid deployments were found in config/")
+	}
+	deploySpecs := sous.DeploySpecs{}
+	for clusterName, spec := range detected.DeploySpecs {
+		if _, ok := state.Defs.Clusters[clusterName]; !ok {
+			sous.Log.Warn.Printf("otpl-deploy config for cluster %q ignored", clusterName)
+			continue
+		}
+		deploySpecs[clusterName] = spec
+	}
+	return UserSelectedOTPLDeploySpecs{deploySpecs}, nil
+}
+
+func newNewManifest(tm TargetManifest, s *sous.State) (NewManifest, error) {
+	if _, ok := s.Manifests.Get(tm.ID()); ok {
+		return NewManifest{}, UsageErrorf("manifest %q already exists", tm.ID())
+	}
+	return NewManifest(tm), nil
+}
+
+func newTargetManifest(auto UserSelectedOTPLDeploySpecs, tsl TargetSourceLocation, s *sous.State) (TargetManifest, error) {
+	sl := sous.SourceLocation(tsl)
+	//ds := gdm.Filter(func(d *sous.Deployment) bool {
+	//	return d.SourceID.Location() == sl
+	//})
+	m, ok := s.Manifests.Get(sl)
+	if ok {
+		return TargetManifest{m}, nil
+	}
+	deploySpecs := auto.DeploySpecs
+	if len(deploySpecs) == 0 {
+		deploySpecs = defaultDeploySpecs()
+	}
+
+	m = &sous.Manifest{
+		Source:      sl,
+		Deployments: deploySpecs,
+	}
+	return TargetManifest{m}, nil
+}

--- a/cli/graph_targetmanifest.go
+++ b/cli/graph_targetmanifest.go
@@ -41,13 +41,6 @@ func newUserSelectedOTPLDeploySpecs(detected DetectedOTPLDeploySpecs, tsl Target
 	return UserSelectedOTPLDeploySpecs{deploySpecs}, nil
 }
 
-func newNewManifest(tm TargetManifest, s *sous.State) (NewManifest, error) {
-	if _, ok := s.Manifests.Get(tm.ID()); ok {
-		return NewManifest{}, UsageErrorf("manifest %q already exists", tm.ID())
-	}
-	return NewManifest(tm), nil
-}
-
 func newTargetManifest(auto UserSelectedOTPLDeploySpecs, tsl TargetSourceLocation, s *sous.State) (TargetManifest, error) {
 	sl := sous.SourceLocation(tsl)
 	//ds := gdm.Filter(func(d *sous.Deployment) bool {

--- a/cli/graph_targetmanifest.go
+++ b/cli/graph_targetmanifest.go
@@ -41,14 +41,14 @@ func newUserSelectedOTPLDeploySpecs(detected DetectedOTPLDeploySpecs, tsl Target
 	return UserSelectedOTPLDeploySpecs{deploySpecs}, nil
 }
 
-func newTargetManifest(auto UserSelectedOTPLDeploySpecs, tsl TargetSourceLocation, s *sous.State) (TargetManifest, error) {
+func newTargetManifest(auto UserSelectedOTPLDeploySpecs, tsl TargetSourceLocation, s *sous.State) TargetManifest {
 	sl := sous.SourceLocation(tsl)
 	//ds := gdm.Filter(func(d *sous.Deployment) bool {
 	//	return d.SourceID.Location() == sl
 	//})
 	m, ok := s.Manifests.Get(sl)
 	if ok {
-		return TargetManifest{m}, nil
+		return TargetManifest{m}
 	}
 	deploySpecs := auto.DeploySpecs
 	if len(deploySpecs) == 0 {
@@ -59,5 +59,5 @@ func newTargetManifest(auto UserSelectedOTPLDeploySpecs, tsl TargetSourceLocatio
 		Source:      sl,
 		Deployments: deploySpecs,
 	}
-	return TargetManifest{m}, nil
+	return TargetManifest{m}
 }

--- a/cli/graph_targetmanifest.go
+++ b/cli/graph_targetmanifest.go
@@ -14,8 +14,13 @@ func newDetectedOTPLConfig(wd LocalWorkDirShell, otplFlags *OTPLFlags) (Detected
 	return DetectedOTPLDeploySpecs{otplDeploySpecs}, nil
 }
 
-func newUserSelectedOTPLDeploySpecs(detected DetectedOTPLDeploySpecs, flags *OTPLFlags, state *sous.State) (UserSelectedOTPLDeploySpecs, error) {
+func newUserSelectedOTPLDeploySpecs(detected DetectedOTPLDeploySpecs, tsl TargetSourceLocation, flags *OTPLFlags, state *sous.State) (UserSelectedOTPLDeploySpecs, error) {
 	var nowt UserSelectedOTPLDeploySpecs
+	sl := sous.SourceLocation(tsl)
+	// we don't care about these flags when a manifest already exists
+	if _, ok := state.Manifests.Get(sl); ok {
+		return nowt, nil
+	}
 	if !flags.UseOTPLDeploy && !flags.IgnoreOTPLDeploy && len(detected.DeploySpecs) != 0 {
 		return nowt, UsageErrorf("otpl-deploy detected in config/, please specify either -use-otpl-deploy, or -ignore-otpl-deploy to proceed")
 	}

--- a/cli/graph_targetmanifest_test.go
+++ b/cli/graph_targetmanifest_test.go
@@ -92,3 +92,16 @@ func TestNewUserSelectedOTPLDeploySpecs(t *testing.T) {
 		}
 	}
 }
+
+func TestNewTargetManifest(t *testing.T) {
+	detected := UserSelectedOTPLDeploySpecs{}
+	sl := sous.MustParseSourceLocation("github.com/user/project")
+	tsl := TargetSourceLocation(sl)
+	m := &sous.Manifest{Source: sl}
+	s := sous.NewState()
+	s.Manifests.Add(m)
+	tm := newTargetManifest(detected, tsl, s)
+	if tm.Source != sl {
+		t.Errorf("unexpected manifest %q", m)
+	}
+}

--- a/cli/graph_targetmanifest_test.go
+++ b/cli/graph_targetmanifest_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"testing"
+
+	sous "github.com/opentable/sous/lib"
+)
+
+type newUserSelectedOTPLDeploySpecTest struct {
+	Detected            sous.DeploySpecs
+	TSL                 TargetSourceLocation
+	Flags               OTPLFlags
+	Clusters            sous.Clusters
+	Manifest            *sous.Manifest
+	ExpectedDeploySpecs sous.DeploySpecs
+	ExpectedErr         string
+}
+
+var nusodsTests = []newUserSelectedOTPLDeploySpecTest{
+	{},
+	{
+		Detected: sous.DeploySpecs{
+			"some-cluster": {},
+		},
+		ExpectedErr: "otpl-deploy detected in config/, please specify either -use-otpl-deploy, or -ignore-otpl-deploy to proceed",
+	},
+	{
+		Detected: sous.DeploySpecs{
+			"some-cluster": {},
+		},
+		Flags: OTPLFlags{IgnoreOTPLDeploy: true},
+	},
+	{
+		Clusters: sous.Clusters{
+			"some-cluster": nil,
+		},
+		Detected: sous.DeploySpecs{
+			"some-cluster": {},
+		},
+		Flags: OTPLFlags{UseOTPLDeploy: true},
+		ExpectedDeploySpecs: sous.DeploySpecs{
+			"some-cluster": {},
+		},
+	},
+	{
+		Clusters: sous.Clusters{
+			"some-cluster": nil,
+		},
+		Detected: sous.DeploySpecs{
+			"some-cluster": {},
+		},
+		Flags: OTPLFlags{IgnoreOTPLDeploy: true},
+	},
+	{
+		Flags:       OTPLFlags{UseOTPLDeploy: true},
+		ExpectedErr: "you specified -use-otpl-deploy, but no valid deployments were found in config/",
+	},
+}
+
+func TestNewUserSelectedOTPLDeploySpecs(t *testing.T) {
+	for _, test := range nusodsTests {
+		state := sous.NewState()
+		if test.Manifest != nil {
+			state.Manifests.MustAdd(test.Manifest)
+		}
+		state.Defs.Clusters = test.Clusters
+		ds, err := newUserSelectedOTPLDeploySpecs(
+			DetectedOTPLDeploySpecs{test.Detected},
+			test.TSL,
+			&test.Flags,
+			state,
+		)
+		if err != nil {
+			if test.ExpectedErr == "" {
+				t.Error(err)
+				continue
+			}
+			actualErr := err.Error()
+			if actualErr != test.ExpectedErr {
+				t.Errorf("got error %q; want %q", actualErr, test.ExpectedErr)
+			}
+			continue
+		}
+		if err == nil && test.ExpectedErr != "" {
+			t.Errorf("got nil; want error %q", test.ExpectedErr)
+			continue
+		}
+		actualLen := len(ds.DeploySpecs)
+		expectedLen := len(test.ExpectedDeploySpecs)
+		if actualLen != expectedLen {
+			t.Errorf("got %d deploy specs; want %d", actualLen, expectedLen)
+		}
+	}
+}

--- a/cli/graph_test.go
+++ b/cli/graph_test.go
@@ -12,7 +12,8 @@ func TestBuildGraph(t *testing.T) {
 	g := BuildGraph(&cmdr.CLI{}, ioutil.Discard, ioutil.Discard)
 	g.Add(&Sous{})
 	g.Add(&DeployFilterFlags{})
-	g.Add(&PolicyFlags{}) //provided by Build
+	g.Add(&PolicyFlags{}) //provided by SousBuild
+	g.Add(&OTPLFlags{})   //provided by SousInit and SousDeploy
 
 	if err := g.Test(); err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/cli/sous_deploy.go
+++ b/cli/sous_deploy.go
@@ -99,7 +99,7 @@ func (su *SousDeploy) Execute(args []string) cmdr.Result {
 func updateState(s *sous.State, gdm CurrentGDM, sid sous.SourceID, did sous.DeployID) error {
 	deployment, ok := gdm.Get(did)
 	if !ok {
-		log.Printf("Deployment %q does not exist, creating.\n", did)
+		sous.Log.Warn.Printf("Deployment %q does not exist, creating.\n", did)
 		deployment = &sous.Deployment{}
 	}
 

--- a/cli/sous_deploy.go
+++ b/cli/sous_deploy.go
@@ -12,7 +12,9 @@ import (
 
 // SousDeploy is the command description for `sous deploy`
 type SousDeploy struct {
-	DeployFilterFlags DeployFilterFlags
+	DeployFilterFlags
+	OTPLFlags
+	Manifest TargetManifest
 	*sous.SourceContext
 	WD          LocalWorkDirShell
 	GDM         CurrentGDM
@@ -37,14 +39,12 @@ func (su *SousDeploy) Help() string { return sousInitHelp }
 
 // AddFlags adds the flags for sous init.
 func (su *SousDeploy) AddFlags(fs *flag.FlagSet) {
-	err := AddFlags(fs, &su.DeployFilterFlags, rectifyFilterFlagsHelp+tagFlagHelp)
-	if err != nil {
+	if err := AddFlags(fs, &su.DeployFilterFlags, rectifyFilterFlagsHelp+tagFlagHelp); err != nil {
 		panic(err)
 	}
-	fs.BoolVar(&su.Flags.UseOTPLDeploy, "use-otpl-deploy", false,
-		"if specified, copies OpenTable-specific otpl-deploy configuration to the manifest")
-	fs.BoolVar(&su.Flags.IgnoreOTPLDeploy, "ignore-otpl-deploy", false,
-		"if specified, ignores OpenTable-specific otpl-deploy configuration")
+	if err := AddFlags(fs, &su.OTPLFlags, otplFlagsHelp); err != nil {
+		panic(err)
+	}
 }
 
 // RegisterOn adds the DeploymentConfig to the psyringe to configure the

--- a/cli/sous_deploy_test.go
+++ b/cli/sous_deploy_test.go
@@ -138,3 +138,19 @@ func TestUpdateState(t *testing.T) {
 		}
 	}
 }
+
+type DummyStateManager struct{}
+
+func (dsm *DummyStateManager) WriteState(s *sous.State) error  { return nil }
+func (dsm *DummyStateManager) ReadState() (*sous.State, error) { return nil, nil }
+
+func TestSousDeploy_Execute(t *testing.T) {
+	dsm := &DummyStateManager{}
+	su := SousUpdate{
+		StateReader: LocalStateReader{dsm},
+		StateWriter: LocalStateWriter{dsm},
+		GDM:         CurrentGDM{sous.MakeDeployments(0)},
+		Manifest:    TargetManifest{&sous.Manifest{}},
+	}
+	su.Execute(nil)
+}

--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"flag"
 
-	"github.com/opentable/sous/ext/otpl"
 	"github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/cmdr"
 )
@@ -12,6 +11,7 @@ import (
 type SousInit struct {
 	DeployFilterFlags
 	Flags         OTPLFlags
+	Target        TargetManifest
 	SourceContext *sous.SourceContext
 	WD            LocalWorkDirShell
 	GDM           CurrentGDM
@@ -50,54 +50,13 @@ func (si *SousInit) AddFlags(fs *flag.FlagSet) {
 
 // Execute fulfills the cmdr.Executor interface
 func (si *SousInit) Execute(args []string) cmdr.Result {
-	ctx := si.SourceContext
-	sourceLocation := ctx.SourceLocation()
-
-	ds := si.GDM.Filter(func(d *sous.Deployment) bool {
-		return d.SourceID.Location() == sourceLocation
-	})
-	if ds.Len() != 0 {
-		return UsageErrorf("init failed: manifest %q already exists", sourceLocation)
-	}
-
-	var deploySpecs, otplDeploySpecs sous.DeploySpecs
-	if !si.Flags.IgnoreOTPLDeploy {
-		otplParser := otpl.NewDeploySpecParser()
-		otplDeploySpecs = otplParser.GetDeploySpecs(si.WD.Sh)
-	}
-	if !si.Flags.UseOTPLDeploy && !si.Flags.IgnoreOTPLDeploy && len(otplDeploySpecs) != 0 {
-		return UsageErrorf("otpl-deploy detected in config/, please specify either -use-otpl-deploy, or -ignore-otpl-deploy to proceed")
-	}
-	if si.Flags.UseOTPLDeploy {
-		if len(otplDeploySpecs) == 0 {
-			return UsageErrorf("you specified -use-otpl-deploy, but no valid deployments were found in config/")
-		}
-		deploySpecs = sous.DeploySpecs{}
-		for clusterName, spec := range otplDeploySpecs {
-			if _, ok := si.State.Defs.Clusters[clusterName]; !ok {
-				sous.Log.Warn.Printf("otpl-deploy config for cluster %q ignored", clusterName)
-				continue
-			}
-			deploySpecs[clusterName] = spec
-		}
-	}
-	if len(deploySpecs) == 0 {
-		deploySpecs = defaultDeploySpecs()
-	}
-
-	m := &sous.Manifest{
-		Source:      sourceLocation,
-		Deployments: deploySpecs,
-	}
-
+	m := si.Target.Manifest
 	if ok := si.State.Manifests.Add(m); !ok {
 		return UsageErrorf("manifest %q already exists", m.ID())
 	}
-
 	if err := si.StateWriter.WriteState(si.State); err != nil {
 		return EnsureErrorResult(err)
 	}
-
 	return SuccessYAML(m)
 }
 

--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -17,7 +17,6 @@ type SousInit struct {
 	State         *sous.State
 	StateWriter   LocalStateWriter
 	Flags         struct {
-		RepoURL, RepoOffset             string
 		UseOTPLDeploy, IgnoreOTPLDeploy bool
 	}
 }

--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -11,14 +11,12 @@ import (
 // SousInit is the command description for `sous init`
 type SousInit struct {
 	DeployFilterFlags
+	Flags         OTPLFlags
 	SourceContext *sous.SourceContext
 	WD            LocalWorkDirShell
 	GDM           CurrentGDM
 	State         *sous.State
 	StateWriter   LocalStateWriter
-	Flags         struct {
-		UseOTPLDeploy, IgnoreOTPLDeploy bool
-	}
 }
 
 func init() { TopLevelCommands["init"] = &SousInit{} }
@@ -36,17 +34,18 @@ flesh out some additional details.
 // Help returns the help string for this command
 func (si *SousInit) Help() string { return sousInitHelp }
 
-// RegisterOn adds a zero DFF to the graph, because Init should assume a clean build
+// RegisterOn adds flag sets for sous init to the dependency injector.
 func (si *SousInit) RegisterOn(psy Addable) {
+	// Add a zero DepoyFilterFlags to the graph, as we assume a clean build.
 	psy.Add(&si.DeployFilterFlags)
+	psy.Add(&si.Flags)
 }
 
 // AddFlags adds the flags for sous init.
 func (si *SousInit) AddFlags(fs *flag.FlagSet) {
-	fs.BoolVar(&si.Flags.UseOTPLDeploy, "use-otpl-deploy", false,
-		"if specified, copies OpenTable-specific otpl-deploy configuration to the manifest")
-	fs.BoolVar(&si.Flags.IgnoreOTPLDeploy, "ignore-otpl-deploy", false,
-		"if specified, ignores OpenTable-specific otpl-deploy configuration")
+	if err := AddFlags(fs, &si.Flags, otplFlagsHelp); err != nil {
+		panic(err)
+	}
 }
 
 // Execute fulfills the cmdr.Executor interface

--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"flag"
-	"log"
 
 	"github.com/opentable/sous/ext/otpl"
 	"github.com/opentable/sous/lib"
@@ -78,7 +77,7 @@ func (si *SousInit) Execute(args []string) cmdr.Result {
 		deploySpecs = sous.DeploySpecs{}
 		for clusterName, spec := range otplDeploySpecs {
 			if _, ok := si.State.Defs.Clusters[clusterName]; !ok {
-				log.Printf("otpl-deploy config for cluster %q ignored", clusterName)
+				sous.Log.Warn.Printf("otpl-deploy config for cluster %q ignored", clusterName)
 				continue
 			}
 			deploySpecs[clusterName] = spec

--- a/cli/sous_update.go
+++ b/cli/sous_update.go
@@ -10,8 +10,8 @@ import (
 	"github.com/samsalisbury/semv"
 )
 
-// SousDeploy is the command description for `sous deploy`
-type SousDeploy struct {
+// SousUpdate is the command description for `sous update`
+type SousUpdate struct {
 	DeployFilterFlags
 	OTPLFlags
 	Manifest TargetManifest
@@ -26,19 +26,22 @@ type SousDeploy struct {
 	}
 }
 
-func init() { TopLevelCommands["deploy"] = &SousDeploy{} }
+func init() { TopLevelCommands["update"] = &SousUpdate{} }
 
 const sousUpdateHelp = `
-deploy a new version
+update the version to be deployed in a cluster
 
-usage: sous deploy -cluster <name> -tag <semver>
+usage: sous update -cluster <name> -tag <semver> [-use-otpl-deploy|-ignore-otpl-deploy]
+
+sous update will update the version tag for this application in the named
+cluster. You can then use 'sous rectify' to have that version deployed.
 `
 
 // Help returns the help string for this command
-func (su *SousDeploy) Help() string { return sousInitHelp }
+func (su *SousUpdate) Help() string { return sousUpdateHelp }
 
 // AddFlags adds the flags for sous init.
-func (su *SousDeploy) AddFlags(fs *flag.FlagSet) {
+func (su *SousUpdate) AddFlags(fs *flag.FlagSet) {
 	if err := AddFlags(fs, &su.DeployFilterFlags, rectifyFilterFlagsHelp+tagFlagHelp); err != nil {
 		panic(err)
 	}
@@ -49,13 +52,13 @@ func (su *SousDeploy) AddFlags(fs *flag.FlagSet) {
 
 // RegisterOn adds the DeploymentConfig to the psyringe to configure the
 // labeller and registrar
-func (su *SousDeploy) RegisterOn(psy Addable) {
+func (su *SousUpdate) RegisterOn(psy Addable) {
 	psy.Add(&su.DeployFilterFlags)
 	psy.Add(&su.OTPLFlags)
 }
 
 // Execute fulfills the cmdr.Executor interface.
-func (su *SousDeploy) Execute(args []string) cmdr.Result {
+func (su *SousUpdate) Execute(args []string) cmdr.Result {
 	sl := su.Manifest.ID()
 	sid, did, err := getIDs(su.DeployFilterFlags, sl)
 	if err != nil {

--- a/cli/sous_update.go
+++ b/cli/sous_update.go
@@ -21,9 +21,6 @@ type SousUpdate struct {
 	State       *sous.State
 	StateWriter LocalStateWriter
 	StateReader LocalStateReader
-	Flags       struct {
-		UseOTPLDeploy, IgnoreOTPLDeploy bool
-	}
 }
 
 func init() { TopLevelCommands["update"] = &SousUpdate{} }

--- a/ext/storage/disk_state_manager.go
+++ b/ext/storage/disk_state_manager.go
@@ -20,14 +20,6 @@ import (
 )
 
 type (
-	// StateReader knows how to read state.
-	StateReader interface {
-		ReadState() (*sous.State, error)
-	}
-	// StateWriter know how to write state.
-	StateWriter interface {
-		WriteState(*sous.State) error
-	}
 	// DiskStateManager implements StateReader and StateWriter using disk
 	// storage as its back-end.
 	DiskStateManager struct {

--- a/util/cmdr/errors.go
+++ b/util/cmdr/errors.go
@@ -3,8 +3,6 @@ package cmdr
 import (
 	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 type (
@@ -51,7 +49,6 @@ type (
 // intelligently, and eventially falls back to UnknownErr if no sensible
 // ErrorResult exists for that error.
 func EnsureErrorResult(err error) ErrorResult {
-	err = errors.Cause(err)
 	if result, ok := err.(ErrorResult); ok {
 		return result
 	}
@@ -112,6 +109,10 @@ func (e *cliErr) WithTip(tip string) ErrorResult {
 func (e *cliErr) WithUnderlyingError(err error) ErrorResult {
 	e.Err = err
 	return e
+}
+
+func (e *cliErr) UnderlyingError() error {
+	return e.Err
 }
 
 func (e *cliErr) prefix(prefix string) string {

--- a/util/cmdr/errors.go
+++ b/util/cmdr/errors.go
@@ -3,6 +3,8 @@ package cmdr
 import (
 	"fmt"
 	"os"
+
+	"github.com/pkg/errors"
 )
 
 type (
@@ -49,6 +51,7 @@ type (
 // intelligently, and eventially falls back to UnknownErr if no sensible
 // ErrorResult exists for that error.
 func EnsureErrorResult(err error) ErrorResult {
+	err = errors.Cause(err)
 	if result, ok := err.(ErrorResult); ok {
 		return result
 	}


### PR DESCRIPTION
Includes #126 

'sous deploy' now calls 'sous init' internally if the target manifest does not exist.

The way this is achieved leaves something to be desired, in that we manually re-read state and re-compute the GDM, but it works and get us closer to our goal.