### PR TITLE
Adding a porcelain `sous deploy`

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -65,7 +65,8 @@ func NewSousCLI(v semv.Version, out, errout io.Writer) (*cmdr.CLI, error) {
 
 	cli := &cmdr.CLI{
 		Root: s,
-		Out:  stdout, Err: stderr,
+		Out:  stdout,
+		Err:  stderr,
 		// HelpCommand is shown to the user if they type something that looks
 		// like they want help, but which isn't recognised by Sous properly. It
 		// uses the standard flag.ErrHelp value to decide whether or not to show

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/nyarly/testify/assert"
@@ -228,8 +229,22 @@ func TestInvokeQueryArtifacts(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(exe)
 }
-
 */
+func TestInvokeWithUnknownFlags(t *testing.T) {
+	log.SetFlags(log.Flags() | log.Lshortfile)
+	assert := assert.New(t)
+	require := require.New(t)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	c, err := NewSousCLI(semv.MustParse(`1.2.3`), stdout, stderr)
+	require.NoError(err)
+
+	c.Invoke([]string{`sous`, `-cobblers`})
+	assert.Regexp(`flag provided but not defined`, stderr.String())
+}
+
 func TestInvokeRectifyWithDebugFlags(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -65,6 +65,14 @@ func TestInvokeUpdate(t *testing.T) {
 	assert.Len(exe.Args, 0)
 }
 
+func TestInvokeDeploy(t *testing.T) {
+	assert := assert.New(t)
+
+	exe := justCommand(t, []string{`sous`, `update`})
+	assert.NotNil(exe)
+	assert.Len(exe.Args, 0)
+}
+
 /*
 usage: sous context
 

--- a/cli/sous_deploy.go
+++ b/cli/sous_deploy.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"flag"
+
+	"github.com/opentable/sous/util/cmdr"
+)
+
+// SousDeploy is the command description for `sous deploy`
+type SousDeploy struct {
+	*cmdr.CLI
+	DeployFilterFlags
+	OTPLFlags
+	components struct {
+		SousUpdate
+		SousRectify
+	}
+	rectifyFlags struct {
+		dryrun string
+	}
+}
+
+func init() { TopLevelCommands["deploy"] = &SousDeploy{} }
+
+const sousDeployHelp = `
+deploys a new version into a particular cluster
+
+usage: sous deploy -cluster <name> -tag <semver> [-use-otpl-deploy|-ignore-otpl-deploy]
+
+sous deploy will deploy the version tag for this application in the named
+cluster.
+`
+
+// Help returns the help string for this command
+func (sd *SousDeploy) Help() string { return sousDeployHelp }
+
+// AddFlags adds the flags for sous init.
+func (sd *SousDeploy) AddFlags(fs *flag.FlagSet) {
+	if err := AddFlags(fs, &sd.DeployFilterFlags, rectifyFilterFlagsHelp+tagFlagHelp); err != nil {
+		panic(err)
+	}
+	if err := AddFlags(fs, &sd.OTPLFlags, otplFlagsHelp); err != nil {
+		panic(err)
+	}
+
+	fs.StringVar(&sd.rectifyFlags.dryrun, "dry-run", "none",
+		"prevent rectify from actually changing things - "+
+			"values are none,scheduler,registry,both")
+}
+
+// RegisterOn adds the DeploymentConfig to the psyringe to configure the
+// labeller and registrar
+func (sd *SousDeploy) RegisterOn(psy Addable) {
+	psy.Add(&sd.DeployFilterFlags)
+	psy.Add(&sd.OTPLFlags)
+}
+
+// Execute fulfills the cmdr.Executor interface.
+func (sd *SousDeploy) Execute(args []string) cmdr.Result {
+	su := sd.components.SousUpdate
+	sr := sd.components.SousRectify
+
+	su.DeployFilterFlags = sd.DeployFilterFlags
+	su.OTPLFlags = sd.OTPLFlags
+	res := su.Execute(args)
+	if !sd.CLI.OutputResult(res) {
+		return res
+	}
+
+	sr.SourceFlags = sd.DeployFilterFlags
+	sr.flags.dryrun = sd.rectifyFlags.dryrun
+	return sr.Execute([]string{})
+}

--- a/cli/sous_harvest.go
+++ b/cli/sous_harvest.go
@@ -16,9 +16,10 @@ type SousHarvest struct {
 
 func init() { TopLevelCommands["harvest"] = &SousHarvest{} }
 
-const sousHarvestHelp = `sous harvest <repo>...
+const sousHarvestHelp = `
 Retrieve data from images in an artifact repostiory
 
+usage: sous harvest <repo>...
 `
 
 // Help prints the help

--- a/ext/docker/builder.go
+++ b/ext/docker/builder.go
@@ -71,10 +71,10 @@ func (b *Builder) Register(br *sous.BuildResult, bc *sous.BuildContext) error {
 
 // ApplyMetadata applies container metadata etc. to a container
 func (b *Builder) ApplyMetadata(br *sous.BuildResult, bc *sous.BuildContext) error {
-	versionName := b.VersionTag(bc.Version())
-	revisionName := b.RevisionTag(bc.Version())
+	br.VersionName = b.VersionTag(bc.Version())
+	br.RevisionName = b.RevisionTag(bc.Version())
 
-	c := b.SourceShell.Cmd("docker", "build", "-t", versionName, "-t", revisionName, "-")
+	c := b.SourceShell.Cmd("docker", "build", "-t", br.VersionName, "-t", br.RevisionName, "-")
 	bf := b.metadataDockerfile(br, bc)
 	c.SetStdin(bf)
 

--- a/ext/otpl/otpl.go
+++ b/ext/otpl/otpl.go
@@ -3,7 +3,6 @@
 package otpl
 
 import (
-	"log"
 	"path"
 	"strconv"
 	"sync"
@@ -42,7 +41,7 @@ func (sr SingularityResources) SousResources() sous.Resources {
 }
 
 func NewDeploySpecParser() *DeploySpecParser {
-	return &DeploySpecParser{debugf: log.Printf, debug: log.Println}
+	return &DeploySpecParser{debugf: sous.Log.Debug.Printf, debug: sous.Log.Debug.Println}
 }
 
 type namedDeploySpec struct {

--- a/lib/build_config.go
+++ b/lib/build_config.go
@@ -146,11 +146,6 @@ func (c *BuildConfig) Advisories(ctx *BuildContext) (advs []string) {
 		advs = append(advs, string(Unversioned))
 	}
 
-	if s.NearestTagRevision != s.Revision {
-		Log.Debug.Printf("%s != %s", s.NearestTagRevision, s.Revision)
-		advs = append(advs, string(TagNotHead))
-	}
-
 	if c.Tag != "" {
 		hasTag := false
 		for _, t := range s.Tags {
@@ -161,6 +156,9 @@ func (c *BuildConfig) Advisories(ctx *BuildContext) (advs []string) {
 		}
 		if !hasTag {
 			advs = append(advs, string(EphemeralTag))
+		} else if s.NearestTagRevision != s.Revision {
+			Log.Debug.Printf("%s != %s", s.NearestTagRevision, s.Revision)
+			advs = append(advs, string(TagNotHead))
 		}
 	}
 

--- a/lib/build_config.go
+++ b/lib/build_config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/samsalisbury/semv"
 )
 
 type (
@@ -90,6 +92,14 @@ func (c *BuildConfig) chooseOffset() string {
 		return ""
 	}
 	return clean
+}
+
+// Validate checks that the Config is well formed
+func (c *BuildConfig) Validate() error {
+	if _, ve := semv.Parse(c.Tag); ve != nil {
+		return fmt.Errorf("build config: tag format %q invalid: %s", c.Tag, ve)
+	}
+	return nil
 }
 
 // GuardStrict returns an error if there are imperfections in the proposed build

--- a/lib/build_config_test.go
+++ b/lib/build_config_test.go
@@ -191,7 +191,7 @@ func TestEphemeralTag(t *testing.T) {
 				PrimaryRemoteURL:   "github.com/opentable/present",
 				Revision:           "abcd",
 				NearestTagName:     "1.2.0",
-				NearestTagRevision: "abcd",
+				NearestTagRevision: "3541",
 			},
 		},
 	}
@@ -222,6 +222,7 @@ func TestEphemeralTag(t *testing.T) {
 	ctx := bc.NewContext()
 	assert.Equal(`1.2.3+abcd`, ctx.Source.Version().Version.String())
 	assert.Contains(ctx.Advisories, string(EphemeralTag))
+	assert.NotContains(ctx.Advisories, string(TagNotHead))
 	assert.NoError(bc.GuardRegister(ctx))
 }
 

--- a/lib/build_manager.go
+++ b/lib/build_manager.go
@@ -20,6 +20,7 @@ func (m *BuildManager) Build() (br *BuildResult, e error) {
 	var bc *BuildContext
 
 	e = firsterr.Returned(
+		func() (e error) { return m.BuildConfig.Validate() },
 		func() (e error) { bc = m.BuildConfig.NewContext(); return nil },
 		func() (e error) { e = m.BuildConfig.GuardStrict(bc); return },
 		func() (e error) { bp, e = m.SelectBuildpack(bc); return },

--- a/lib/build_result_test.go
+++ b/lib/build_result_test.go
@@ -1,0 +1,24 @@
+package sous
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/nyarly/testify/assert"
+)
+
+func TestBuildResultString(t *testing.T) {
+	assert := assert.New(t)
+
+	br := &BuildResult{
+		Elapsed:     time.Second * 5,
+		Advisories:  []string{"ephemeral tag"},
+		VersionName: "something-something-2.3.4",
+	}
+
+	str := fmt.Sprintln(br)
+	assert.Regexp(`ephemeral`, str)
+	assert.Regexp(`2.3.4`, str)
+	assert.Regexp(`5`, str)
+}

--- a/lib/buildpack.go
+++ b/lib/buildpack.go
@@ -1,6 +1,10 @@
 package sous
 
-import "time"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
 
 type (
 	// A Selector selects the buildpack for a given build context
@@ -63,4 +67,12 @@ type (
 
 func (s *EchoSelector) SelectBuildpack(c *BuildContext) (Buildpack, error) {
 	return s.Factory(c)
+}
+
+func (br *BuildResult) String() string {
+	str := fmt.Sprintf("Built: %q", br.ImageID)
+	if len(br.Advisories) > 0 {
+		str = str + "\nAdvisories:\n  " + strings.Join(br.Advisories, "  \n")
+	}
+	return fmt.Sprintf("%s\nElapsed: %v", str, br.Elapsed)
 }

--- a/lib/buildpack.go
+++ b/lib/buildpack.go
@@ -70,7 +70,7 @@ func (s *EchoSelector) SelectBuildpack(c *BuildContext) (Buildpack, error) {
 }
 
 func (br *BuildResult) String() string {
-	str := fmt.Sprintf("Built: %q", br.ImageID)
+	str := fmt.Sprintf("Built: %q", br.VersionName)
 	if len(br.Advisories) > 0 {
 		str = str + "\nAdvisories:\n  " + strings.Join(br.Advisories, "  \n")
 	}

--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -1,7 +1,6 @@
 package sous
 
 import (
-	"log"
 	"sync"
 
 	"github.com/opentable/sous/util/firsterr"
@@ -80,7 +79,6 @@ func guardImages(r Registry, gdm Deployments) error {
 			continue
 		}
 		for _, q := range art.Qualities {
-			log.Printf("%+v", q)
 			if q.Kind == `advisory` {
 				found := false
 				var advs []string

--- a/util/cmdr/cli.go
+++ b/util/cmdr/cli.go
@@ -88,13 +88,17 @@ func (c *CLI) AddGlobalFlagSetFunc(f func(*flag.FlagSet)) {
 // all command output. It then returns the result for further processing.
 func (c *CLI) Invoke(args []string) Result {
 	result := c.InvokeWithoutPrinting(args)
-	c.outputResult(result)
+	c.OutputResult(result)
 	return result
 }
 
-func (c *CLI) outputResult(result Result) {
+// OutputResult formats and outputs a cmdr.Result -
+// handles tips when the result is an error, etc.
+// returns true if the result was a success
+func (c *CLI) OutputResult(result Result) bool {
 	if success, ok := result.(SuccessResult); ok {
 		c.handleSuccessResult(success)
+		return true
 	}
 	if result == nil {
 		result = InternalErrorf("nil result returned from %T", c.Root)
@@ -102,6 +106,7 @@ func (c *CLI) outputResult(result Result) {
 	if err, ok := result.(ErrorResult); ok {
 		c.handleErrorResult(err)
 	}
+	return false
 }
 
 // InvokeWithoutPrinting invokes the CLI without printing the results.

--- a/util/cmdr/errors.go
+++ b/util/cmdr/errors.go
@@ -112,6 +112,9 @@ func (e *cliErr) WithUnderlyingError(err error) ErrorResult {
 }
 
 func (e *cliErr) UnderlyingError() error {
+	if e.Err == nil {
+		return e
+	}
 	return e.Err
 }
 


### PR DESCRIPTION
Reduces the usual workflow from 3 commands to 2, sets up for proper server
use