### PR TITLE
Version

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -103,10 +103,7 @@ for T in "${REQUESTED_TARGETS[@]}"; do
 
 	export GOOS="${PARTS[0]}" GOARCH="${PARTS[1]}"
 
-	flags="-X 'main.RevisionID=$COMMIT' \
-		-X 'main.VersionString=$VERSION' \
-		-X 'main.OS=$GOOS' -X 'main.Arch=$GOARCH' \
-		-X 'main.GoVersion=$GOVERSION'"
+	flags="-X 'main.RevisionID=$COMMIT'"
 
 	ART_PATH="$ARTIFACTS_DIR/$VERSION/$GOOS/$GOARCH"
 	

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -12,7 +12,6 @@ import (
 	"github.com/opentable/sous/util/cmdr"
 	"github.com/opentable/sous/util/yaml"
 	"github.com/pkg/errors"
-	"github.com/samsalisbury/semv"
 )
 
 // Func aliases, for convenience returning from commands.
@@ -70,15 +69,16 @@ func (cli *CLI) Plumbing(cmd cmdr.Executor, args []string) cmdr.Result {
 	return cmd.Execute(args)
 }
 
+// BuildCLIGraph builds the CLI DI graph.
 func BuildCLIGraph(cli *CLI, root *Sous, out, err io.Writer) *graph.SousGraph {
 	g := graph.BuildGraph(out, err)
 	g.Add(cli)
 	g.Add(root)
 	g.Add(func(c *CLI) graph.Out {
-		return graph.Out{c.Out}
+		return graph.Out{Output: c.Out}
 	})
 	g.Add(func(c *CLI) graph.ErrOut {
-		return graph.ErrOut{c.Err}
+		return graph.ErrOut{Output: c.Err}
 	})
 	cli.SousGraph = g //Ugh, weird state.
 
@@ -86,9 +86,7 @@ func BuildCLIGraph(cli *CLI, root *Sous, out, err io.Writer) *graph.SousGraph {
 }
 
 // NewSousCLI creates a new Sous cli app.
-func NewSousCLI(v semv.Version, out, errout io.Writer) (*CLI, error) {
-
-	s := &Sous{Version: v}
+func NewSousCLI(s *Sous, out, errout io.Writer) (*CLI, error) {
 
 	stdout := cmdr.NewOutput(out)
 	stderr := cmdr.NewOutput(errout)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -18,7 +18,8 @@ func prepareCommand(t *testing.T, cl []string) (*CLI, *cmdr.PreparedExecution, f
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	c, err := NewSousCLI(semv.MustParse(`1.2.3`), stdout, stderr)
+	s := &Sous{Version: semv.MustParse(`1.2.3`)}
+	c, err := NewSousCLI(s, stdout, stderr)
 	require.NoError(err)
 
 	exe, err := c.Prepare(cl)
@@ -251,7 +252,8 @@ func TestInvokeWithUnknownFlags(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	c, err := NewSousCLI(semv.MustParse(`1.2.3`), stdout, stderr)
+	s := &Sous{Version: semv.MustParse(`1.2.3`)}
+	c, err := NewSousCLI(s, stdout, stderr)
 	require.NoError(err)
 
 	c.Invoke([]string{`sous`, `-cobblers`})

--- a/cli/sous.go
+++ b/cli/sous.go
@@ -21,6 +21,12 @@ type Sous struct {
 	Err *graph.ErrOut
 	// Version is the version of Sous itself.
 	Version semv.Version
+	// OS is the OS this Sous is running on.
+	OS string
+	// Arch is the architecture this Sous is running on.
+	Arch string
+	// GoVersion is the version of Go this sous was built with.
+	GoVersion string
 	// flags holds the values of flags passed to this command
 	flags struct {
 		Help bool

--- a/cli/sous_version.go
+++ b/cli/sous_version.go
@@ -21,5 +21,7 @@ func (*SousVersion) Help() string { return sousVersionHelp }
 
 // Execute runs the 'sous version' command.
 func (sv *SousVersion) Execute(args []string) cmdr.Result {
-	return cmdr.Successf("sous version %s", sv.Sous.Version)
+	out := `sous version %s %s/%s (built with %s)`
+	s := sv.Sous
+	return Successf(out, s.Version, s.OS, s.Arch, s.GoVersion)
 }

--- a/cli/sous_version.go
+++ b/cli/sous_version.go
@@ -2,6 +2,7 @@ package cli
 
 import "github.com/opentable/sous/util/cmdr"
 
+// SousVersion is the 'sous version' command.
 type SousVersion struct {
 	Sous *Sous
 }
@@ -13,15 +14,12 @@ print the version of sous
 
 prints the current version of sous. Please include the output from this
 command with any bug reports sent to https://github.com/opentable/sous/issues
-
-args:
-
-Sous is versioned using semver. There are three versioned pieces of Sous:
-Sous Engine, Sous Server, and Sous CLI.
 `
 
+// Help returns help for sous version.
 func (*SousVersion) Help() string { return sousVersionHelp }
 
+// Execute runs the 'sous version' command.
 func (sv *SousVersion) Execute(args []string) cmdr.Result {
 	return cmdr.Successf("sous version %s", sv.Sous.Version)
 }

--- a/cli/tests/sous_test.go
+++ b/cli/tests/sous_test.go
@@ -28,5 +28,5 @@ func TestSousVersion(t *testing.T) {
 	term.RunCommand("sous version")
 	term.Stderr.ShouldHaveNumLines(0)
 	term.Stdout.ShouldHaveNumLines(1)
-	term.Stdout.ShouldHaveExactLine("sous version 1.0.0-test")
+	term.Stdout.ShouldHaveLineContaining("sous version")
 }

--- a/main.go
+++ b/main.go
@@ -8,6 +8,14 @@ import (
 	"github.com/opentable/sous/cli"
 )
 
+// Sous is the Sous CLI root command.
+var Sous = &cli.Sous{
+	Version:   Version,
+	OS:        OS,
+	Arch:      Arch,
+	GoVersion: GoVersion,
+}
+
 func main() {
 	defer handlePanic()
 	// Eventually, these should become flags on the top level application
@@ -15,13 +23,7 @@ func main() {
 	//sous.Log.Debug.SetOutput(os.Stderr)
 	log.SetFlags(log.Flags() | log.Lshortfile)
 
-	s := &cli.Sous{
-		Version:   Version,
-		OS:        OS,
-		Arch:      Arch,
-		GoVersion: GoVersion,
-	}
-	c, err := cli.NewSousCLI(s, os.Stdout, os.Stderr)
+	c, err := cli.NewSousCLI(Sous, os.Stdout, os.Stderr)
 	if err != nil {
 		die(err)
 	}

--- a/main.go
+++ b/main.go
@@ -15,7 +15,13 @@ func main() {
 	//sous.Log.Debug.SetOutput(os.Stderr)
 	log.SetFlags(log.Flags() | log.Lshortfile)
 
-	c, err := cli.NewSousCLI(Version, os.Stdout, os.Stderr)
+	s := &cli.Sous{
+		Version:   Version,
+		OS:        OS,
+		Arch:      Arch,
+		GoVersion: GoVersion,
+	}
+	c, err := cli.NewSousCLI(s, os.Stdout, os.Stderr)
 	if err != nil {
 		die(err)
 	}

--- a/version.go
+++ b/version.go
@@ -1,19 +1,23 @@
 package main
 
-import "github.com/samsalisbury/semv"
+import (
+	"runtime"
 
-var (
-	// These variables are set by build flags.
-	VersionString, OS, Arch, GoVersion string
-	// Revision should be set by the build process using build flags.
-	Revision string
-	// Version is the current version of Sous
-	Version semv.Version
+	"github.com/samsalisbury/semv"
 )
 
-func init() {
-	if VersionString == "" {
-		VersionString = "0.0.0-unversioned"
-	}
-	Version = semv.MustParse(VersionString)
-}
+// VersionString is the version of Sous.
+const VersionString = "0.0.1"
+
+var (
+	// Version is the version of Sous.
+	Version = semv.MustParse(VersionString + "+" + Revision)
+	// OS is the OS this Sous is running on.
+	OS = runtime.GOOS
+	// Arch is the architecture this Sous is running on.
+	Arch = runtime.GOARCH
+	// GoVersion is the version of Go this sous was built with.
+	GoVersion = runtime.Version()
+	// Revision may be set by the build process using build flags.
+	Revision string
+)


### PR DESCRIPTION
I was about to release 0.0.2, then noticed the version command was a bit rubbish and mostly reports the unhelpful '0.0.0-unversioned'. Now we at least get the major.minor.patch, even when the build fails to inject version strings via flags.

Commit message:

- In the interests of simplicity, make VersionString a constant.
- This also means less environmental data leaking into the build.
- Revision is still respected if injected by the build flags.
- 'sous version' now outputs OS/Arch and the Go version.
- This may be useful debug info at some point.
- Intention is now to release by first incrementing VersionString, then
  adding a tag to the repo to create the release.