### PR TITLE
Fixes mute "no such flag" errors

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -65,7 +65,8 @@ func NewSousCLI(v semv.Version, out, errout io.Writer) (*cmdr.CLI, error) {
 
 	cli := &cmdr.CLI{
 		Root: s,
-		Out:  stdout, Err: stderr,
+		Out:  stdout,
+		Err:  stderr,
 		// HelpCommand is shown to the user if they type something that looks
 		// like they want help, but which isn't recognised by Sous properly. It
 		// uses the standard flag.ErrHelp value to decide whether or not to show

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/nyarly/testify/assert"
@@ -228,8 +229,22 @@ func TestInvokeQueryArtifacts(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(exe)
 }
-
 */
+func TestInvokeWithUnknownFlags(t *testing.T) {
+	log.SetFlags(log.Flags() | log.Lshortfile)
+	assert := assert.New(t)
+	require := require.New(t)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	c, err := NewSousCLI(semv.MustParse(`1.2.3`), stdout, stderr)
+	require.NoError(err)
+
+	c.Invoke([]string{`sous`, `-cobblers`})
+	assert.Regexp(`flag provided but not defined`, stderr.String())
+}
+
 func TestInvokeRectifyWithDebugFlags(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/util/cmdr/errors.go
+++ b/util/cmdr/errors.go
@@ -112,6 +112,9 @@ func (e *cliErr) WithUnderlyingError(err error) ErrorResult {
 }
 
 func (e *cliErr) UnderlyingError() error {
+	if e.Err == nil {
+		return e
+	}
 	return e.Err
 }
 


### PR DESCRIPTION
Stumbled into this as I was working with demo-service