### PR TITLE
Flavor implementation.

### DIFF
--- a/cli/add_flags_test.go
+++ b/cli/add_flags_test.go
@@ -13,10 +13,12 @@ func TestAddFlagsForRectify(t *testing.T) {
 				all deployments should be considered
 	-cluster string
 				target deployment cluster
-  -offset string
-        source code relative repository offset
-  -repo string
-        source code repository location
+	-flavor string
+				flavor is a short string used to differentiate alternative deployments
+	-offset string
+				source code relative repository offset
+	-repo string
+				source code repository location
 `
 
 	fs := flag.NewFlagSet("rectify", flag.ContinueOnError)
@@ -80,6 +82,8 @@ func TestAddFlagsForRectify(t *testing.T) {
 
 func TestAddFlags(t *testing.T) {
 	expectedHelpText := `
+  -flavor string
+        flavor is a short string used to differentiate alternative deployments
   -offset string
         source code relative repository offset
   -repo string

--- a/cli/graph.go
+++ b/cli/graph.go
@@ -94,9 +94,9 @@ type (
 	// UserSelectedOTPLDeploySpecs is a set of otpl-deploy configured deploy
 	// specs that the user has explicitly selected. (May be empty.)
 	UserSelectedOTPLDeploySpecs struct{ sous.DeploySpecs }
-	// TargetSourceLocation is the source location being targeted, after
-	// resolving all context and flags.
-	TargetSourceLocation sous.SourceLocation
+	// TargetManifestID is the manifest ID being targeted, after resolving all
+	// context and flags.
+	TargetManifestID sous.ManifestID
 )
 
 // BuildGraph builds the dependency injection graph, used to populate commands
@@ -189,11 +189,11 @@ func newSourceContext(f *DeployFilterFlags, g GitSourceContext) (*sous.SourceCon
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting source location")
 	}
-	sl := sous.SourceLocation(tsl)
-	if sl.Repo != c.SourceLocation().Repo {
+	sl := sous.ManifestID(tsl)
+	if sl.Source.Repo != c.SourceLocation().Repo {
 		// TODO: Clone the repository, and use the cloned dir as source context.
 		return nil, errors.Errorf("source location %q is not the same as the remote %q",
-			sl.Repo, c.SourceLocation().Repo)
+			sl.Source.Repo, c.SourceLocation().Repo)
 	}
 	return c, nil
 }

--- a/cli/graph_sourcecontext.go
+++ b/cli/graph_sourcecontext.go
@@ -5,7 +5,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func newTargetSourceLocation(f *DeployFilterFlags, c *sous.SourceContext) (TargetSourceLocation, error) {
+func newTargetSourceLocation(f *DeployFilterFlags, c *sous.SourceContext) (TargetManifestID, error) {
 	if c == nil {
 		c = &sous.SourceContext{}
 	}
@@ -22,15 +22,18 @@ func newTargetSourceLocation(f *DeployFilterFlags, c *sous.SourceContext) (Targe
 	}
 	if f.Offset != "" {
 		if f.Repo == "" {
-			return TargetSourceLocation{}, errors.Errorf("you specified -offset but not -repo")
+			return TargetManifestID{}, errors.Errorf("you specified -offset but not -repo")
 		}
 		offset = f.Offset
 	}
 	if repo == "" {
-		return TargetSourceLocation{}, errors.Errorf("no repo specified, please use -repo or run sous inside a git repo")
+		return TargetManifestID{}, errors.Errorf("no repo specified, please use -repo or run sous inside a git repo")
 	}
-	return TargetSourceLocation{
-		Repo: repo,
-		Dir:  offset,
+	return TargetManifestID{
+		Source: sous.SourceLocation{
+			Repo: repo,
+			Dir:  offset,
+		},
+		Flavor: f.Flavor,
 	}, nil
 }

--- a/cli/graph_sourcecontext_test.go
+++ b/cli/graph_sourcecontext_test.go
@@ -38,19 +38,19 @@ func TestResolveSourceLocation_failure(t *testing.T) {
 	}
 }
 
-var goodResolveSourceLocationCalls = map[sous.SourceLocation][]resolveSourceLocationInput{
-	{Repo: "github.com/user/project", Dir: ""}: {
+var goodResolveSourceLocationCalls = map[sous.ManifestID][]resolveSourceLocationInput{
+	{Source: sous.SourceLocation{Repo: "github.com/user/project"}}: {
 		{Flags: &DeployFilterFlags{Repo: "github.com/user/project"}},
 		{Context: &sous.SourceContext{PrimaryRemoteURL: "github.com/user/project"}},
 	},
-	{Repo: "github.com/user/project", Dir: "some/path"}: {
+	{Source: sous.SourceLocation{Repo: "github.com/user/project", Dir: "some/path"}}: {
 		{Flags: &DeployFilterFlags{Repo: "github.com/user/project", Offset: "some/path"}},
 		{Context: &sous.SourceContext{
 			PrimaryRemoteURL: "github.com/user/project",
 			OffsetDir:        "some/path",
 		}},
 	},
-	{Repo: "github.com/from/flags", Dir: ""}: {
+	{Source: sous.SourceLocation{Repo: "github.com/from/flags"}}: {
 		{
 			Context: &sous.SourceContext{
 				PrimaryRemoteURL: "github.com/original/context",
@@ -71,11 +71,14 @@ func TestResolveSourceLocation_success(t *testing.T) {
 				t.Error(err)
 				continue
 			}
-			if actual.Repo != expected.Repo {
-				t.Errorf("got repo %q; want %q", actual.Repo, expected.Repo)
+			if actual.Source.Repo != expected.Source.Repo {
+				t.Errorf("got repo %q; want %q", actual.Source.Repo, expected.Source.Repo)
 			}
-			if actual.Dir != expected.Dir {
-				t.Errorf("got offset %q; want %q", actual.Dir, expected.Dir)
+			if actual.Source.Dir != expected.Source.Dir {
+				t.Errorf("got offset %q; want %q", actual.Source.Dir, expected.Source.Dir)
+			}
+			if actual.Flavor != expected.Flavor {
+				t.Errorf("got flavor %q; want %q", actual.Flavor, expected.Flavor)
 			}
 		}
 	}

--- a/cli/graph_targetmanifest.go
+++ b/cli/graph_targetmanifest.go
@@ -14,9 +14,9 @@ func newDetectedOTPLConfig(wd LocalWorkDirShell, otplFlags *OTPLFlags) (Detected
 	return DetectedOTPLDeploySpecs{otplDeploySpecs}, nil
 }
 
-func newUserSelectedOTPLDeploySpecs(detected DetectedOTPLDeploySpecs, tsl TargetSourceLocation, flags *OTPLFlags, state *sous.State) (UserSelectedOTPLDeploySpecs, error) {
+func newUserSelectedOTPLDeploySpecs(detected DetectedOTPLDeploySpecs, tsl TargetManifestID, flags *OTPLFlags, state *sous.State) (UserSelectedOTPLDeploySpecs, error) {
 	var nowt UserSelectedOTPLDeploySpecs
-	sl := sous.SourceLocation(tsl)
+	sl := sous.ManifestID(tsl)
 	// we don't care about these flags when a manifest already exists
 	if _, ok := state.Manifests.Get(sl); ok {
 		return nowt, nil
@@ -41,12 +41,12 @@ func newUserSelectedOTPLDeploySpecs(detected DetectedOTPLDeploySpecs, tsl Target
 	return UserSelectedOTPLDeploySpecs{deploySpecs}, nil
 }
 
-func newTargetManifest(auto UserSelectedOTPLDeploySpecs, tsl TargetSourceLocation, s *sous.State) TargetManifest {
-	sl := sous.SourceLocation(tsl)
+func newTargetManifest(auto UserSelectedOTPLDeploySpecs, tsl TargetManifestID, s *sous.State) TargetManifest {
+	mid := sous.ManifestID(tsl)
 	//ds := gdm.Filter(func(d *sous.Deployment) bool {
 	//	return d.SourceID.Location() == sl
 	//})
-	m, ok := s.Manifests.Get(sl)
+	m, ok := s.Manifests.Get(mid)
 	if ok {
 		return TargetManifest{m}
 	}
@@ -56,8 +56,8 @@ func newTargetManifest(auto UserSelectedOTPLDeploySpecs, tsl TargetSourceLocatio
 	}
 
 	m = &sous.Manifest{
-		Source:      sl,
 		Deployments: deploySpecs,
 	}
+	m.SetID(mid)
 	return TargetManifest{m}
 }

--- a/cli/graph_targetmanifest_test.go
+++ b/cli/graph_targetmanifest_test.go
@@ -8,7 +8,7 @@ import (
 
 type newUserSelectedOTPLDeploySpecTest struct {
 	Detected            sous.DeploySpecs
-	TSL                 TargetSourceLocation
+	TSL                 TargetManifestID
 	Flags               OTPLFlags
 	Clusters            sous.Clusters
 	Manifest            *sous.Manifest
@@ -96,8 +96,10 @@ func TestNewUserSelectedOTPLDeploySpecs(t *testing.T) {
 func TestNewTargetManifest(t *testing.T) {
 	detected := UserSelectedOTPLDeploySpecs{}
 	sl := sous.MustParseSourceLocation("github.com/user/project")
-	tsl := TargetSourceLocation(sl)
-	m := &sous.Manifest{Source: sl}
+	flavor := "some-flavor"
+	mid := sous.ManifestID{Source: sl, Flavor: flavor}
+	tsl := TargetManifestID(mid)
+	m := &sous.Manifest{Source: sl, Flavor: flavor}
 	s := sous.NewState()
 	s.Manifests.Add(m)
 	tm := newTargetManifest(detected, tsl, s)

--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -44,6 +44,7 @@ func (si *SousInit) RegisterOn(psy Addable) {
 // AddFlags adds the flags for sous init.
 func (si *SousInit) AddFlags(fs *flag.FlagSet) {
 	MustAddFlags(fs, &si.Flags, otplFlagsHelp)
+	fs.StringVar(&si.DeployFilterFlags.Flavor, "flavor", "", flavorFlagHelp)
 }
 
 // Execute fulfills the cmdr.Executor interface

--- a/cli/sous_update.go
+++ b/cli/sous_update.go
@@ -108,7 +108,7 @@ func updateState(s *sous.State, gdm CurrentGDM, sid sous.SourceID, did sous.Depl
 	return nil
 }
 
-func getIDs(flags DeployFilterFlags, sl sous.SourceLocation) (sous.SourceID, sous.DeployID, error) {
+func getIDs(flags DeployFilterFlags, mid sous.ManifestID) (sous.SourceID, sous.DeployID, error) {
 	clusterName, tag, sid, did := flags.Cluster, flags.Tag, sous.SourceID{}, sous.DeployID{}
 	if clusterName == "" {
 		return sid, did, UsageErrorf("You must select a cluster using the -cluster flag.")
@@ -120,7 +120,7 @@ func getIDs(flags DeployFilterFlags, sl sous.SourceLocation) (sous.SourceID, sou
 	if err != nil {
 		return sid, did, UsageErrorf("Version %q not valid: %s", flags.Tag, err)
 	}
-	sid = sl.SourceID(newVersion)
-	did = sous.DeployID{Source: sl, Cluster: clusterName}
+	sid = mid.Source.SourceID(newVersion)
+	did = sous.DeployID{ManifestID: mid, Cluster: clusterName}
 	return sid, did, nil
 }

--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -339,7 +339,7 @@ func TestCreates(t *testing.T) {
 	if assert.Len(client.deployed, 1) {
 		dep := client.deployed[0]
 		assert.Equal("cluster", dep.cluster)
-		assert.Equal("reqid 0.0.0", dep.imageName)
+		assert.Equal("reqid,0.0.0", dep.imageName)
 	}
 
 	if assert.Len(client.created, 1) {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -263,7 +263,7 @@ func deploymentWithRepo(assert *assert.Assertions, sc sous.Deployer, repo string
 func findRepo(deps sous.Deployments, repo string) sous.DeployID {
 	for i, d := range deps.Snapshot() {
 		if d != nil {
-			if i.Source.Repo == repo {
+			if i.ManifestID.Source.Repo == repo {
 				return i
 			}
 		}

--- a/lib/assemble_test.go
+++ b/lib/assemble_test.go
@@ -90,7 +90,7 @@ func TestInheritingFromGlobal(t *testing.T) {
 		t.Fatalf("got %d deployments; want %d", actualLen, expectedLen)
 	}
 
-	id := DeployID{Source: m.Source, Cluster: "sf-qa-ci"}
+	id := DeployID{ManifestID: m.ID(), Cluster: "sf-qa-ci"}
 	qa, ok := deps.Get(id)
 	if !ok {
 		t.Errorf("deployment %s not found", id)

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -26,6 +26,9 @@ type (
 		Cluster *Cluster
 		// SourceID is the precise version of the software to be deployed.
 		SourceID SourceID
+		// Flavor is the flavor of this deployment. See ManifestID for a fuller
+		// description.
+		Flavor string
 		// Owners is a map of named owners of this repository. The type of this
 		// field is subject to change.
 		Owners OwnerSet
@@ -56,8 +59,8 @@ type (
 
 	// A DeployID identifies a deployment.
 	DeployID struct {
-		Cluster string
-		Source  SourceLocation
+		ManifestID ManifestID
+		Cluster    string
 	}
 )
 
@@ -68,8 +71,16 @@ func (d *Deployment) String() string {
 // ID returns the DeployID of this deployment.
 func (d *Deployment) ID() DeployID {
 	return DeployID{
-		Source:  d.SourceID.Location,
-		Cluster: d.ClusterName,
+		ManifestID: d.ManifestID(),
+		Cluster:    d.ClusterName,
+	}
+}
+
+// ManifestID returns the ID of the Manifest describing this deployment.
+func (d *Deployment) ManifestID() ManifestID {
+	return ManifestID{
+		Source: d.SourceID.Location,
+		Flavor: d.Flavor,
 	}
 }
 
@@ -125,10 +136,7 @@ func (d *Deployment) Tabbed() string {
 
 // Name returns the DeployID.
 func (d *Deployment) Name() DeployID {
-	return DeployID{
-		Cluster: d.ClusterName,
-		Source:  d.SourceID.Location,
-	}
+	return d.ID()
 }
 
 // Equal returns true if two Deployments are equal.

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -142,7 +142,7 @@ func (d *Deployment) Name() DeployID {
 // Equal returns true if two Deployments are equal.
 func (d *Deployment) Equal(o *Deployment) bool {
 	Log.Vomit.Printf("Comparing: %+ v ?= %+ v", d, o)
-	if !(d.ClusterName == o.ClusterName && d.SourceID.Equal(o.SourceID) && d.Kind == o.Kind) { // && len(d.Owners) == len(o.Owners)) {
+	if d.ClusterName != o.ClusterName || !d.SourceID.Equal(o.SourceID) || d.Flavor != o.Flavor || d.Kind != o.Kind {
 		Log.Debug.Printf("C: %t V: %t, K: %t, #O: %t", d.ClusterName == o.ClusterName, d.SourceID.Equal(o.SourceID), d.Kind == o.Kind, len(d.Owners) == len(o.Owners))
 		return false
 	}

--- a/lib/deployment_diff_test.go
+++ b/lib/deployment_diff_test.go
@@ -88,7 +88,7 @@ func TestRealDiff(t *testing.T) {
 	}
 
 	if assert.Len(ds.Changed, 1, "Should have one modified item.") {
-		assert.Equal(repoThree, string(ds.Changed[0].name.Source.Repo))
+		assert.Equal(repoThree, string(ds.Changed[0].name.ManifestID.Source.Repo))
 		assert.Equal(repoThree, string(ds.Changed[0].Prior.SourceID.Location.Repo))
 		assert.Equal(repoThree, string(ds.Changed[0].Post.SourceID.Location.Repo))
 		assert.Equal(ds.Changed[0].Post.NumInstances, 1)

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -2,7 +2,7 @@ package sous
 
 import "path/filepath"
 
-//go:generate ggen cmap.CMap(cmap.go) sous.Manifests(manifests.go) CMKey:SourceLocation Value:*Manifest
+//go:generate ggen cmap.CMap(cmap.go) sous.Manifests(manifests.go) CMKey:ManifestID Value:*Manifest
 
 type (
 	// Manifest is a minimal representation of the global deployment state of
@@ -14,6 +14,11 @@ type (
 	Manifest struct {
 		// Source is the location of the source code for this piece of software.
 		Source SourceLocation `validate:"nonzero"`
+		// Flavor is an optional string, used to allow a single SourceLocation
+		// to have multiple deployments defined per cluster. The empty Flavor
+		// is perfectly valid. The pair (SourceLocation, Flavor) identifies a
+		// manifest.
+		Flavor string `yaml:",omitempty"`
 		// Owners is a list of named owners of this repository. The type of this
 		// field is subject to change.
 		Owners []string
@@ -35,8 +40,15 @@ type (
 )
 
 // ID returns the SourceLocation.
-func (m *Manifest) ID() SourceLocation {
-	return m.Source
+func (m Manifest) ID() ManifestID {
+	return ManifestID{Source: m.Source, Flavor: m.Flavor}
+}
+
+// SetID sets the Source and Flavor fields of this Manifest to those of the
+// supplied ManifestID.
+func (m *Manifest) SetID(mid ManifestID) {
+	m.Source = mid.Source
+	m.Flavor = mid.Flavor
 }
 
 // FileLocation returns the path that the manifest should be saved to.

--- a/lib/manifest_id.go
+++ b/lib/manifest_id.go
@@ -1,0 +1,70 @@
+package sous
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// ManifestID identifies a manifest by its SourceLocation and optional Flavor.
+type ManifestID struct {
+	// Source is the SourceLocation of deployments described in this Manifest.
+	Source SourceLocation
+	// Flavor is an optional string which can be appended if multiple different
+	// deployments of code from this SourceLocation need to be deployed in the
+	// same cluster.
+	Flavor string
+}
+
+// ParseManifestID parses a ManifestID from a SourceLocation.
+func ParseManifestID(s string) (ManifestID, error) {
+	var mid ManifestID
+	err := mid.UnmarshalText([]byte(s))
+	return mid, err
+
+}
+
+func (mid ManifestID) String() string {
+	f := ""
+	if mid.Flavor != "" {
+		f = ":" + mid.Flavor
+	}
+	return mid.Source.String() + f
+}
+
+// MarshalText implements encoding.TextMarshaler.
+// This is important for serialising maps that use ManifestID as a key.
+func (mid ManifestID) MarshalText() ([]byte, error) {
+	return []byte(mid.String()), nil
+}
+
+// UnmarshalText implements encoding.TextMarshaler.
+// This is important for deserialising maps that use ManifestID as a key.
+func (mid *ManifestID) UnmarshalText(b []byte) error {
+	parts := bytes.Split(b, []byte(":"))
+	if len(parts) > 2 {
+		return fmt.Errorf("illegal manifest ID %q (contains more than one colon)", string(b))
+	}
+	if err := mid.Source.UnmarshalText(parts[0]); err != nil {
+		return err
+	}
+	if len(parts) == 2 {
+		mid.Flavor = string(parts[1])
+	}
+	return nil
+}
+
+// MarshalYAML serializes this ManifestID to a YAML string.
+// It implements the github.com/go-yaml/yaml.Marshaler interface.
+func (mid ManifestID) MarshalYAML() (interface{}, error) {
+	return mid.String(), nil
+}
+
+// UnmarshalYAML deserializes a YAML string into this ManifestID.
+// It implements the github.com/go-yaml/yaml.Unmarshaler interface.
+func (mid *ManifestID) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	return mid.UnmarshalText([]byte(s))
+}

--- a/lib/manifest_id.go
+++ b/lib/manifest_id.go
@@ -15,18 +15,30 @@ type ManifestID struct {
 	Flavor string
 }
 
+// FlavorSeparator separates the flavor part of a ManifestID from the
+// SourceLocation part.
+const FlavorSeparator = "~"
+
 // ParseManifestID parses a ManifestID from a SourceLocation.
 func ParseManifestID(s string) (ManifestID, error) {
 	var mid ManifestID
 	err := mid.UnmarshalText([]byte(s))
 	return mid, err
+}
 
+// MustParseManifestID wraps ParseManifestID and panics if it returns an error.
+func MustParseManifestID(s string) ManifestID {
+	mid, err := ParseManifestID(s)
+	if err != nil {
+		panic(err)
+	}
+	return mid
 }
 
 func (mid ManifestID) String() string {
 	f := ""
 	if mid.Flavor != "" {
-		f = ":" + mid.Flavor
+		f = FlavorSeparator + mid.Flavor
 	}
 	return mid.Source.String() + f
 }
@@ -40,7 +52,7 @@ func (mid ManifestID) MarshalText() ([]byte, error) {
 // UnmarshalText implements encoding.TextMarshaler.
 // This is important for deserialising maps that use ManifestID as a key.
 func (mid *ManifestID) UnmarshalText(b []byte) error {
-	parts := bytes.Split(b, []byte(":"))
+	parts := bytes.Split(b, []byte(FlavorSeparator))
 	if len(parts) > 2 {
 		return fmt.Errorf("illegal manifest ID %q (contains more than one colon)", string(b))
 	}

--- a/lib/manifest_id_test.go
+++ b/lib/manifest_id_test.go
@@ -1,0 +1,140 @@
+package sous
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+var manifestIDTests = []struct {
+	String string
+	MID    ManifestID
+}{
+	{
+		String: "github.com/user/repo",
+		MID: ManifestID{
+			Source: SourceLocation{
+				Repo: "github.com/user/repo",
+			},
+		},
+	},
+	{
+		String: "github.com/user/repo,some-dir",
+		MID: ManifestID{
+			Source: SourceLocation{
+				Repo: "github.com/user/repo",
+				Dir:  "some-dir",
+			},
+		},
+	},
+	{
+		String: "github.com/user/repo,some-dir:british-flavoured",
+		MID: ManifestID{
+			Source: SourceLocation{
+				Repo: "github.com/user/repo",
+				Dir:  "some-dir",
+			},
+			Flavor: "british-flavoured",
+		},
+	},
+}
+
+func TestParseManifestID(t *testing.T) {
+	for _, test := range manifestIDTests {
+		input := test.String
+		expected := test.MID
+		actual, err := ParseManifestID(input)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if actual != expected {
+			t.Errorf("%q got %#v; want %#v", input, actual, expected)
+		}
+	}
+}
+
+func TestManifestID_String(t *testing.T) {
+	for _, test := range manifestIDTests {
+		expected := test.String
+		actual := test.MID.String()
+		if actual != expected {
+			t.Errorf("%#v got %q; want %q", test.MID, actual, expected)
+		}
+	}
+}
+
+func TestManifestID_MarshalText(t *testing.T) {
+	for _, test := range manifestIDTests {
+		input := test.MID
+		expected := test.String
+		actualBytes, err := input.MarshalText()
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		actual := string(actualBytes)
+		if actual != expected {
+			t.Errorf("%#v got %q; want %q", input, actual, expected)
+		}
+	}
+}
+
+func TestManifestID_MarshalYAML(t *testing.T) {
+	for _, test := range manifestIDTests {
+		input := test.MID
+		expected := test.String
+		actualInterface, err := input.MarshalYAML()
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		actual := actualInterface.(string)
+		if actual != expected {
+			t.Errorf("%#v got %q; want %q", input, actual, expected)
+		}
+	}
+}
+
+func TestManifestID_UnmarshalText(t *testing.T) {
+	for _, test := range manifestIDTests {
+		input := []byte(test.String)
+		expected := test.MID
+		var actual ManifestID
+		if err := actual.UnmarshalText(input); err != nil {
+			t.Error(err)
+			continue
+		}
+		if actual != expected {
+			t.Errorf("%q got %#v; want %#v", input, actual, expected)
+		}
+	}
+}
+
+func TestManifestID_UnmarshalYAML(t *testing.T) {
+	for _, test := range manifestIDTests {
+		inputStr := test.String
+		expected := test.MID
+		var actual ManifestID
+		// inputFunc mocks out behaviour of the github.com/go-yaml/yaml library.
+		inputFunc := func(v interface{}) error {
+			sp := reflect.ValueOf(v)
+			if sp.Kind() != reflect.Ptr {
+				return fmt.Errorf("got %s; want *string", sp.Type())
+			}
+			s := sp.Elem()
+			if s.Kind() != reflect.String {
+				return fmt.Errorf("got %s; want a *string", sp.Type())
+			}
+			s.Set(reflect.ValueOf(inputStr))
+			return nil
+		}
+		if err := actual.UnmarshalYAML(inputFunc); err != nil {
+			t.Error(err)
+			continue
+		}
+		if actual != expected {
+			t.Errorf("%q got %#v; want %#v", inputStr, actual, expected)
+		}
+	}
+}

--- a/lib/manifest_id_test.go
+++ b/lib/manifest_id_test.go
@@ -28,7 +28,7 @@ var manifestIDTests = []struct {
 		},
 	},
 	{
-		String: "github.com/user/repo,some-dir:british-flavoured",
+		String: "github.com/user/repo,some-dir~british-flavoured",
 		MID: ManifestID{
 			Source: SourceLocation{
 				Repo: "github.com/user/repo",

--- a/lib/manifests_generated.go
+++ b/lib/manifests_generated.go
@@ -1,4 +1,4 @@
-// DO NOT EDIT. Generated with goinline -package=github.com/opentable/sous/util/blueprints/cmap --target-package-name=sous --target-dir=. -w SourceLocation->SourceLocation *Manifest->*Manifest
+// DO NOT EDIT. Generated with goinline -package=github.com/opentable/sous/util/blueprints/cmap --target-package-name=sous --target-dir=. -w ManifestID->ManifestID *Manifest->*Manifest
 
 package sous
 
@@ -7,18 +7,18 @@ import (
 	"sync"
 )
 
-// Manifests is a wrapper around map[SourceLocation]*Manifest
+// Manifests is a wrapper around map[ManifestID]*Manifest
 // which is safe for concurrent read and write.
 type Manifests struct {
 	mu *sync.RWMutex
-	m  map[SourceLocation](*Manifest)
+	m  map[ManifestID](*Manifest)
 }
 
 // MakeManifests creates a new Manifests with capacity set.
 func MakeManifests(capacity int) Manifests {
 	return Manifests{
 		mu: &sync.RWMutex{},
-		m:  make(map[SourceLocation](*Manifest), capacity),
+		m:  make(map[ManifestID](*Manifest), capacity),
 	}
 }
 
@@ -42,13 +42,13 @@ func (m Manifests) read(f func()) {
 
 // NewManifestsFromMap creates a new Manifests.
 // You may optionally pass any number of
-// map[SourceLocation]*Manifests,
+// map[ManifestID]*Manifests,
 // which will be merged key-wise into the new Manifests,
 // with keys from the right-most map taking precedence.
-func NewManifestsFromMap(from ...map[SourceLocation](*Manifest)) Manifests {
+func NewManifestsFromMap(from ...map[ManifestID](*Manifest)) Manifests {
 	cm := Manifests{
 		mu: &sync.RWMutex{},
-		m:  map[SourceLocation](*Manifest){},
+		m:  map[ManifestID](*Manifest){},
 	}
 	for _, m := range from {
 		for k, v := range m {
@@ -64,7 +64,7 @@ func NewManifestsFromMap(from ...map[SourceLocation](*Manifest)) Manifests {
 func NewManifests(from ...(*Manifest)) Manifests {
 	m := Manifests{
 		mu: &sync.RWMutex{},
-		m:  map[SourceLocation](*Manifest){},
+		m:  map[ManifestID](*Manifest){},
 	}
 	for _, v := range from {
 		if !m.Add(v) {
@@ -76,7 +76,7 @@ func NewManifests(from ...(*Manifest)) Manifests {
 
 // Get returns (value, true) if k is in the map, or (zero value, false)
 // otherwise.
-func (m Manifests) Get(key SourceLocation) (v *Manifest, ok bool) {
+func (m Manifests) Get(key ManifestID) (v *Manifest, ok bool) {
 	m.read(func() {
 		v, ok = m.m[key]
 	})
@@ -84,7 +84,7 @@ func (m Manifests) Get(key SourceLocation) (v *Manifest, ok bool) {
 }
 
 // Set sets the value of index k to v.
-func (m Manifests) Set(key SourceLocation, value *Manifest) {
+func (m Manifests) Set(key ManifestID, value *Manifest) {
 	m.write(func() {
 		m.m[key] = value
 	})
@@ -97,7 +97,7 @@ func (m Manifests) Filter(predicate func(*Manifest) bool) Manifests {
 	if predicate == nil {
 		return m.Clone()
 	}
-	out := map[SourceLocation](*Manifest){}
+	out := map[ManifestID](*Manifest){}
 	m.read(func() {
 		for k, v := range m.m {
 			if predicate(v) {
@@ -171,11 +171,11 @@ func (m Manifests) MustAdd(v *Manifest) {
 	}
 }
 
-// AddAll returns (zero SourceLocation, true) if all  entries from the passed in
+// AddAll returns (zero ManifestID, true) if all  entries from the passed in
 // Manifests have different keys and all are added to this Manifests.
 // If any of the keys conflict, nothing will be added to this
-// Manifests and AddAll will return the conflicting SourceLocation and false.
-func (m Manifests) AddAll(from Manifests) (conflicting SourceLocation, success bool) {
+// Manifests and AddAll will return the conflicting ManifestID and false.
+func (m Manifests) AddAll(from Manifests) (conflicting ManifestID, success bool) {
 	ss := from.Snapshot()
 	var exists bool
 	m.write(func() {
@@ -193,7 +193,7 @@ func (m Manifests) AddAll(from Manifests) (conflicting SourceLocation, success b
 }
 
 // Remove value for a key k if present, a no-op otherwise.
-func (m Manifests) Remove(key SourceLocation) {
+func (m Manifests) Remove(key ManifestID) {
 	m.write(func() {
 		delete(m.m, key)
 	})
@@ -209,10 +209,10 @@ func (m Manifests) Len() int {
 }
 
 // Keys returns a slice containing all the keys in the map.
-func (m Manifests) Keys() []SourceLocation {
-	var keys []SourceLocation
+func (m Manifests) Keys() []ManifestID {
+	var keys []ManifestID
 	m.read(func() {
-		keys = make([]SourceLocation, len(m.m))
+		keys = make([]ManifestID, len(m.m))
 		i := 0
 		for k := range m.m {
 			keys[i] = k
@@ -223,11 +223,11 @@ func (m Manifests) Keys() []SourceLocation {
 }
 
 // Snapshot returns a moment-in-time copy of the current underlying
-// map[SourceLocation]*Manifest.
-func (m Manifests) Snapshot() map[SourceLocation](*Manifest) {
-	var ss map[SourceLocation](*Manifest)
+// map[ManifestID]*Manifest.
+func (m Manifests) Snapshot() map[ManifestID](*Manifest) {
+	var ss map[ManifestID](*Manifest)
 	m.read(func() {
-		ss = make(map[SourceLocation](*Manifest), len(m.m))
+		ss = make(map[ManifestID](*Manifest), len(m.m))
 		for k, v := range m.m {
 			ss[k] = v
 		}
@@ -236,11 +236,11 @@ func (m Manifests) Snapshot() map[SourceLocation](*Manifest) {
 }
 
 // FilteredSnapshot returns a moment-in-time filtered copy of the current
-// underlying map[SourceLocation]*Manifest.
-// (SourceLocation, *Manifest) pairs are included
+// underlying map[ManifestID]*Manifest.
+// (ManifestID, *Manifest) pairs are included
 // if they satisfy predicate.
-func (m Manifests) FilteredSnapshot(predicate func(*Manifest) bool) map[SourceLocation](*Manifest) {
-	clone := map[SourceLocation](*Manifest){}
+func (m Manifests) FilteredSnapshot(predicate func(*Manifest) bool) map[ManifestID](*Manifest) {
+	clone := map[ManifestID](*Manifest){}
 	m.read(func() {
 		for k, v := range m.m {
 			if predicate(v) {
@@ -252,13 +252,13 @@ func (m Manifests) FilteredSnapshot(predicate func(*Manifest) bool) map[SourceLo
 }
 
 // GetAll returns SnapShot (it allows hy to marshal Manifests).
-func (m Manifests) GetAll() map[SourceLocation](*Manifest) {
+func (m Manifests) GetAll() map[ManifestID](*Manifest) {
 	return m.Snapshot()
 }
 
 // SetAll sets the internal map (it allows hy to unmarshal Manifests).
 // Note: SetAll is the only method that is not safe for concurrent access.
-func (m *Manifests) SetAll(v map[SourceLocation](*Manifest)) {
+func (m *Manifests) SetAll(v map[ManifestID](*Manifest)) {
 	if m.mu == nil {
 		m.mu = &sync.RWMutex{}
 	}

--- a/lib/map_state_to_deployments.go
+++ b/lib/map_state_to_deployments.go
@@ -31,7 +31,7 @@ func (s *State) Deployments() (Deployments, error) {
 		cluster, ok := s.Defs.Clusters[d.ClusterName]
 		if !ok {
 			return ds, errors.Errorf("cluster %q is not described in defs.yaml (but specified in manifest %q)",
-				d.ClusterName, id.Source)
+				d.ClusterName, id.ManifestID)
 		}
 		if cluster == nil {
 			return ds, errors.Errorf("cluster %q is nil, check defs.yaml", d.ClusterName)
@@ -56,16 +56,16 @@ func (ds Deployments) Manifests(defs Defs) (Manifests, error) {
 			}
 			d.Cluster = cluster
 		}
-		sl := d.SourceID.Location
-		// Lookup the current manifest for this source location.
-		m, ok := ms.Get(sl)
+		// Lookup the current manifest for this deployment.
+		mid := d.ManifestID()
+		m, ok := ms.Get(mid)
 		if !ok {
 			m = &Manifest{Deployments: DeploySpecs{}}
 			for o := range d.Owners {
 				// TODO: de-dupe or use a set on manifests.
 				m.Owners = append(m.Owners, o)
 			}
-			m.Source = sl
+			m.SetID(mid)
 		}
 		spec := DeploySpec{
 			Version:      d.SourceID.Version,
@@ -81,7 +81,7 @@ func (ds Deployments) Manifests(defs Defs) (Manifests, error) {
 			}
 		}
 		m.Deployments[d.ClusterName] = spec
-		ms.Set(sl, m)
+		ms.Set(mid, m)
 	}
 	return ms, nil
 }

--- a/lib/map_state_to_deployments.go
+++ b/lib/map_state_to_deployments.go
@@ -122,6 +122,7 @@ func BuildDeployment(s *State, m *Manifest, nick string, spec DeploySpec, inheri
 		ClusterName:  nick,
 		Cluster:      s.Defs.Clusters[nick],
 		DeployConfig: ds.DeployConfig,
+		Flavor:       m.Flavor,
 		Owners:       ownMap,
 		Kind:         m.Kind,
 		SourceID:     m.Source.SourceID(ds.Version),

--- a/lib/map_state_to_deployments_test.go
+++ b/lib/map_state_to_deployments_test.go
@@ -163,7 +163,7 @@ func TestDeployments_Manifests(t *testing.T) {
 		}
 		// Check all expected DeploySpecs are in actual.
 		for clusterName := range expected.Deployments {
-			did := DeployID{Cluster: clusterName, Source: expected.Source}
+			did := DeployID{Cluster: clusterName, ManifestID: expected.ID()}
 			_, ok := actual.Deployments[clusterName]
 			if !ok {
 				t.Errorf("deployment %q missing", did)
@@ -173,7 +173,7 @@ func TestDeployments_Manifests(t *testing.T) {
 		}
 		// Check actual contains only the expected DeploySpecs.
 		for clusterName := range actual.Deployments {
-			did := DeployID{Cluster: clusterName, Source: actual.Source}
+			did := DeployID{Cluster: clusterName, ManifestID: actual.ID()}
 			_, ok := expected.Deployments[clusterName]
 			if !ok {
 				t.Errorf("extra deployment %q", did)

--- a/lib/map_state_to_deployments_test.go
+++ b/lib/map_state_to_deployments_test.go
@@ -79,6 +79,39 @@ func makeTestState() *State {
 					},
 				},
 			},
+			&Manifest{
+				Source: project1,
+				Flavor: "some-flavor",
+				Owners: []string{"owner1flav"},
+				Deployments: DeploySpecs{
+					"cluster-1": {
+						Version: semv.MustParse("1.0.1"),
+						DeployConfig: DeployConfig{
+							Resources: Resources{
+								"cpus": "1.5",
+								"mem":  "1024",
+							},
+							Env: Env{
+								"ENV_1": "ENV ONE FLAVORED",
+							},
+							NumInstances: 4,
+						},
+					},
+					"cluster-2": {
+						Version: semv.MustParse("2.0.1"),
+						DeployConfig: DeployConfig{
+							Resources: Resources{
+								"cpus": "2.5",
+								"mem":  "2048",
+							},
+							Env: Env{
+								"ENV_2": "ENV TWO FLAVORED",
+							},
+							NumInstances: 5,
+						},
+					},
+				},
+			},
 		),
 	}
 }
@@ -88,7 +121,7 @@ var expectedDeployments = NewDeployments(
 		SourceID:    project1.SourceID(semv.MustParse("1.0.0")),
 		ClusterName: "cluster-1",
 		Cluster:     cluster1,
-		Owners:      OwnerSet{"owner1": struct{}{}},
+		Owners:      NewOwnerSet("owner1"),
 		DeployConfig: DeployConfig{
 			Resources: Resources{
 				"cpus": "1",
@@ -105,7 +138,7 @@ var expectedDeployments = NewDeployments(
 		SourceID:    project1.SourceID(semv.MustParse("2.0.0")),
 		ClusterName: "cluster-2",
 		Cluster:     cluster2,
-		Owners:      OwnerSet{"owner1": struct{}{}},
+		Owners:      NewOwnerSet("owner1"),
 		DeployConfig: DeployConfig{
 			Resources: Resources{
 				"cpus": "2",
@@ -116,6 +149,42 @@ var expectedDeployments = NewDeployments(
 				"CLUSTER_LONG_NAME": "Cluster Two",
 			},
 			NumInstances: 3,
+		},
+	},
+	&Deployment{
+		Flavor:      "some-flavor",
+		SourceID:    project1.SourceID(semv.MustParse("1.0.1")),
+		ClusterName: "cluster-1",
+		Cluster:     cluster1,
+		Owners:      NewOwnerSet("owner1flav"),
+		DeployConfig: DeployConfig{
+			Resources: Resources{
+				"cpus": "1.5",
+				"mem":  "1024",
+			},
+			Env: Env{
+				"ENV_1":             "ENV ONE FLAVORED",
+				"CLUSTER_LONG_NAME": "Cluster One",
+			},
+			NumInstances: 4,
+		},
+	},
+	&Deployment{
+		Flavor:      "some-flavor",
+		SourceID:    project1.SourceID(semv.MustParse("2.0.1")),
+		ClusterName: "cluster-2",
+		Cluster:     cluster2,
+		Owners:      NewOwnerSet("owner1flav"),
+		DeployConfig: DeployConfig{
+			Resources: Resources{
+				"cpus": "2.5",
+				"mem":  "2048",
+			},
+			Env: Env{
+				"ENV_2":             "ENV TWO FLAVORED",
+				"CLUSTER_LONG_NAME": "Cluster Two",
+			},
+			NumInstances: 5,
 		},
 	},
 )
@@ -150,12 +219,12 @@ func TestDeployments_Manifests(t *testing.T) {
 	if actualLen != expectedLen {
 		t.Fatalf("got %d manifests; want %d", actualLen, expectedLen)
 	}
-	for _, sl := range expectedManifests.Keys() {
-		t.Log(sl, "READING")
-		expected, _ := expectedManifests.Get(sl)
-		actual, ok := actualManifests.Get(sl)
+	for _, mid := range expectedManifests.Keys() {
+		t.Log(mid, "READING")
+		expected, _ := expectedManifests.Get(mid)
+		actual, ok := actualManifests.Get(mid)
 		if !ok {
-			t.Errorf("missing manifest %q", sl)
+			t.Errorf("missing manifest %q", mid)
 			continue
 		}
 		if !actual.Equal(expected) {
@@ -179,7 +248,7 @@ func TestDeployments_Manifests(t *testing.T) {
 				t.Errorf("extra deployment %q", did)
 			}
 		}
-		t.Log(sl, "OK")
+		t.Log(mid, "OK")
 	}
 }
 

--- a/lib/owner_set.go
+++ b/lib/owner_set.go
@@ -3,6 +3,15 @@ package sous
 // OwnerSet collects the names of the owners of a deployment.
 type OwnerSet map[string]struct{}
 
+// NewOwnerSet creates a new owner set from the provided list of owners.
+func NewOwnerSet(owners ...string) OwnerSet {
+	os := OwnerSet{}
+	for _, o := range owners {
+		os.Add(o)
+	}
+	return os
+}
+
 // Add adds an owner to an ownerset.
 func (os OwnerSet) Add(owner string) {
 	os[owner] = struct{}{}

--- a/lib/source_id.go
+++ b/lib/source_id.go
@@ -50,7 +50,7 @@ func (sid SourceID) String() string {
 	if sid.Location.Dir == "" {
 		return fmt.Sprintf("%s,%s", sid.Location.Repo, sid.Version)
 	}
-	return fmt.Sprintf("%s,%s,%s", sid.Location.Repo, sid.Location.Dir, sid.Version)
+	return fmt.Sprintf("%s,%s,%s", sid.Location.Repo, sid.Version, sid.Location.Dir)
 }
 
 // Tag returns the version tag for this source ID.

--- a/lib/source_id.go
+++ b/lib/source_id.go
@@ -48,9 +48,9 @@ const DefaultDelim = ","
 
 func (sid SourceID) String() string {
 	if sid.Location.Dir == "" {
-		return fmt.Sprintf("%s %s", sid.Location.Repo, sid.Version)
+		return fmt.Sprintf("%s,%s", sid.Location.Repo, sid.Version)
 	}
-	return fmt.Sprintf("%s:%s %s", sid.Location.Repo, sid.Location.Dir, sid.Version)
+	return fmt.Sprintf("%s,%s,%s", sid.Location.Repo, sid.Location.Dir, sid.Version)
 }
 
 // Tag returns the version tag for this source ID.

--- a/lib/source_id_test.go
+++ b/lib/source_id_test.go
@@ -126,3 +126,50 @@ func TestMustNewSourceID_failure(t *testing.T) {
 		t.Errorf("got error %q; want %q", actual, expected)
 	}
 }
+
+var sourceIDStringTests = map[string]SourceID{
+	"github.com/opentable/sous,1": {
+		Location: SourceLocation{
+			Repo: "github.com/opentable/sous",
+		},
+		Version: semv.MustParse("1"),
+	},
+	"github.com/opentable/sous,1,util": {
+		Location: SourceLocation{
+			Repo: "github.com/opentable/sous",
+			Dir:  "util",
+		},
+		Version: semv.MustParse("1"),
+	},
+	"git+ssh://github.com/opentable/sous,1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3,sous": {
+		Location: SourceLocation{
+			Repo: "git+ssh://github.com/opentable/sous",
+			Dir:  "sous",
+		},
+		Version: semv.MustParse("1.0.0-pre+4f850e9030224f528cfdb085d558f8508d06a6d3"),
+	},
+}
+
+func TestSourceID_String(t *testing.T) {
+	for expected, input := range sourceIDStringTests {
+		actual := input.String()
+		if actual != expected {
+			t.Errorf("%+v got %q; want %q", input, actual, expected)
+		}
+	}
+}
+
+func TestSourceID_roundtrip_String_Parse(t *testing.T) {
+	for _, sid := range sourceIDStringTests {
+		intermediate := sid.String()
+		expected := sid
+		actual, err := ParseSourceID(intermediate)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if actual != expected {
+			t.Errorf("%+v round-tripped as %+v", actual, expected)
+		}
+	}
+}

--- a/lib/source_location.go
+++ b/lib/source_location.go
@@ -11,15 +11,13 @@ import (
 type (
 	// SourceLocation identifies a directory inside a source code repository.
 	// Note that the directory is ambiguous without the addition of a revision
-	// ID. This type is used as a shorthand for deploy manifests, enabling the
-	// logical grouping of deploys of different versions of a particular
-	// service.
+	// ID.
 	SourceLocation struct {
 		// Repo identifies a source code repository.
 		Repo,
 		// Dir is a directory within the repository at Repo containing the
 		// source code for one piece of software.
-		Dir string `yaml:",omitempty"`
+		Dir string
 	}
 )
 

--- a/lib/source_location.go
+++ b/lib/source_location.go
@@ -2,9 +2,7 @@ package sous
 
 import (
 	"fmt"
-	"io"
 
-	"github.com/pkg/errors"
 	"github.com/samsalisbury/semv"
 )
 
@@ -69,15 +67,9 @@ func (sl SourceLocation) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements encoding.TextMarshaler.
 func (sl *SourceLocation) UnmarshalText(b []byte) error {
-	s := string(b)
-	n, err := fmt.Sscanf(s, "%s %s", &sl.Repo, &sl.Dir)
-	if err != nil && err != io.EOF {
-		return errors.Wrapf(err, "unable to unmarshal source location %q", s)
-	}
-	if n == 0 {
-		return errors.Errorf("incomplete source location %q", s)
-	}
-	return nil
+	var err error
+	*sl, err = ParseSourceLocation(string(b))
+	return err
 }
 
 // UnmarshalYAML deserializes a YAML document into this SourceLocation

--- a/lib/source_location.go
+++ b/lib/source_location.go
@@ -97,7 +97,7 @@ func (sl SourceLocation) String() string {
 	if sl.Dir == "" {
 		return fmt.Sprintf("%s", sl.Repo)
 	}
-	return fmt.Sprintf("%s:%s", sl.Repo, sl.Dir)
+	return fmt.Sprintf("%s,%s", sl.Repo, sl.Dir)
 }
 
 // SourceID returns a SourceID built from this location with the addition of a version.

--- a/lib/source_location_test.go
+++ b/lib/source_location_test.go
@@ -44,3 +44,16 @@ func TestMustParseSourceLocation(t *testing.T) {
 		}
 	}
 }
+
+func TestSourceLocation_UnmarshalText(t *testing.T) {
+	for in, expected := range parseSourceLocationTests {
+		var actual SourceLocation
+		if err := actual.UnmarshalText([]byte(in)); err != nil {
+			t.Error(err)
+			continue
+		}
+		if actual != expected {
+			t.Errorf("%q got %#v; want %#v", in, actual, expected)
+		}
+	}
+}


### PR DESCRIPTION
Includes #148 

This PR implements the concept of "Flavor" as part of a manifest's and deployment's ID.

Flavor is a way to multiply deployments of a single codebase per cluster. The name "Flavor" is already in use at OpenTable to describe short strings used for this purpose, so we have kept the name.

The original spec we imagined for ManifestID.String was to use a colon to separate the SourceLocation from the Flavor, however this makes for file paths in the GDM that are difficult to work with (colon being the default path list separator on gnu/linux type operating systems). Therefore, the implementation uses tilde `~` to separate the two. This means that tilde is a special character in Sous, and for now will not be usable in repository names. Follow-up PR coming to make sure we validate incoming source locations, tags (versions), and cluster names to ensure none of them make use of tilde or comma, which are both special characters for Sous.

It would be possible to use alternative encoding for file paths based on ManifestID, however that would add significant complexity, which we don't need to tackle, at least not yet.

Similarly, we originally intended for the comma separator used in SourceIDs to be optional, by specifying an alternative separator at the start of the line. We can still accept this for user input for now, but regardless will validate that source locations and tags do not contain commas or tildes in their particles, to avoid the cost of allowing escape chars. If this becomes a problem later (e.g. we need to support SourceLocations containing commas and tildes), then we can address it by adding escaping at that point. I doubt this will ever become an issue for more than a couple of oddball repositories though.