### PR TITLE
Flavor preparation.

### DIFF
--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -339,7 +339,7 @@ func TestCreates(t *testing.T) {
 	if assert.Len(client.deployed, 1) {
 		dep := client.deployed[0]
 		assert.Equal("cluster", dep.cluster)
-		assert.Equal("reqid 0.0.0", dep.imageName)
+		assert.Equal("reqid,0.0.0", dep.imageName)
 	}
 
 	if assert.Len(client.created, 1) {

--- a/lib/source_id.go
+++ b/lib/source_id.go
@@ -50,7 +50,7 @@ func (sid SourceID) String() string {
 	if sid.Location.Dir == "" {
 		return fmt.Sprintf("%s,%s", sid.Location.Repo, sid.Version)
 	}
-	return fmt.Sprintf("%s,%s,%s", sid.Location.Repo, sid.Location.Dir, sid.Version)
+	return fmt.Sprintf("%s,%s,%s", sid.Location.Repo, sid.Version, sid.Location.Dir)
 }
 
 // Tag returns the version tag for this source ID.

--- a/lib/source_id.go
+++ b/lib/source_id.go
@@ -48,9 +48,9 @@ const DefaultDelim = ","
 
 func (sid SourceID) String() string {
 	if sid.Location.Dir == "" {
-		return fmt.Sprintf("%s %s", sid.Location.Repo, sid.Version)
+		return fmt.Sprintf("%s,%s", sid.Location.Repo, sid.Version)
 	}
-	return fmt.Sprintf("%s:%s %s", sid.Location.Repo, sid.Location.Dir, sid.Version)
+	return fmt.Sprintf("%s,%s,%s", sid.Location.Repo, sid.Location.Dir, sid.Version)
 }
 
 // Tag returns the version tag for this source ID.

--- a/lib/source_id_test.go
+++ b/lib/source_id_test.go
@@ -126,3 +126,50 @@ func TestMustNewSourceID_failure(t *testing.T) {
 		t.Errorf("got error %q; want %q", actual, expected)
 	}
 }
+
+var sourceIDStringTests = map[string]SourceID{
+	"github.com/opentable/sous,1": {
+		Location: SourceLocation{
+			Repo: "github.com/opentable/sous",
+		},
+		Version: semv.MustParse("1"),
+	},
+	"github.com/opentable/sous,1,util": {
+		Location: SourceLocation{
+			Repo: "github.com/opentable/sous",
+			Dir:  "util",
+		},
+		Version: semv.MustParse("1"),
+	},
+	"git+ssh://github.com/opentable/sous,1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3,sous": {
+		Location: SourceLocation{
+			Repo: "git+ssh://github.com/opentable/sous",
+			Dir:  "sous",
+		},
+		Version: semv.MustParse("1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3"),
+	},
+}
+
+func TestSourceID_String(t *testing.T) {
+	for expected, input := range sourceIDStringTests {
+		actual := input.String()
+		if actual != expected {
+			t.Errorf("%+v got %q; want %q", input, actual, expected)
+		}
+	}
+}
+
+func TestSourceID_roundtrip_String_Parse(t *testing.T) {
+	for _, sid := range sourceIDStringTests {
+		intermediate := sid.String()
+		expected := sid
+		actual, err := ParseSourceID(intermediate)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if actual != expected {
+			t.Errorf("%+v round-tripped as %+v", actual, expected)
+		}
+	}
+}

--- a/lib/source_location.go
+++ b/lib/source_location.go
@@ -11,15 +11,13 @@ import (
 type (
 	// SourceLocation identifies a directory inside a source code repository.
 	// Note that the directory is ambiguous without the addition of a revision
-	// ID. This type is used as a shorthand for deploy manifests, enabling the
-	// logical grouping of deploys of different versions of a particular
-	// service.
+	// ID.
 	SourceLocation struct {
 		// Repo identifies a source code repository.
 		Repo,
 		// Dir is a directory within the repository at Repo containing the
 		// source code for one piece of software.
-		Dir string `yaml:",omitempty"`
+		Dir string
 	}
 )
 

--- a/lib/source_location.go
+++ b/lib/source_location.go
@@ -2,9 +2,7 @@ package sous
 
 import (
 	"fmt"
-	"io"
 
-	"github.com/pkg/errors"
 	"github.com/samsalisbury/semv"
 )
 
@@ -69,15 +67,9 @@ func (sl SourceLocation) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements encoding.TextMarshaler.
 func (sl *SourceLocation) UnmarshalText(b []byte) error {
-	s := string(b)
-	n, err := fmt.Sscanf(s, "%s %s", &sl.Repo, &sl.Dir)
-	if err != nil && err != io.EOF {
-		return errors.Wrapf(err, "unable to unmarshal source location %q", s)
-	}
-	if n == 0 {
-		return errors.Errorf("incomplete source location %q", s)
-	}
-	return nil
+	var err error
+	*sl, err = ParseSourceLocation(string(b))
+	return err
 }
 
 // UnmarshalYAML deserializes a YAML document into this SourceLocation

--- a/lib/source_location.go
+++ b/lib/source_location.go
@@ -97,7 +97,7 @@ func (sl SourceLocation) String() string {
 	if sl.Dir == "" {
 		return fmt.Sprintf("%s", sl.Repo)
 	}
-	return fmt.Sprintf("%s:%s", sl.Repo, sl.Dir)
+	return fmt.Sprintf("%s,%s", sl.Repo, sl.Dir)
 }
 
 // SourceID returns a SourceID built from this location with the addition of a version.

--- a/lib/source_location_test.go
+++ b/lib/source_location_test.go
@@ -44,3 +44,16 @@ func TestMustParseSourceLocation(t *testing.T) {
 		}
 	}
 }
+
+func TestSourceLocation_UnmarshalText(t *testing.T) {
+	for in, expected := range parseSourceLocationTests {
+		var actual SourceLocation
+		if err := actual.UnmarshalText([]byte(in)); err != nil {
+			t.Error(err)
+			continue
+		}
+		if actual != expected {
+			t.Errorf("%q got %#v; want %#v", in, actual, expected)
+		}
+	}
+}


### PR DESCRIPTION
Writing tests for ManifestID/Flavor I noticed that `ParseSourceID(sid.String()) != sid` and that SourceLocation.String() used a colon instead of the default comma separator. This PR addresses those, and a few other issues.