### PR TITLE
SourceID = (SourceLocation, Version) in code.

### DIFF
--- a/cli/flags_source.go
+++ b/cli/flags_source.go
@@ -23,13 +23,13 @@ func (f *DeployFilterFlags) buildPredicate() sous.DeploymentPredicate {
 
 	if f.Repo != "" {
 		preds = append(preds, func(d *sous.Deployment) bool {
-			return d.SourceID.SourceLocation.Repo == f.Repo
+			return d.SourceID.Location.Repo == f.Repo
 		})
 	}
 
 	if f.Offset != "" {
 		preds = append(preds, func(d *sous.Deployment) bool {
-			return d.SourceID.SourceLocation.Dir == f.Offset
+			return d.SourceID.Location.Dir == f.Offset
 		})
 	}
 

--- a/cli/flags_source.go
+++ b/cli/flags_source.go
@@ -23,13 +23,13 @@ func (f *DeployFilterFlags) buildPredicate() sous.DeploymentPredicate {
 
 	if f.Repo != "" {
 		preds = append(preds, func(d *sous.Deployment) bool {
-			return d.SourceID.Repo == f.Repo
+			return d.SourceID.SourceLocation.Repo == f.Repo
 		})
 	}
 
 	if f.Offset != "" {
 		preds = append(preds, func(d *sous.Deployment) bool {
-			return d.SourceID.Dir == f.Offset
+			return d.SourceID.SourceLocation.Dir == f.Offset
 		})
 	}
 

--- a/cli/rectify_test.go
+++ b/cli/rectify_test.go
@@ -21,8 +21,10 @@ func TestPredicateBuilder(t *testing.T) {
 				ds = append(ds, &sous.Deployment{
 					ClusterName: c,
 					SourceID: sous.SourceID{
-						Repo: r,
-						Dir:  o,
+						SourceLocation: sous.SourceLocation{
+							Repo: r,
+							Dir:  o,
+						},
 					},
 				})
 			}

--- a/cli/rectify_test.go
+++ b/cli/rectify_test.go
@@ -21,7 +21,7 @@ func TestPredicateBuilder(t *testing.T) {
 				ds = append(ds, &sous.Deployment{
 					ClusterName: c,
 					SourceID: sous.SourceID{
-						SourceLocation: sous.SourceLocation{
+						Location: sous.SourceLocation{
 							Repo: r,
 							Dir:  o,
 						},

--- a/cli/sous_update_test.go
+++ b/cli/sous_update_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	sous "github.com/opentable/sous/lib"
-	"github.com/samsalisbury/semv"
 )
 
 var getIDsTests = []struct {
@@ -102,11 +101,7 @@ var updateStateTests = []struct {
 
 func TestUpdateState(t *testing.T) {
 	for _, test := range updateStateTests {
-		sid := sous.SourceID{
-			Repo:    test.DID.Source.Repo,
-			Dir:     test.DID.Source.Dir,
-			Version: semv.MustParse("1.0.0"),
-		}
+		sid := sous.MustNewSourceID(test.DID.Source.Repo, test.DID.Source.Dir, "1.0.0")
 		err := updateState(test.State, test.GDM, sid, test.DID)
 		if err != nil {
 			if test.ExpectedErr == "" {

--- a/cli/sous_update_test.go
+++ b/cli/sous_update_test.go
@@ -122,9 +122,9 @@ func TestUpdateState(t *testing.T) {
 			t.Errorf("got %d manifests; want %d", actualNumManifests, test.ExpectedNumManifests)
 		}
 		if (test.DID != sous.DeployID{}) {
-			m, ok := test.State.Manifests.Get(sid.SourceLocation)
+			m, ok := test.State.Manifests.Get(sid.Location)
 			if !ok {
-				t.Errorf("manifest %q not found", sid.SourceLocation)
+				t.Errorf("manifest %q not found", sid.Location)
 			}
 			_, ok = m.Deployments[test.DID.Cluster]
 			if !ok {

--- a/cli/sous_update_test.go
+++ b/cli/sous_update_test.go
@@ -122,9 +122,9 @@ func TestUpdateState(t *testing.T) {
 			t.Errorf("got %d manifests; want %d", actualNumManifests, test.ExpectedNumManifests)
 		}
 		if (test.DID != sous.DeployID{}) {
-			m, ok := test.State.Manifests.Get(sid.Location())
+			m, ok := test.State.Manifests.Get(sid.SourceLocation)
 			if !ok {
-				t.Errorf("manifest %q not found", sid.Location())
+				t.Errorf("manifest %q not found", sid.SourceLocation)
 			}
 			_, ok = m.Deployments[test.DID.Cluster]
 			if !ok {

--- a/ext/docker/builder_test.go
+++ b/ext/docker/builder_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/nyarly/testify/assert"
 	"github.com/opentable/sous/lib"
-	"github.com/samsalisbury/semv"
 )
 
 func TestMetadataDockerfile(t *testing.T) {
@@ -42,10 +41,9 @@ LABEL \
 func TestTagStrings(t *testing.T) {
 	assert := assert.New(t)
 
-	sid := sous.SourceID{
-		Repo:    "github.com/opentable/sous",
-		Dir:     "docker",
-		Version: semv.MustParse("1.2.3+deadbeef"),
+	sid, err := sous.NewSourceID("github.com/opentable/sous", "docker", "1.2.3+deadbeef")
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	assert.Equal("/sous/docker:1.2.3", versionName(sid))

--- a/ext/docker/image_mapping.go
+++ b/ext/docker/image_mapping.go
@@ -133,7 +133,7 @@ func (nc *NameCache) GetSourceID(a *sous.BuildArtifact) (sous.SourceID, error) {
 		return sous.SourceID{}, err
 	} else {
 
-		sid, err = makeSourceID(repo, offset, version)
+		sid, err = sous.NewSourceID(repo, offset, version)
 		if err != nil {
 			return sid, err
 		}
@@ -461,13 +461,13 @@ func (nc *NameCache) dbInsert(sid sous.SourceID, in, etag string, quals []sous.Q
 	id, err = nc.ensureInDB(
 		"select location_id from docker_search_location where repo = $1 and offset = $2",
 		"insert into docker_search_location (repo, offset) values ($1, $2);",
-		sid.Repo, sid.Dir)
+		sid.SourceLocation.Repo, sid.SourceLocation.Dir)
 
 	if err != nil {
 		return err
 	}
 
-	Log.Vomit.Printf("Source Loc: %s,%s -> id: %d", sid.Repo, sid.Dir, id)
+	Log.Vomit.Printf("Source Loc: %s -> id: %d", sid.SourceLocation, id)
 
 	_, err = nc.DB.Exec("insert or ignore into repo_through_location "+
 		"(repo_name_id, location_id) values ($1, $2)", nid, id)
@@ -588,7 +588,12 @@ func (nc *NameCache) dbQueryAllSourceIds() (ids []sous.SourceID, err error) {
 	for rows.Next() {
 		var r, o, v string
 		rows.Scan(&r, &o, &v)
-		ids = append(ids, sous.SourceID{Repo: r, Dir: o, Version: semv.MustParse(v)})
+		ids = append(ids, sous.SourceID{
+			SourceLocation: sous.SourceLocation{
+				Repo: r, Dir: o,
+			},
+			Version: semv.MustParse(v),
+		})
 	}
 	err = rows.Err()
 	return
@@ -607,9 +612,9 @@ func (nc *NameCache) dbQueryOnSourceID(sid sous.SourceID) (cn string, ins []stri
 		"docker_search_location.repo = $1 and "+
 		"docker_search_location.offset = $2 and "+
 		"docker_search_metadata.version = $3",
-		sid.Repo, sid.Dir, sid.Version.String())
+		sid.SourceLocation.Repo, sid.SourceLocation.Dir, sid.Version.String())
 
-	Log.Vomit.Printf("Selecting on %q %q %q", sid.Repo, sid.Dir, sid.Version.String())
+	Log.Vomit.Printf("Selecting on %q %q %q", sid.SourceLocation.Repo, sid.SourceLocation.Dir, sid.Version.String())
 
 	if err == sql.ErrNoRows {
 		err = errors.Wrap(NoImageNameFound{sid}, "")
@@ -652,14 +657,4 @@ func (nc *NameCache) dbQueryOnSourceID(sid sous.SourceID) (cn string, ins []stri
 	err = rows.Err()
 
 	return
-}
-
-func makeSourceID(repo, offset, version string) (sous.SourceID, error) {
-	v, err := semv.Parse(version)
-	if err != nil {
-		return sous.SourceID{}, err
-	}
-	return sous.SourceID{
-		Repo: repo, Version: v, Dir: offset,
-	}, nil
 }

--- a/ext/docker/image_mapping.go
+++ b/ext/docker/image_mapping.go
@@ -182,7 +182,7 @@ func (nc *NameCache) getImageName(sid sous.SourceID) (string, strpairs, error) {
 	cn, _, qls, err := nc.dbQueryOnSourceID(sid)
 	if _, ok := errors.Cause(err).(NoImageNameFound); ok {
 		Log.Vomit.Print(err)
-		err = nc.harvest(sid.Location())
+		err = nc.harvest(sid.SourceLocation)
 		if err != nil {
 			Log.Vomit.Printf("Err: %v", err)
 			return "", nil, err

--- a/ext/docker/image_mapping_test.go
+++ b/ext/docker/image_mapping_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/nyarly/testify/require"
 	"github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/docker_registry"
-	"github.com/samsalisbury/semv"
 )
 
 func inMemoryDB(name string) *sql.DB {
@@ -29,12 +28,8 @@ func TestRoundTrip(t *testing.T) {
 	dc := docker_registry.NewDummyClient()
 	nc := NewNameCache(dc, inMemoryDB("roundtrip"))
 
-	v := semv.MustParse("1.2.3")
-	sv := sous.SourceID{
-		Version: v,
-		Repo:    "https://github.com/opentable/wackadoo",
-		Dir:     "nested/there",
-	}
+	sv := sous.MustNewSourceID("https://github.com/opentable/wackadoo", "nested/there", "1.2.3")
+
 	host := "docker.repo.io"
 	base := "ot/wackadoo"
 	in := base + ":version-1.2.3"
@@ -51,12 +46,7 @@ func TestRoundTrip(t *testing.T) {
 		assert.Equal(in, nin)
 	}
 
-	newV := semv.MustParse("1.2.42")
-	newSV := sous.SourceID{
-		Version: newV,
-		Repo:    "https://github.com/opentable/wackadoo",
-		Dir:     "nested/there",
-	}
+	newSV := sous.MustNewSourceID("https://github.com/opentable/wackadoo", "nested/there", "1.2.42")
 
 	cn = base + "@" + digest
 	dc.FeedMetadata(docker_registry.Metadata{
@@ -89,16 +79,13 @@ func TestHarvestAlso(t *testing.T) {
 	repo := "github.com/opentable/test-app"
 
 	stuffBA := func(n, v string) sous.SourceID {
-		vs := semv.MustParse(v)
 		ba := &sous.BuildArtifact{
 			Name: n,
 			Type: "docker",
 		}
-		sv := sous.SourceID{
-			Repo:    repo,
-			Dir:     "",
-			Version: vs,
-		}
+
+		sv := sous.MustNewSourceID(repo, "", v)
+
 		in := base + ":version-" + v
 		digBs := sha256.Sum256([]byte(in))
 		digest := hex.EncodeToString(digBs[:])
@@ -142,16 +129,13 @@ func TestSecondCanonicalName(t *testing.T) {
 	stuffBA := func(digest string) sous.SourceID {
 		n := "test-service"
 		v := `0.1.2-ci1234`
-		vs := semv.MustParse(v)
 		ba := &sous.BuildArtifact{
 			Name: n,
 			Type: "docker",
 		}
-		sv := sous.SourceID{
-			Repo:    repo,
-			Dir:     "",
-			Version: vs,
-		}
+
+		sv := sous.MustNewSourceID(repo, "", v)
+
 		in := base + ":version-" + v
 		cn := base + "@sha256:" + digest
 
@@ -185,19 +169,11 @@ func TestHarvesting(t *testing.T) {
 	dc := docker_registry.NewDummyClient()
 	nc := NewNameCache(dc, inMemoryDB("harvesting"))
 
-	v := semv.MustParse("1.2.3")
-	sv := sous.SourceID{
-		Version: v,
-		Repo:    "https://github.com/opentable/wackadoo",
-		Dir:     "nested/there",
-	}
+	v := "1.2.3"
+	sv := sous.MustNewSourceID("https://github.com/opentable/wackadoo", "nested/there", v)
 
-	v2 := semv.MustParse("2.3.4")
-	sisterSV := sous.SourceID{
-		Version: v2,
-		Repo:    "https://github.com/opentable/wackadoo",
-		Dir:     "nested/there",
-	}
+	v2 := "2.3.4"
+	sisterSV := sous.MustNewSourceID("https://github.com/opentable/wackadoo", "nested/there", v2)
 
 	host := "docker.repo.io"
 	base := "ot/wackadoo"
@@ -245,12 +221,8 @@ func TestRecordAdvisories(t *testing.T) {
 	require := require.New(t)
 	dc := docker_registry.NewDummyClient()
 	nc := NewNameCache(dc, inMemoryDB("advisories"))
-	v := semv.MustParse("1.2.3")
-	sv := sous.SourceID{
-		Version: v,
-		Repo:    "https://github.com/opentable/wackadoo",
-		Dir:     "nested/there",
-	}
+	v := "1.2.3"
+	sv := sous.MustNewSourceID("https://github.com/opentable/wackadoo", "nested/there", v)
 	base := "ot/wackadoo"
 	digest := "sha256:012345678901234567890123456789AB012345678901234567890123456789AB"
 	cn := base + "@" + digest
@@ -284,12 +256,8 @@ func TestMissingName(t *testing.T) {
 	dc := docker_registry.NewDummyClient()
 	nc := NewNameCache(dc, inMemoryDB("missing"))
 
-	v := semv.MustParse("4.5.6")
-	sv := sous.SourceID{
-		Version: v,
-		Repo:    "https://github.com/opentable/brand-new-idea",
-		Dir:     "nested/there",
-	}
+	v := "4.5.6"
+	sv := sous.MustNewSourceID("https://github.com/opentable/brand-new-idea", "nested/there", v)
 
 	name, _, err := nc.getImageName(sv)
 	assert.Equal("", name)

--- a/ext/docker/names.go
+++ b/ext/docker/names.go
@@ -51,17 +51,17 @@ func Labels(sid sous.SourceID) map[string]string {
 	labels := make(map[string]string)
 	labels[DockerVersionLabel] = sid.Version.Format(`M.m.p-?`)
 	labels[DockerRevisionLabel] = sid.RevID()
-	labels[DockerPathLabel] = sid.SourceLocation.Dir
-	labels[DockerRepoLabel] = sid.SourceLocation.Repo
+	labels[DockerPathLabel] = sid.Location.Dir
+	labels[DockerRepoLabel] = sid.Location.Repo
 	return labels
 }
 
 func imageNameBase(sid sous.SourceID) string {
-	name := sid.SourceLocation.Repo
+	name := sid.Location.Repo
 
 	name = stripRE.ReplaceAllString(name, "")
-	if sid.SourceLocation.Dir != "" {
-		name = strings.Join([]string{name, sid.SourceLocation.Dir}, "/")
+	if sid.Location.Dir != "" {
+		name = strings.Join([]string{name, sid.Location.Dir}, "/")
 	}
 	return name
 }

--- a/ext/docker/names.go
+++ b/ext/docker/names.go
@@ -38,14 +38,9 @@ func SourceIDFromLabels(labels map[string]string) (sous.SourceID, error) {
 		return sous.SourceID{}, err
 	}
 
-	version, err := semv.Parse(versionStr)
-	version.Meta = revision
-
-	return sous.SourceID{
-		Repo:    repo,
-		Version: version,
-		Dir:     path,
-	}, err
+	id, err := sous.NewSourceID(repo, path, versionStr)
+	id.Version.Meta = revision
+	return id, err
 }
 
 var stripRE = regexp.MustCompile("^([[:alpha:]]+://)?(github.com(/opentable)?)?")
@@ -56,17 +51,17 @@ func Labels(sid sous.SourceID) map[string]string {
 	labels := make(map[string]string)
 	labels[DockerVersionLabel] = sid.Version.Format(`M.m.p-?`)
 	labels[DockerRevisionLabel] = sid.RevID()
-	labels[DockerPathLabel] = string(sid.Dir)
-	labels[DockerRepoLabel] = string(sid.Repo)
+	labels[DockerPathLabel] = sid.SourceLocation.Dir
+	labels[DockerRepoLabel] = sid.SourceLocation.Repo
 	return labels
 }
 
 func imageNameBase(sid sous.SourceID) string {
-	name := string(sid.Repo)
+	name := sid.SourceLocation.Repo
 
 	name = stripRE.ReplaceAllString(name, "")
-	if string(sid.Dir) != "" {
-		name = strings.Join([]string{name, string(sid.Dir)}, "/")
+	if sid.SourceLocation.Dir != "" {
+		name = strings.Join([]string{name, sid.SourceLocation.Dir}, "/")
 	}
 	return name
 }

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -162,7 +162,7 @@ func computeRequestID(d *sous.Deployment) string {
 }
 
 func buildReqID(sv sous.SourceID, nick string) string {
-	return MakeDeployID(sv.SourceLocation.String() + nick)
+	return MakeDeployID(sv.Location.String() + nick)
 }
 
 func newDepID() string {

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -162,7 +162,7 @@ func computeRequestID(d *sous.Deployment) string {
 }
 
 func buildReqID(sv sous.SourceID, nick string) string {
-	return MakeDeployID(sv.Location().String() + nick)
+	return MakeDeployID(sv.SourceLocation.String() + nick)
 }
 
 func newDepID() string {

--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -35,7 +35,7 @@ func TestModifyScale(t *testing.T) {
 	pair := &sous.DeploymentPair{
 		Prior: &sous.Deployment{
 			SourceID: sous.SourceID{
-				SourceLocation: sous.SourceLocation{
+				Location: sous.SourceLocation{
 					Repo: "reqid",
 				},
 			},
@@ -49,7 +49,7 @@ func TestModifyScale(t *testing.T) {
 		},
 		Post: &sous.Deployment{
 			SourceID: sous.SourceID{
-				SourceLocation: sous.SourceLocation{
+				Location: sous.SourceLocation{
 					Repo: "reqid",
 				},
 			},
@@ -264,7 +264,7 @@ func TestDeletes(t *testing.T) {
 
 	deleted := &sous.Deployment{
 		SourceID: sous.SourceID{
-			SourceLocation: sous.SourceLocation{
+			Location: sous.SourceLocation{
 				Repo: "reqid",
 			},
 		},
@@ -308,7 +308,7 @@ func TestCreates(t *testing.T) {
 
 	created := &sous.Deployment{
 		SourceID: sous.SourceID{
-			SourceLocation: sous.SourceLocation{
+			Location: sous.SourceLocation{
 				Repo: "reqid",
 			},
 		},

--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/nyarly/testify/assert"
 	"github.com/nyarly/testify/require"
 	"github.com/opentable/sous/lib"
-	"github.com/samsalisbury/semv"
 )
 
 /* TESTS BEGIN */
@@ -36,7 +35,9 @@ func TestModifyScale(t *testing.T) {
 	pair := &sous.DeploymentPair{
 		Prior: &sous.Deployment{
 			SourceID: sous.SourceID{
-				Repo: "reqid",
+				SourceLocation: sous.SourceLocation{
+					Repo: "reqid",
+				},
 			},
 			DeployConfig: sous.DeployConfig{
 				NumInstances: 12,
@@ -48,7 +49,9 @@ func TestModifyScale(t *testing.T) {
 		},
 		Post: &sous.Deployment{
 			SourceID: sous.SourceID{
-				Repo: "reqid",
+				SourceLocation: sous.SourceLocation{
+					Repo: "reqid",
+				},
 			},
 			DeployConfig: sous.DeployConfig{
 				NumInstances: 24,
@@ -87,14 +90,11 @@ func TestModifyScale(t *testing.T) {
 
 func TestModifyImage(t *testing.T) {
 	assert := assert.New(t)
-	before, _ := semv.Parse("1.2.3-test")
-	after, _ := semv.Parse("2.3.4-new")
+	before := "1.2.3-test"
+	after := "2.3.4-new"
 	pair := &sous.DeploymentPair{
 		Prior: &sous.Deployment{
-			SourceID: sous.SourceID{
-				Repo:    "reqid",
-				Version: before,
-			},
+			SourceID: sous.MustNewSourceID("reqid", "", before),
 			DeployConfig: sous.DeployConfig{
 				NumInstances: 1,
 			},
@@ -104,10 +104,7 @@ func TestModifyImage(t *testing.T) {
 			},
 		},
 		Post: &sous.Deployment{
-			SourceID: sous.SourceID{
-				Repo:    "reqid",
-				Version: after,
-			},
+			SourceID: sous.MustNewSourceID("reqid", "", after),
 			DeployConfig: sous.DeployConfig{
 				NumInstances: 1,
 			},
@@ -144,13 +141,10 @@ func TestModifyImage(t *testing.T) {
 
 func TestModifyResources(t *testing.T) {
 	assert := assert.New(t)
-	version := semv.MustParse("1.2.3-test")
+	version := "1.2.3-test"
 	pair := &sous.DeploymentPair{
 		Prior: &sous.Deployment{
-			SourceID: sous.SourceID{
-				Repo:    "reqid",
-				Version: version,
-			},
+			SourceID: sous.MustNewSourceID("reqid", "", version),
 			DeployConfig: sous.DeployConfig{
 				NumInstances: 1,
 				Resources: sous.Resources{
@@ -163,10 +157,7 @@ func TestModifyResources(t *testing.T) {
 			},
 		},
 		Post: &sous.Deployment{
-			SourceID: sous.SourceID{
-				Repo:    "reqid",
-				Version: version,
-			},
+			SourceID: sous.MustNewSourceID("reqid", "", version),
 			DeployConfig: sous.DeployConfig{
 				NumInstances: 1,
 				Resources: sous.Resources{
@@ -208,14 +199,11 @@ func TestModify(t *testing.T) {
 	Log.Debug.SetOutput(os.Stderr)
 	defer Log.Debug.SetOutput(ioutil.Discard)
 	assert := assert.New(t)
-	before := semv.MustParse("1.2.3-test")
-	after := semv.MustParse("2.3.4-new")
+	before := "1.2.3-test"
+	after := "2.3.4-new"
 	pair := &sous.DeploymentPair{
 		Prior: &sous.Deployment{
-			SourceID: sous.SourceID{
-				Repo:    "reqid",
-				Version: before,
-			},
+			SourceID: sous.MustNewSourceID("reqid", "", before),
 			DeployConfig: sous.DeployConfig{
 				NumInstances: 1,
 				Volumes: sous.Volumes{
@@ -228,10 +216,7 @@ func TestModify(t *testing.T) {
 			},
 		},
 		Post: &sous.Deployment{
-			SourceID: sous.SourceID{
-				Repo:    "reqid",
-				Version: after,
-			},
+			SourceID: sous.MustNewSourceID("reqid", "", after),
 			DeployConfig: sous.DeployConfig{
 				NumInstances: 24,
 				Volumes: sous.Volumes{
@@ -279,7 +264,9 @@ func TestDeletes(t *testing.T) {
 
 	deleted := &sous.Deployment{
 		SourceID: sous.SourceID{
-			Repo: "reqid",
+			SourceLocation: sous.SourceLocation{
+				Repo: "reqid",
+			},
 		},
 		DeployConfig: sous.DeployConfig{
 			NumInstances: 12,
@@ -321,7 +308,9 @@ func TestCreates(t *testing.T) {
 
 	created := &sous.Deployment{
 		SourceID: sous.SourceID{
-			Repo: "reqid",
+			SourceLocation: sous.SourceLocation{
+				Repo: "reqid",
+			},
 		},
 		DeployConfig: sous.DeployConfig{
 			NumInstances: 12,

--- a/integration/deployment_builder_test.go
+++ b/integration/deployment_builder_test.go
@@ -99,7 +99,7 @@ func TestBuildDeployments(t *testing.T) {
 			if assert.Len(dep.DeployConfig.Volumes, 1) {
 				assert.Equal(dep.DeployConfig.Volumes[0].Host, "/tmp")
 			}
-			assert.Equal("https://github.com/docker/dockercloud-hello-world.git", dep.SourceID.SourceLocation.Repo)
+			assert.Equal("https://github.com/docker/dockercloud-hello-world.git", dep.SourceID.Location.Repo)
 		}
 	}
 }

--- a/integration/deployment_builder_test.go
+++ b/integration/deployment_builder_test.go
@@ -99,7 +99,7 @@ func TestBuildDeployments(t *testing.T) {
 			if assert.Len(dep.DeployConfig.Volumes, 1) {
 				assert.Equal(dep.DeployConfig.Volumes[0].Host, "/tmp")
 			}
-			assert.Equal("https://github.com/docker/dockercloud-hello-world.git", string(dep.SourceID.Repo))
+			assert.Equal("https://github.com/docker/dockercloud-hello-world.git", dep.SourceID.SourceLocation.Repo)
 		}
 	}
 }

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -68,7 +68,7 @@ func (d *Deployment) String() string {
 // ID returns the DeployID of this deployment.
 func (d *Deployment) ID() DeployID {
 	return DeployID{
-		Source:  d.SourceID.SourceLocation,
+		Source:  d.SourceID.Location,
 		Cluster: d.ClusterName,
 	}
 }
@@ -113,9 +113,9 @@ func (d *Deployment) Tabbed() string {
 			"%s\t"+ //"Resources\t" +
 			"%s", //"Env"
 		d.ClusterName,
-		d.SourceID.SourceLocation.Repo,
+		d.SourceID.Location.Repo,
 		d.SourceID.Version.String(),
-		d.SourceID.SourceLocation.Dir,
+		d.SourceID.Location.Dir,
 		d.NumInstances,
 		o,
 		strings.Join(rs, ", "),
@@ -127,7 +127,7 @@ func (d *Deployment) Tabbed() string {
 func (d *Deployment) Name() DeployID {
 	return DeployID{
 		Cluster: d.ClusterName,
-		Source:  d.SourceID.SourceLocation,
+		Source:  d.SourceID.Location,
 	}
 }
 

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -68,7 +68,7 @@ func (d *Deployment) String() string {
 // ID returns the DeployID of this deployment.
 func (d *Deployment) ID() DeployID {
 	return DeployID{
-		Source:  d.SourceID.Location(),
+		Source:  d.SourceID.SourceLocation,
 		Cluster: d.ClusterName,
 	}
 }
@@ -127,7 +127,7 @@ func (d *Deployment) Tabbed() string {
 func (d *Deployment) Name() DeployID {
 	return DeployID{
 		Cluster: d.ClusterName,
-		Source:  d.SourceID.Location(),
+		Source:  d.SourceID.SourceLocation,
 	}
 }
 

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -113,9 +113,9 @@ func (d *Deployment) Tabbed() string {
 			"%s\t"+ //"Resources\t" +
 			"%s", //"Env"
 		d.ClusterName,
-		string(d.SourceID.Repo),
+		d.SourceID.SourceLocation.Repo,
 		d.SourceID.Version.String(),
-		string(d.SourceID.Dir),
+		d.SourceID.SourceLocation.Dir,
 		d.NumInstances,
 		o,
 		strings.Join(rs, ", "),

--- a/lib/deployment_diff_test.go
+++ b/lib/deployment_diff_test.go
@@ -36,7 +36,7 @@ func makeDepl(repo string, num int) *Deployment {
 	owners.Add("judson")
 	return &Deployment{
 		SourceID: SourceID{
-			SourceLocation: SourceLocation{
+			Location: SourceLocation{
 				Repo: repo,
 			},
 			Version: version,
@@ -89,8 +89,8 @@ func TestRealDiff(t *testing.T) {
 
 	if assert.Len(ds.Changed, 1, "Should have one modified item.") {
 		assert.Equal(repoThree, string(ds.Changed[0].name.Source.Repo))
-		assert.Equal(repoThree, string(ds.Changed[0].Prior.SourceID.SourceLocation.Repo))
-		assert.Equal(repoThree, string(ds.Changed[0].Post.SourceID.SourceLocation.Repo))
+		assert.Equal(repoThree, string(ds.Changed[0].Prior.SourceID.Location.Repo))
+		assert.Equal(repoThree, string(ds.Changed[0].Post.SourceID.Location.Repo))
 		assert.Equal(ds.Changed[0].Post.NumInstances, 1)
 		assert.Equal(ds.Changed[0].Prior.NumInstances, 2)
 	}

--- a/lib/deployment_diff_test.go
+++ b/lib/deployment_diff_test.go
@@ -36,7 +36,9 @@ func makeDepl(repo string, num int) *Deployment {
 	owners.Add("judson")
 	return &Deployment{
 		SourceID: SourceID{
-			Repo:    repo,
+			SourceLocation: SourceLocation{
+				Repo: repo,
+			},
 			Version: version,
 		},
 		DeployConfig: DeployConfig{
@@ -87,8 +89,8 @@ func TestRealDiff(t *testing.T) {
 
 	if assert.Len(ds.Changed, 1, "Should have one modified item.") {
 		assert.Equal(repoThree, string(ds.Changed[0].name.Source.Repo))
-		assert.Equal(repoThree, string(ds.Changed[0].Prior.SourceID.Repo))
-		assert.Equal(repoThree, string(ds.Changed[0].Post.SourceID.Repo))
+		assert.Equal(repoThree, string(ds.Changed[0].Prior.SourceID.SourceLocation.Repo))
+		assert.Equal(repoThree, string(ds.Changed[0].Post.SourceID.SourceLocation.Repo))
 		assert.Equal(ds.Changed[0].Post.NumInstances, 1)
 		assert.Equal(ds.Changed[0].Prior.NumInstances, 2)
 	}

--- a/lib/deployment_test.go
+++ b/lib/deployment_test.go
@@ -27,8 +27,10 @@ func TestCanonName(t *testing.T) {
 	vers, _ := semv.Parse("1.2.3-test+thing")
 	dep := Deployment{
 		SourceID: SourceID{
-			Repo:    "one",
-			Dir:     "two",
+			SourceLocation: SourceLocation{
+				Repo: "one",
+				Dir:  "two",
+			},
 			Version: vers,
 		},
 	}

--- a/lib/deployment_test.go
+++ b/lib/deployment_test.go
@@ -27,14 +27,14 @@ func TestCanonName(t *testing.T) {
 	vers, _ := semv.Parse("1.2.3-test+thing")
 	dep := Deployment{
 		SourceID: SourceID{
-			SourceLocation: SourceLocation{
+			Location: SourceLocation{
 				Repo: "one",
 				Dir:  "two",
 			},
 			Version: vers,
 		},
 	}
-	str := dep.SourceID.SourceLocation.String()
+	str := dep.SourceID.Location.String()
 	assert.Regexp("one", str)
 	assert.Regexp("two", str)
 }

--- a/lib/deployment_test.go
+++ b/lib/deployment_test.go
@@ -34,7 +34,7 @@ func TestCanonName(t *testing.T) {
 			Version: vers,
 		},
 	}
-	str := dep.SourceID.Location().String()
+	str := dep.SourceID.SourceLocation.String()
 	assert.Regexp("one", str)
 	assert.Regexp("two", str)
 }

--- a/lib/map_state_to_deployments.go
+++ b/lib/map_state_to_deployments.go
@@ -56,7 +56,7 @@ func (ds Deployments) Manifests(defs Defs) (Manifests, error) {
 			}
 			d.Cluster = cluster
 		}
-		sl := d.SourceID.Location()
+		sl := d.SourceID.SourceLocation
 		// Lookup the current manifest for this source location.
 		m, ok := ms.Get(sl)
 		if !ok {

--- a/lib/map_state_to_deployments.go
+++ b/lib/map_state_to_deployments.go
@@ -56,7 +56,7 @@ func (ds Deployments) Manifests(defs Defs) (Manifests, error) {
 			}
 			d.Cluster = cluster
 		}
-		sl := d.SourceID.SourceLocation
+		sl := d.SourceID.Location
 		// Lookup the current manifest for this source location.
 		m, ok := ms.Get(sl)
 		if !ok {

--- a/lib/registry_dumper.go
+++ b/lib/registry_dumper.go
@@ -72,5 +72,5 @@ func (rd *RegistryDumper) Entries() (de []DumperEntry, err error) {
 
 // Tabbed emits a tab-delimited string representing the entry
 func (de *DumperEntry) Tabbed() string {
-	return fmt.Sprintf("%s\t%s\t%s\t%s\t%s", de.SourceLocation.Repo, de.SourceLocation.Dir, de.Version.Format(semv.MajorMinorPatch), de.Name, de.Type)
+	return fmt.Sprintf("%s\t%s\t%s\t%s\t%s", de.Location.Repo, de.Location.Dir, de.Version.Format(semv.MajorMinorPatch), de.Name, de.Type)
 }

--- a/lib/registry_dumper.go
+++ b/lib/registry_dumper.go
@@ -72,5 +72,5 @@ func (rd *RegistryDumper) Entries() (de []DumperEntry, err error) {
 
 // Tabbed emits a tab-delimited string representing the entry
 func (de *DumperEntry) Tabbed() string {
-	return fmt.Sprintf("%s\t%s\t%s\t%s\t%s", de.Repo, de.Dir, de.Version.Format(semv.MajorMinorPatch), de.Name, de.Type)
+	return fmt.Sprintf("%s\t%s\t%s\t%s\t%s", de.SourceLocation.Repo, de.SourceLocation.Dir, de.Version.Format(semv.MajorMinorPatch), de.Name, de.Type)
 }

--- a/lib/source_context.go
+++ b/lib/source_context.go
@@ -35,9 +35,11 @@ func (sc *SourceContext) Version() SourceID {
 	// Append revision ID.
 	v = semv.MustParse(v.Format("M.m.p-?") + "+" + sc.Revision)
 	sv := SourceID{
-		Repo:    sc.RemoteURL,
+		SourceLocation: SourceLocation{
+			Repo: sc.RemoteURL,
+			Dir:  sc.OffsetDir,
+		},
 		Version: v,
-		Dir:     sc.OffsetDir,
 	}
 	Log.Debug.Printf("Version: % #v", sv)
 	return sv

--- a/lib/source_context.go
+++ b/lib/source_context.go
@@ -35,7 +35,7 @@ func (sc *SourceContext) Version() SourceID {
 	// Append revision ID.
 	v = semv.MustParse(v.Format("M.m.p-?") + "+" + sc.Revision)
 	sv := SourceID{
-		SourceLocation: SourceLocation{
+		Location: SourceLocation{
 			Repo: sc.RemoteURL,
 			Dir:  sc.OffsetDir,
 		},

--- a/lib/source_context_test.go
+++ b/lib/source_context_test.go
@@ -15,7 +15,7 @@ func TestVersion(t *testing.T) {
 		NearestTagName: "1.2.3",
 	}
 	id := sc.Version()
-	assert.Equal("github.com/opentable/test", string(id.Repo))
-	assert.Equal("sub", string(id.Dir))
+	assert.Equal("github.com/opentable/test", id.SourceLocation.Repo)
+	assert.Equal("sub", string(id.SourceLocation.Dir))
 	assert.Equal("1.2.3", id.Version.String())
 }

--- a/lib/source_context_test.go
+++ b/lib/source_context_test.go
@@ -15,7 +15,7 @@ func TestVersion(t *testing.T) {
 		NearestTagName: "1.2.3",
 	}
 	id := sc.Version()
-	assert.Equal("github.com/opentable/test", id.SourceLocation.Repo)
-	assert.Equal("sub", string(id.SourceLocation.Dir))
+	assert.Equal("github.com/opentable/test", id.Location.Repo)
+	assert.Equal("sub", string(id.Location.Dir))
 	assert.Equal("1.2.3", id.Version.String())
 }

--- a/lib/source_id.go
+++ b/lib/source_id.go
@@ -14,8 +14,7 @@ type (
 	SourceID struct {
 		// Location is the repo/dir pair indicating the location of the source
 		// code. Note that not all locations will be valid with all Versions.
-		// TODO: Rename to Location once we have removed the Location func.
-		SourceLocation SourceLocation
+		Location SourceLocation
 		// Version identifies a specific version of the source code at Repo/Dir.
 		Version semv.Version
 	}
@@ -47,16 +46,11 @@ type (
 // representation of a SourceID or a SourceLocation.
 const DefaultDelim = ","
 
-// Location returns the SourceLocation. TODO: Remove this.
-func (sid SourceID) Location() SourceLocation {
-	return sid.SourceLocation
-}
-
 func (sid SourceID) String() string {
-	if sid.SourceLocation.Dir == "" {
-		return fmt.Sprintf("%s %s", sid.SourceLocation.Repo, sid.Version)
+	if sid.Location.Dir == "" {
+		return fmt.Sprintf("%s %s", sid.Location.Repo, sid.Version)
 	}
-	return fmt.Sprintf("%s:%s %s", sid.SourceLocation.Repo, sid.SourceLocation.Dir, sid.Version)
+	return fmt.Sprintf("%s:%s %s", sid.Location.Repo, sid.Location.Dir, sid.Version)
 }
 
 // Tag returns the version tag for this source ID.
@@ -116,7 +110,7 @@ func sourceIDFromChunks(source string, chunks []string) (SourceID, error) {
 		repoOffset = chunks[2]
 	}
 	return SourceID{
-		SourceLocation: SourceLocation{
+		Location: SourceLocation{
 			Dir:  repoOffset,
 			Repo: repoURL,
 		},
@@ -147,7 +141,7 @@ func NewSourceID(repo, offset, version string) (SourceID, error) {
 		return SourceID{}, err
 	}
 	return SourceID{
-		SourceLocation: SourceLocation{
+		Location: SourceLocation{
 			Repo: repo, Dir: offset,
 		},
 		Version: v,

--- a/lib/source_id_test.go
+++ b/lib/source_id_test.go
@@ -8,36 +8,50 @@ import (
 
 var parseSourceIDTests = map[string]SourceID{
 	"github.com/opentable/sous,1,": {
-		Repo:    "github.com/opentable/sous",
+		SourceLocation: SourceLocation{
+			Repo: "github.com/opentable/sous",
+		},
 		Version: semv.MustParse("1"),
 	},
 	":github.com/opentable/sous:1:": {
-		Repo:    "github.com/opentable/sous",
+		SourceLocation: SourceLocation{
+			Repo: "github.com/opentable/sous",
+		},
 		Version: semv.MustParse("1"),
 	},
 	"github.com/opentable/sous,1": {
-		Repo:    "github.com/opentable/sous",
+		SourceLocation: SourceLocation{
+			Repo: "github.com/opentable/sous",
+		},
 		Version: semv.MustParse("1"),
 	},
 	",github.com/opentable/sous,1,util": {
-		Repo:    "github.com/opentable/sous",
+		SourceLocation: SourceLocation{
+			Repo: "github.com/opentable/sous",
+			Dir:  "util",
+		},
 		Version: semv.MustParse("1"),
-		Dir:     "util",
 	},
 	"github.com/opentable/sous,1,util": {
-		Repo:    "github.com/opentable/sous",
+		SourceLocation: SourceLocation{
+			Repo: "github.com/opentable/sous",
+			Dir:  "util",
+		},
 		Version: semv.MustParse("1"),
-		Dir:     "util",
 	},
 	":github.com/opentable/sous:1:util": {
-		Repo:    "github.com/opentable/sous",
+		SourceLocation: SourceLocation{
+			Repo: "github.com/opentable/sous",
+			Dir:  "util",
+		},
 		Version: semv.MustParse("1"),
-		Dir:     "util",
 	},
 	"git+ssh://github.com/opentable/sous,1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3,sous": {
-		Repo:    "git+ssh://github.com/opentable/sous",
+		SourceLocation: SourceLocation{
+			Repo: "git+ssh://github.com/opentable/sous",
+			Dir:  "sous",
+		},
 		Version: semv.MustParse("1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3"),
-		Dir:     "sous",
 	},
 }
 

--- a/lib/source_id_test.go
+++ b/lib/source_id_test.go
@@ -55,7 +55,7 @@ var parseSourceIDTests = map[string]SourceID{
 	},
 }
 
-func TestParseSourceID(t *testing.T) {
+func TestParseSourceID_success(t *testing.T) {
 	for in, expected := range parseSourceIDTests {
 		actual, err := ParseSourceID(in)
 		if err != nil {
@@ -65,5 +65,64 @@ func TestParseSourceID(t *testing.T) {
 		if actual != expected {
 			t.Errorf("got %v; want %v", actual, expected)
 		}
+	}
+}
+
+func TestNewSourceID_success(t *testing.T) {
+	for _, sid := range parseSourceIDTests {
+		actual, err := NewSourceID(sid.SourceLocation.Repo, sid.SourceLocation.Dir, sid.Version.String())
+		if err != nil {
+			t.Error(err)
+		}
+		if actual != sid {
+			t.Errorf("Got %+v; want %+v", actual, sid)
+		}
+	}
+}
+
+func TestNewSourceID_failure(t *testing.T) {
+	sid, err := NewSourceID("", "", "not a version")
+	expected := "unexpected character 'n' at position 0"
+	if err == nil {
+		t.Errorf("got nil; want error %q", expected)
+	}
+	if (sid != SourceID{}) {
+		t.Errorf("got non-zero SourceID: %+v", sid)
+	}
+	actual := err.Error()
+	if actual != expected {
+		t.Errorf("got error %q; want %q", actual, expected)
+	}
+}
+
+func TestMustNewSourceID_success(t *testing.T) {
+	for _, sid := range parseSourceIDTests {
+		actual := MustNewSourceID(sid.SourceLocation.Repo, sid.SourceLocation.Dir, sid.Version.String())
+		if actual != sid {
+			t.Errorf("Got %+v; want %+v", actual, sid)
+		}
+	}
+}
+
+func TestMustNewSourceID_failure(t *testing.T) {
+	var actualErr error
+	sid := func() SourceID {
+		defer func() {
+			if err := recover(); err != nil {
+				actualErr = err.(error)
+			}
+		}()
+		return MustNewSourceID("", "", "_")
+	}()
+	expected := "unexpected character '_' at position 0"
+	if actualErr == nil {
+		t.Errorf("got nil; want error %q", expected)
+	}
+	if (sid != SourceID{}) {
+		t.Errorf("got non-zero SourceID: %+v", sid)
+	}
+	actual := actualErr.Error()
+	if actual != expected {
+		t.Errorf("got error %q; want %q", actual, expected)
 	}
 }

--- a/lib/source_id_test.go
+++ b/lib/source_id_test.go
@@ -8,46 +8,46 @@ import (
 
 var parseSourceIDTests = map[string]SourceID{
 	"github.com/opentable/sous,1,": {
-		SourceLocation: SourceLocation{
+		Location: SourceLocation{
 			Repo: "github.com/opentable/sous",
 		},
 		Version: semv.MustParse("1"),
 	},
 	":github.com/opentable/sous:1:": {
-		SourceLocation: SourceLocation{
+		Location: SourceLocation{
 			Repo: "github.com/opentable/sous",
 		},
 		Version: semv.MustParse("1"),
 	},
 	"github.com/opentable/sous,1": {
-		SourceLocation: SourceLocation{
+		Location: SourceLocation{
 			Repo: "github.com/opentable/sous",
 		},
 		Version: semv.MustParse("1"),
 	},
 	",github.com/opentable/sous,1,util": {
-		SourceLocation: SourceLocation{
+		Location: SourceLocation{
 			Repo: "github.com/opentable/sous",
 			Dir:  "util",
 		},
 		Version: semv.MustParse("1"),
 	},
 	"github.com/opentable/sous,1,util": {
-		SourceLocation: SourceLocation{
+		Location: SourceLocation{
 			Repo: "github.com/opentable/sous",
 			Dir:  "util",
 		},
 		Version: semv.MustParse("1"),
 	},
 	":github.com/opentable/sous:1:util": {
-		SourceLocation: SourceLocation{
+		Location: SourceLocation{
 			Repo: "github.com/opentable/sous",
 			Dir:  "util",
 		},
 		Version: semv.MustParse("1"),
 	},
 	"git+ssh://github.com/opentable/sous,1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3,sous": {
-		SourceLocation: SourceLocation{
+		Location: SourceLocation{
 			Repo: "git+ssh://github.com/opentable/sous",
 			Dir:  "sous",
 		},
@@ -70,7 +70,7 @@ func TestParseSourceID_success(t *testing.T) {
 
 func TestNewSourceID_success(t *testing.T) {
 	for _, sid := range parseSourceIDTests {
-		actual, err := NewSourceID(sid.SourceLocation.Repo, sid.SourceLocation.Dir, sid.Version.String())
+		actual, err := NewSourceID(sid.Location.Repo, sid.Location.Dir, sid.Version.String())
 		if err != nil {
 			t.Error(err)
 		}
@@ -97,7 +97,7 @@ func TestNewSourceID_failure(t *testing.T) {
 
 func TestMustNewSourceID_success(t *testing.T) {
 	for _, sid := range parseSourceIDTests {
-		actual := MustNewSourceID(sid.SourceLocation.Repo, sid.SourceLocation.Dir, sid.Version.String())
+		actual := MustNewSourceID(sid.Location.Repo, sid.Location.Dir, sid.Version.String())
 		if actual != sid {
 			t.Errorf("Got %+v; want %+v", actual, sid)
 		}

--- a/lib/source_location.go
+++ b/lib/source_location.go
@@ -103,7 +103,7 @@ func (sl SourceLocation) String() string {
 // SourceID returns a SourceID built from this location with the addition of a version.
 func (sl SourceLocation) SourceID(version semv.Version) SourceID {
 	return SourceID{
-		SourceLocation: sl,
-		Version:        version,
+		Location: sl,
+		Version:  version,
 	}
 }

--- a/lib/source_location.go
+++ b/lib/source_location.go
@@ -101,10 +101,9 @@ func (sl SourceLocation) String() string {
 }
 
 // SourceID returns a SourceID built from this location with the addition of a version.
-func (sl *SourceLocation) SourceID(version semv.Version) SourceID {
+func (sl SourceLocation) SourceID(version semv.Version) SourceID {
 	return SourceID{
-		Repo:    sl.Repo,
-		Dir:     sl.Dir,
-		Version: version,
+		SourceLocation: sl,
+		Version:        version,
 	}
 }


### PR DESCRIPTION
- SourceID was always this pair conceptually, now the code makes that clear.
- This can be merged as-is, a follow-up PR will remove the SourceID.Location
  method, and rename SourceID.SourceLocation to SourceID.Location.