### PR TITLE
Sous version 0.1

### DIFF
--- a/doc/sous0.1.md
+++ b/doc/sous0.1.md
@@ -1,0 +1,133 @@
+# Sous 0.1 release notes
+
+## Sous 0.1
+
+Sous 0.1 adds:
+- A number of new features to the CLI.
+  - `sous deploy` command (alpha)
+  - `-flavor` flag, and support for flavors (see below)
+  - `-source` flag which can be used instead of `-repo` and `-offset`
+- Automatic migrations for the Docker image name cache.
+- Consistent identifier parse and print round-tripping.
+- Updates to various pieces of documentation.
+- Nicer Singularity request names.
+
+### Consistency
+
+- Changes to the schema of the local Docker image name cache database no longer require user
+  intervention and re-building the entire cache from source. Now, we track the schema, and
+  migrate your cache as necessary.
+- SourceIDs and SourceLocations now correctly round-trip from parse to string and back again.
+- SourceLocations now have a single parse method, so we always get the same results and/or errors. 
+- We somehow abbreviated "Actual Deployment Set" "ADC" ?! That's fixed, we're now using "ADS".
+
+### CLI
+
+#### New command `sous deploy` (alpha)
+
+Is intended to provide a hook for deploying single applications from a CI context.
+Right now, this command works with a local GDM, modifying it, and running rectification
+locally.
+Over time, we will migrate how this command works whilst maintaining its interface and
+semantics.
+(The intention is that eventually 'sous deploy' will work by making an API call and
+allowing the server to handle updating the GDM and rectifying.)
+
+#### New flag `-flavor`
+
+Actually, this is more than a flag, it affects the underlying data model, and the way
+we think about how deployments are grouped.
+
+Previously, Sous enabled at most a single deployment configuration per SourceLocation
+per cluster. This model covers 90% of our use cases at OpenTable, but there are
+exceptions.
+
+We added "flavor" as a core concept in Sous, which allows multiple different deployment
+configurations to be defined for a single codebase (SourceLocation) in each cluster. We
+don't expect this feature to be used very much, but in those cases where configuration
+needs to be more granular than per cluster, you now have that option available.
+
+All commands that accept the `-source` flag (and/or the `-repo` and `-offset` flags) now
+also accept the `-flavor` flag. Flavor is intended to be a short string made of
+alphanumerics and possibly a hyphen, although we are not yet validating this string.
+Each `-flavor` of a given `-source` is treated as a separate application, and has its
+own manifest, allowing that application to be configured globally by a single manifest,
+just like any other.
+
+To create a new flavored application, you need to `sous init` with a `-flavor` flag. E.g.:
+
+    sous init -flavor orange
+
+From inside a repository would initiate a flavored manifest for that repo. Further calls
+to `sous update`, `sous deploy`, etc, need to also specify the flavor `orange` to
+work with that manifest. You can add an arbitrary number of flavors per SourceLocation,
+and using a flavored manifest does not preclude you from also using a standard manifest
+with no explicit flavor.
+
+#### New flag `-source`
+
+The `-source` flag is intended to be a replacement for the `-repo` and
+`-offset` combination, for use in development environments. Note that we do not have
+any plans to remove `-repo` and `-offset` since they may still be useful, especially
+in scripting environments.
+
+Source allows you to specify your SourceLocation in a single flag.
+Source also performs additional validation,
+ensuring that the source you pass can be handled by Sous end-to-end.
+At present, that
+means the repository must be a GitHub-based, in the form:
+
+    github.com/<user>/<repo>
+
+If your source code is not based in the root of the repository, you can add the offset
+by separating it with a comma, e.g.:
+
+    github.com/<user>/<repo>,<offset>
+
+Because GitHub repository paths have a fixed format that Sous understands, you can
+optionally use a slash instead of a comma, so the following is equivalent:
+
+    github.com/<user>/<repo>/<offset>
+
+(and offset can itself contain slashes if necessary, just like before).
+
+### Documentation
+
+We have made various documentation improvements, but there are definitely some that are
+still out of date, which we will look to resolve in the coming weeks. Improvements made
+in this release include:
+
+- Better description of networking setup for Singularity deployments.
+- Update to the deployment workflow documentation.
+- Some fixes to the getting started document.
+
+### Singularity request names
+
+Up until now, Singularity request names looked something like this:
+
+    github.comopentablereponameclustername
+
+Which is not a great user experience, and has a large chance of causing naming collisions.
+This version of Sous changes these names to use the form:
+
+    <SourceLocation>:<Flavor>:<ClusterName>
+
+E.g. for a simple repo with no offset or flavor, it looks like this:
+
+    github.com>opentable>sous::cluster-name
+
+With an offset and flavor, it expands to something like this:
+
+    github.com>opentable>sous,offset:flavor-name:cluster-name
+
+
+### Other
+
+There have been numerous other small tweaks and fixes, mostly at code level to make our
+own lives easier. We are also conscientiously working on improving test coverage, and this
+cycle hit 54%, we expect to see that rise quickly now that we fail CI when it falls. You
+can track test coverage at https://codecov.io/gh/opentable/sous.
+
+For more gory detail, check out the [full list of commits between 0.0.1 and 0.1.0](https://github.com/opentable/sous/compare/v0.0.1...v0.1.0).
+
+

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -1,6 +1,9 @@
 package singularity
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/opentable/go-singularity"
 	"github.com/opentable/sous/lib"
 	"github.com/satori/go.uuid"
@@ -158,11 +161,13 @@ func computeRequestID(d *sous.Deployment) string {
 	if len(d.RequestID) > 0 {
 		return d.RequestID
 	}
-	return buildReqID(d.SourceID, d.ClusterName)
+	return MakeRequestID(d.ID())
 }
 
-func buildReqID(sv sous.SourceID, nick string) string {
-	return MakeDeployID(sv.Location.String() + nick)
+// MakeRequestID creats a Singularity request ID from a sous.DeployID.
+func MakeRequestID(mid sous.DeployID) string {
+	sl := strings.Replace(mid.ManifestID.Source.String(), "/", ">", -1)
+	return fmt.Sprintf("%s:%s:%s", sl, mid.ManifestID.Flavor, mid.Cluster)
 }
 
 func newDepID() string {

--- a/ext/singularity/deployer_test.go
+++ b/ext/singularity/deployer_test.go
@@ -1,0 +1,76 @@
+package singularity
+
+import (
+	"testing"
+
+	sous "github.com/opentable/sous/lib"
+)
+
+var requestIDTests = []struct {
+	DeployID sous.DeployID
+	String   string
+}{
+	// repo, cluster
+	{
+		DeployID: sous.DeployID{
+			ManifestID: sous.ManifestID{
+				Source: sous.SourceLocation{
+					Repo: "github.com/user/repo",
+				},
+			},
+			Cluster: "some-cluster",
+		},
+		String: "github.com>user>repo::some-cluster",
+	},
+	// repo, dir, cluster
+	{
+		DeployID: sous.DeployID{
+			ManifestID: sous.ManifestID{
+				Source: sous.SourceLocation{
+					Repo: "github.com/user/repo",
+					Dir:  "some/offset/dir",
+				},
+			},
+			Cluster: "some-cluster",
+		},
+		String: "github.com>user>repo,some>offset>dir::some-cluster",
+	},
+	// repo, flavor, cluster
+	{
+		DeployID: sous.DeployID{
+			ManifestID: sous.ManifestID{
+				Source: sous.SourceLocation{
+					Repo: "github.com/user/repo",
+				},
+				Flavor: "tasty-flavor",
+			},
+			Cluster: "some-cluster",
+		},
+		String: "github.com>user>repo:tasty-flavor:some-cluster",
+	},
+	// repo, dir, flavor, cluster
+	{
+		DeployID: sous.DeployID{
+			ManifestID: sous.ManifestID{
+				Source: sous.SourceLocation{
+					Repo: "github.com/user/repo",
+					Dir:  "some/offset/dir",
+				},
+				Flavor: "tasty-flavor",
+			},
+			Cluster: "some-cluster",
+		},
+		String: "github.com>user>repo,some>offset>dir:tasty-flavor:some-cluster",
+	},
+}
+
+func TestMakeRequestID(t *testing.T) {
+	for _, test := range requestIDTests {
+		input := test.DeployID
+		expected := test.String
+		actual := MakeRequestID(input)
+		if actual != expected {
+			t.Errorf("%#v got %q; want %q", input, actual, expected)
+		}
+	}
+}

--- a/ext/singularity/deployment_builder.go
+++ b/ext/singularity/deployment_builder.go
@@ -175,7 +175,7 @@ func (db *deploymentBuilder) retrieveImageLabels() error {
 		posNick = nn
 		matchCount++
 
-		checkID := buildReqID(db.Target.SourceID, nn)
+		checkID := MakeRequestID(db.Target.ID())
 		sous.Log.Vomit.Printf("Trying hypothetical request ID: %s", checkID)
 		if checkID == db.request.Id {
 			db.Target.ClusterName = nn

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -35,9 +35,9 @@ func NewRectiAgent(b sous.Registry) *RectiAgent {
 	}
 }
 
-// SingMap produces a DTOMap appropriate for building a Singularity
+// mapResources produces a dtoMap appropriate for building a Singularity
 // dto.Resources struct from
-func MapResources(r sous.Resources) dtoMap {
+func mapResources(r sous.Resources) dtoMap {
 	return dtoMap{
 		"Cpus":     r.Cpus(),
 		"MemoryMb": r.Memory(),
@@ -69,7 +69,7 @@ func buildDeployRequest(dockerImage string, e sous.Env, r sous.Resources, reqID 
 		return nil, err
 	}
 
-	res, err := swaggering.LoadMap(&dtos.Resources{}, MapResources(r))
+	res, err := swaggering.LoadMap(&dtos.Resources{}, mapResources(r))
 	if err != nil {
 		return nil, err
 	}

--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -299,7 +299,7 @@ func TestDeletes(t *testing.T) {
 	if assert.Len(client.deleted, 1) {
 		req := client.deleted[0]
 		assert.Equal("cluster", req.cluster)
-		assert.Equal("reqid", req.reqid)
+		assert.Equal("reqid::", req.reqid)
 	}
 }
 
@@ -345,7 +345,7 @@ func TestCreates(t *testing.T) {
 	if assert.Len(client.created, 1) {
 		req := client.created[0]
 		assert.Equal("cluster", req.cluster)
-		assert.Equal("reqidnick", req.id)
+		assert.Equal("reqid::nick", req.id)
 		assert.Equal(12, req.count)
 	}
 }

--- a/version.go
+++ b/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 // VersionString is the version of Sous.
-const VersionString = "0.0.1"
+const VersionString = "0.1"
 
 var (
 	// Version is the version of Sous.


### PR DESCRIPTION
UPDATE: Includes #156 

Adds release notes and bumps version string to 0.1

Once this is merged, it must be tagged `v0.1` in order to tell Travis to create the release binary.

