### PR TITLE
Makes "tag not head" and "ephemeral tag" exclusive of one another

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -65,7 +65,8 @@ func NewSousCLI(v semv.Version, out, errout io.Writer) (*cmdr.CLI, error) {
 
 	cli := &cmdr.CLI{
 		Root: s,
-		Out:  stdout, Err: stderr,
+		Out:  stdout,
+		Err:  stderr,
 		// HelpCommand is shown to the user if they type something that looks
 		// like they want help, but which isn't recognised by Sous properly. It
 		// uses the standard flag.ErrHelp value to decide whether or not to show

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/nyarly/testify/assert"
@@ -228,8 +229,22 @@ func TestInvokeQueryArtifacts(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(exe)
 }
-
 */
+func TestInvokeWithUnknownFlags(t *testing.T) {
+	log.SetFlags(log.Flags() | log.Lshortfile)
+	assert := assert.New(t)
+	require := require.New(t)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	c, err := NewSousCLI(semv.MustParse(`1.2.3`), stdout, stderr)
+	require.NoError(err)
+
+	c.Invoke([]string{`sous`, `-cobblers`})
+	assert.Regexp(`flag provided but not defined`, stderr.String())
+}
+
 func TestInvokeRectifyWithDebugFlags(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/lib/build_config.go
+++ b/lib/build_config.go
@@ -146,11 +146,6 @@ func (c *BuildConfig) Advisories(ctx *BuildContext) (advs []string) {
 		advs = append(advs, string(Unversioned))
 	}
 
-	if s.NearestTagRevision != s.Revision {
-		Log.Debug.Printf("%s != %s", s.NearestTagRevision, s.Revision)
-		advs = append(advs, string(TagNotHead))
-	}
-
 	if c.Tag != "" {
 		hasTag := false
 		for _, t := range s.Tags {
@@ -161,6 +156,9 @@ func (c *BuildConfig) Advisories(ctx *BuildContext) (advs []string) {
 		}
 		if !hasTag {
 			advs = append(advs, string(EphemeralTag))
+		} else if s.NearestTagRevision != s.Revision {
+			Log.Debug.Printf("%s != %s", s.NearestTagRevision, s.Revision)
+			advs = append(advs, string(TagNotHead))
 		}
 	}
 

--- a/lib/build_config_test.go
+++ b/lib/build_config_test.go
@@ -191,7 +191,7 @@ func TestEphemeralTag(t *testing.T) {
 				PrimaryRemoteURL:   "github.com/opentable/present",
 				Revision:           "abcd",
 				NearestTagName:     "1.2.0",
-				NearestTagRevision: "abcd",
+				NearestTagRevision: "3541",
 			},
 		},
 	}
@@ -222,6 +222,7 @@ func TestEphemeralTag(t *testing.T) {
 	ctx := bc.NewContext()
 	assert.Equal(`1.2.3+abcd`, ctx.Source.Version().Version.String())
 	assert.Contains(ctx.Advisories, string(EphemeralTag))
+	assert.NotContains(ctx.Advisories, string(TagNotHead))
 	assert.NoError(bc.GuardRegister(ctx))
 }
 

--- a/util/cmdr/errors.go
+++ b/util/cmdr/errors.go
@@ -112,6 +112,9 @@ func (e *cliErr) WithUnderlyingError(err error) ErrorResult {
 }
 
 func (e *cliErr) UnderlyingError() error {
+	if e.Err == nil {
+		return e
+	}
 	return e.Err
 }
 


### PR DESCRIPTION
Otherwise it's almost impossible to effectively use ephemeral tag, because
it's always tag not head as well.