### PR TITLE
Reject un-accepable advisories on deploy. TECHOPS-485

### DIFF
--- a/ext/docker/builder.go
+++ b/ext/docker/builder.go
@@ -115,7 +115,11 @@ func (b *Builder) recordName(br *sous.BuildResult, bc *sous.BuildContext) error 
 	sv := bc.Version()
 	in := b.VersionTag(bc.Version())
 	b.SourceShell.ConsoleEcho(fmt.Sprintf("[recording \"%s\" as the docker name for \"%s\"]", in, sv.String()))
-	return b.ImageMapper.insert(sv, in, "")
+	var qs []quality
+	for _, adv := range br.Advisories {
+		qs = append(qs, quality{name: adv, kind: "advisory"})
+	}
+	return b.ImageMapper.insert(sv, in, "", qs)
 }
 
 // VersionTag computes an image tag from a SourceVersion's version

--- a/ext/docker/builder.go
+++ b/ext/docker/builder.go
@@ -115,9 +115,9 @@ func (b *Builder) recordName(br *sous.BuildResult, bc *sous.BuildContext) error 
 	sv := bc.Version()
 	in := b.VersionTag(bc.Version())
 	b.SourceShell.ConsoleEcho(fmt.Sprintf("[recording \"%s\" as the docker name for \"%s\"]", in, sv.String()))
-	var qs []quality
+	var qs []sous.Quality
 	for _, adv := range br.Advisories {
-		qs = append(qs, quality{name: adv, kind: "advisory"})
+		qs = append(qs, sous.Quality{Name: adv, Kind: "advisory"})
 	}
 	return b.ImageMapper.insert(sv, in, "", qs)
 }

--- a/ext/docker/image_mapping.go
+++ b/ext/docker/image_mapping.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
+	"log"
 	"regexp"
 	"strings"
 	"text/tabwriter"
@@ -47,8 +48,13 @@ type (
 
 // NewBuildArtifact creates a new sous.BuildArtifact representing a Docker
 // image.
-func NewBuildArtifact(imageName string) *sous.BuildArtifact {
-	return &sous.BuildArtifact{Name: imageName, Type: "docker"}
+func NewBuildArtifact(imageName string, qstrs strpairs) *sous.BuildArtifact {
+	var qs []sous.Quality
+	for _, qstr := range qstrs {
+		qs = append(qs, sous.Quality{Name: qstr[0], Kind: qstr[1]})
+	}
+
+	return &sous.BuildArtifact{Name: imageName, Type: "docker", Qualities: qs}
 }
 
 // InMemory configures SQLite to use an in-memory database
@@ -97,7 +103,7 @@ func (nc *NameCache) Warmup(r string) error {
 		Log.Debug.Printf("Harvested tag: %v for repo: %v", t, r)
 		in, err := reference.WithTag(ref, t)
 		if err == nil {
-			a := NewBuildArtifact(in.String())
+			a := NewBuildArtifact(in.String(), strpairs{})
 			nc.GetSourceID(a) //pull it into the cache...
 		}
 	}
@@ -106,11 +112,11 @@ func (nc *NameCache) Warmup(r string) error {
 
 // GetArtifact implements sous.Registry.GetArtifact
 func (nc *NameCache) GetArtifact(sid sous.SourceID) (*sous.BuildArtifact, error) {
-	name, err := nc.getImageName(sid)
+	name, qls, err := nc.getImageName(sid)
 	if err != nil {
 		return nil, err
 	}
-	return NewBuildArtifact(name), nil
+	return NewBuildArtifact(name, qls), nil
 }
 
 // GetSourceID looks up the source ID for a given image name
@@ -172,42 +178,39 @@ func (nc *NameCache) GetSourceID(a *sous.BuildArtifact) (sous.SourceID, error) {
 }
 
 // GetImageName returns the docker image name for a given source ID
-func (nc *NameCache) getImageName(sid sous.SourceID) (string, error) {
+func (nc *NameCache) getImageName(sid sous.SourceID) (string, strpairs, error) {
 	Log.Vomit.Printf("Getting image name for %+v", sid)
-	cn, _, err := nc.dbQueryOnSourceID(sid)
+	cn, _, qls, err := nc.dbQueryOnSourceID(sid)
 	if _, ok := errors.Cause(err).(NoImageNameFound); ok {
 		Log.Vomit.Print(err)
 		err = nc.harvest(sid.Location())
 		if err != nil {
 			Log.Vomit.Printf("Err: %v", err)
-			return "", err
+			return "", nil, err
 		}
 
-		cn, _, err = nc.dbQueryOnSourceID(sid)
+		cn, _, qls, err = nc.dbQueryOnSourceID(sid)
 		if err != nil {
 			Log.Vomit.Printf("Err: %v", err)
-			return "", err
+			return "", nil, err
 		}
 	} else if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	Log.Debug.Printf("Source ID: %v -> image name %s", sid, cn)
-	return cn, nil
+	return cn, qls, nil
 }
 
-type quality struct {
-	name, kind string
-}
-
-func qualitiesFromLabels(lm map[string]string) []quality {
+func qualitiesFromLabels(lm map[string]string) []sous.Quality {
 	advs, ok := lm[`com.opentable.sous.advisories`]
 	if !ok {
-		return []quality{}
+		return []sous.Quality{}
 	}
-	var qs []quality
+	var qs []sous.Quality
 	for _, adv := range strings.Split(advs, `,`) {
-		qs = append(qs, quality{name: adv, kind: "advisory"})
+		qs = append(qs, sous.Quality{Name: adv, Kind: "advisory"})
 	}
+	return qs
 }
 
 // GetCanonicalName returns the canonical name for an image given any known name
@@ -219,7 +222,8 @@ func (nc *NameCache) GetCanonicalName(in string) (string, error) {
 
 // Insert puts a given SourceID/image name pair into the name cache
 // used by Builder at the moment to register after a build
-func (nc *NameCache) insert(sid sous.SourceID, in, etag string, qs []quality) error {
+func (nc *NameCache) insert(sid sous.SourceID, in, etag string, qs []sous.Quality) error {
+	log.Printf("%+v", qs)
 	return nc.dbInsert(sid, in, etag, qs)
 }
 
@@ -435,11 +439,12 @@ func (nc *NameCache) ensureInDB(sel, ins string, args ...interface{}) (id int64,
 	return id, errors.Wrapf(err, "getting id of new value: %q %v", ins, args[0:insN])
 }
 
-func (nc *NameCache) dbInsert(sid sous.SourceID, in, etag string, quals []quality) error {
+func (nc *NameCache) dbInsert(sid sous.SourceID, in, etag string, quals []sous.Quality) error {
+	log.Printf("%+v", quals)
 	ref, err := reference.ParseNamed(in)
 	Log.Debug.Printf("Parsed image name: %v from %q", ref, in)
 	if err != nil {
-		return fmt.Errorf("%v for %v", err, in)
+		return errors.Errorf("%v for %v", err, in)
 	}
 
 	Log.Vomit.Printf("Inserting name %s for %#v", ref.Name(), sid)
@@ -485,12 +490,14 @@ func (nc *NameCache) dbInsert(sid sous.SourceID, in, etag string, quals []qualit
 		return err
 	}
 
+	log.Printf("%+v", quals)
 	for _, q := range quals {
+		log.Printf("%+v", q)
 		nc.DB.Exec("insert into docker_image_qualities"+
 			"  (metadata_id, quality, kind)"+
 			"  values"+
 			"  ($1,$2,$3)",
-			id, q.name, q.kind)
+			id, q.Name, q.Kind)
 	}
 
 	Log.Vomit.Printf("Inserting search name %v %v", id, in)
@@ -592,8 +599,10 @@ func (nc *NameCache) dbQueryAllSourceIds() (ids []sous.SourceID, err error) {
 	return
 }
 
-func (nc *NameCache) dbQueryOnSourceID(sid sous.SourceID) (cn string, ins []string, err error) {
-	ins = make([]string, 0)
+type strpairs []strpair
+type strpair [2]string
+
+func (nc *NameCache) dbQueryOnSourceID(sid sous.SourceID) (cn string, ins []string, quals strpairs, err error) {
 	rows, err := nc.DB.Query("select docker_search_metadata.canonicalName, "+
 		"docker_search_name.name "+
 		"from "+
@@ -624,6 +633,28 @@ func (nc *NameCache) dbQueryOnSourceID(sid sous.SourceID) (cn string, ins []stri
 	if len(ins) == 0 {
 		err = errors.Wrap(NoImageNameFound{sid}, "")
 	}
+	if err != nil {
+		return
+	}
+
+	rows, err = nc.DB.Query("select"+
+		" docker_image_qualities.quality,"+
+		" docker_image_qualities.kind"+
+		"   from"+
+		" docker_image_qualities natural join docker_search_metadata"+
+		" where"+
+		" docker_search_metadata.canonicalName = $1", cn)
+
+	if err != nil {
+		return
+	}
+
+	for rows.Next() {
+		var pr strpair
+		rows.Scan(&pr[0], &pr[1])
+		quals = append(quals, pr)
+	}
+	err = rows.Err()
 
 	return
 }

--- a/ext/singularity/dummy_rectification_client.go
+++ b/ext/singularity/dummy_rectification_client.go
@@ -103,7 +103,7 @@ func (t *DummyRectificationClient) DeleteRequest(
 
 // ImageLabels gets the labels for an image name
 func (t *DummyRectificationClient) ImageLabels(in string) (map[string]string, error) {
-	a := docker.NewBuildArtifact(in)
+	a := docker.NewBuildArtifact(in, nil)
 	sv, err := t.nameCache.GetSourceID(a)
 	if err != nil {
 		return map[string]string{}, nil

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -164,7 +164,7 @@ func (ra *RectiAgent) Scale(cluster, reqID string, instanceCount int, message st
 
 // ImageLabels gets the labels for an image name.
 func (ra *RectiAgent) ImageLabels(in string) (map[string]string, error) {
-	a := docker.NewBuildArtifact(in)
+	a := docker.NewBuildArtifact(in, nil)
 	sv, err := ra.nameCache.GetSourceID(a)
 	if err != nil {
 		return map[string]string{}, errors.Wrapf(err, "Image name: %s", in)

--- a/ext/storage/testdata/in/defs.yaml
+++ b/ext/storage/testdata/in/defs.yaml
@@ -5,10 +5,12 @@ Clusters:
     Kind: singularity
     BaseURL: http://singularity.example.com
     Env: {}
+    AllowedAdvisories: []
   other-cluster:
     Name: ""
     Kind: singularity
     BaseURL: http://some.singularity.cluster
     Env: {}
+    AllowedAdvisories: []
 EnvVars: []
 Resources: []

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -275,7 +275,7 @@ func manifest(nc sous.Registry, drepo, containerDir, sourceURL, version string) 
 	in := BuildImageName(drepo, version)
 	BuildAndPushContainer(containerDir, in)
 
-	nc.GetSourceID(docker.NewBuildArtifact(in))
+	nc.GetSourceID(docker.NewBuildArtifact(in, nil))
 
 	return &sous.Manifest{
 		Source: sous.SourceLocation{

--- a/lib/buildpack.go
+++ b/lib/buildpack.go
@@ -24,7 +24,17 @@ type (
 	// BuildArtifact describes the actual built binary Sous will deploy
 	BuildArtifact struct {
 		Name, Type string
+		Qualities  []Quality
 	}
+
+	// A Quality represents a characteristic of a BuildArtifact that needs to be recorded.
+	Quality struct {
+		Name string
+		// Kind is the the kind of this quality
+		// Known kinds include: advisory
+		Kind string
+	}
+
 	// Buildpack is a set of instructions used to build a particular
 	// kind of project.
 	Buildpack interface {

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -3,8 +3,6 @@ package sous
 type (
 	// Registry describes a system for mapping SourceIDs to BuildArtifacts and vice versa
 	Registry interface {
-		// GetAdvisories gets all the advisories on the image associated with sourceID.
-		GetAdvisories(SourceID) (Advisories, error)
 		// GetArtifact gets the build artifact address for a source ID.
 		// It does not guarantee that that artifact exists.
 		GetArtifact(SourceID) (*BuildArtifact, error)

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -3,6 +3,8 @@ package sous
 type (
 	// Registry describes a system for mapping SourceIDs to BuildArtifacts and vice versa
 	Registry interface {
+		// GetAdvisories gets all the advisories on the image associated with sourceID.
+		GetAdvisories(SourceID) (Advisories, error)
 		// GetArtifact gets the build artifact address for a source ID.
 		// It does not guarantee that that artifact exists.
 		GetArtifact(SourceID) (*BuildArtifact, error)

--- a/lib/resolve_errors.go
+++ b/lib/resolve_errors.go
@@ -12,11 +12,19 @@ type (
 		Causes []error
 	}
 
-	// MissingImageNamesError reports that we couldn't get names for one or
+	// MissingImageNameError reports that we couldn't get names for one or
 	// more source IDs.
-	MissingImageNamesError struct {
-		Causes []error
+	MissingImageNameError struct {
+		Cause error
 	}
+
+	// An UnacceptableAdvisory reports that there is an advisory on an image
+	// which hasn't been whitelisted on the target cluster
+	UnacceptableAdvisory struct {
+		Quality
+		*SourceID
+	}
+
 	// CreateError is returned when there's an error trying to create a deployment
 	CreateError struct {
 		Deployment *Deployment
@@ -52,13 +60,12 @@ func (re *ResolveErrors) Error() string {
 	return strings.Join(s, "\n  ")
 }
 
-func (e *MissingImageNamesError) Error() string {
-	causeStrs := make([]string, 0, len(e.Causes)+1)
-	causeStrs = append(causeStrs, "Image names are unknown to Sous for source IDs")
-	for _, c := range e.Causes {
-		causeStrs = append(causeStrs, c.Error())
-	}
-	return strings.Join(causeStrs, "  \n")
+func (e *MissingImageNameError) Error() string {
+	return fmt.Sprintf("Image name unknown to Sous for source IDs: %s", e.Cause.Error())
+}
+
+func (e *UnacceptableAdvisory) Error() string {
+	return fmt.Sprintf("Advisory unaccepatable on image: %s for %v", e.Quality.Name, e.SourceID)
 }
 
 func (e *CreateError) Error() string {

--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -86,5 +86,5 @@ func guardImageNamesKnown(r Registry, gdm Deployments) error {
 }
 
 func guardAdvisoriesAcceptable(r Registry, gdm Deployments) error {
-
+	return nil
 }

--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -82,7 +82,20 @@ func guardImages(r Registry, gdm Deployments) error {
 		for _, q := range art.Qualities {
 			log.Printf("%+v", q)
 			if q.Kind == `advisory` {
-				es = append(es, &UnacceptableAdvisory{q, &d.SourceID})
+				found := false
+				var advs []string
+				if d.Cluster != nil {
+					advs = d.Cluster.AllowedAdvisories
+				}
+				for _, aa := range advs {
+					if aa == q.Name {
+						found = true
+						break
+					}
+				}
+				if !found {
+					es = append(es, &UnacceptableAdvisory{q, &d.SourceID})
+				}
 			}
 		}
 	}

--- a/lib/resolver_test.go
+++ b/lib/resolver_test.go
@@ -1,0 +1,31 @@
+package sous
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nyarly/testify/assert"
+	"github.com/nyarly/testify/require"
+	"github.com/pkg/errors"
+)
+
+func TestGuardImages(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	svOne := MustParseSourceID(`github.com/ot/one,1.3.5`)
+	svTwo := MustParseSourceID(`github.com/ot/two,2.3.5`)
+	dr := NewDummyRegistry()
+	missing := Deployment{ClusterName: `x`, SourceID: svOne}
+	rejected := Deployment{ClusterName: `x`, SourceID: svTwo}
+	gdm := MakeDeployments(2)
+	gdm.Add(&missing)
+	gdm.Add(&rejected)
+
+	dr.FeedArtifact(nil, fmt.Errorf("dummy error"))
+	dr.FeedArtifact(&BuildArtifact{"ot-docker/one", "docker", []Quality{{"ephemeral_tag", "advisory"}}}, nil)
+
+	err := errors.Cause(guardImages(dr, gdm)).(*ResolveErrors)
+	assert.Error(err)
+	require.Len(err.Causes, 2)
+}

--- a/lib/resolver_test.go
+++ b/lib/resolver_test.go
@@ -29,3 +29,25 @@ func TestGuardImages(t *testing.T) {
 	assert.Error(err)
 	require.Len(err.Causes, 2)
 }
+
+func TestAllowsWhitelistedAdvisories(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	svOne := MustParseSourceID(`github.com/ot/one,1.3.5`)
+	dr := NewDummyRegistry()
+	intoCI := Deployment{ClusterName: `ci`, Cluster: &Cluster{AllowedAdvisories: []string{"ephemeral_tag"}}, SourceID: svOne}
+	intoProd := Deployment{ClusterName: `prod`, Cluster: &Cluster{}, SourceID: svOne}
+	gdm := MakeDeployments(2)
+	gdm.Add(&intoCI)
+	gdm.Add(&intoProd)
+
+	dr.FeedArtifact(&BuildArtifact{"ot-docker/one", "docker", []Quality{{"ephemeral_tag", "advisory"}}}, nil)
+	dr.FeedArtifact(&BuildArtifact{"ot-docker/one", "docker", []Quality{{"ephemeral_tag", "advisory"}}}, nil)
+
+	err := errors.Cause(guardImages(dr, gdm)).(*ResolveErrors)
+	assert.Error(err)
+	require.Len(err.Causes, 1)
+	require.IsType(&UnacceptableAdvisory{}, err.Causes[0])
+
+}

--- a/lib/state.go
+++ b/lib/state.go
@@ -58,6 +58,9 @@ type (
 		BaseURL string
 		// Env is the default environment for all deployments in this region.
 		Env EnvDefaults
+		// AllowedAdvisories lists the artifact advisories which are permissible in
+		// this cluster
+		AllowedAdvisories []string
 	}
 
 	// EnvDefaults is a list of named environment variables along with their values.


### PR DESCRIPTION
During resolution, deployments are checked against their build artifacts.
Advisories on the artifacts are compared to a whitelist configured for the
cluster in defs.yaml. If the advisory isn't listed, the deploy fails.