### PR TITLE
Singularity names

### DIFF
--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -1,6 +1,9 @@
 package singularity
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/opentable/go-singularity"
 	"github.com/opentable/sous/lib"
 	"github.com/satori/go.uuid"
@@ -158,11 +161,13 @@ func computeRequestID(d *sous.Deployment) string {
 	if len(d.RequestID) > 0 {
 		return d.RequestID
 	}
-	return buildReqID(d.SourceID, d.ClusterName)
+	return MakeRequestID(d.ID())
 }
 
-func buildReqID(sv sous.SourceID, nick string) string {
-	return MakeDeployID(sv.Location.String() + nick)
+// MakeRequestID creats a Singularity request ID from a sous.DeployID.
+func MakeRequestID(mid sous.DeployID) string {
+	sl := strings.Replace(mid.ManifestID.Source.String(), "/", ">", -1)
+	return fmt.Sprintf("%s:%s:%s", sl, mid.ManifestID.Flavor, mid.Cluster)
 }
 
 func newDepID() string {

--- a/ext/singularity/deployer_test.go
+++ b/ext/singularity/deployer_test.go
@@ -1,0 +1,76 @@
+package singularity
+
+import (
+	"testing"
+
+	sous "github.com/opentable/sous/lib"
+)
+
+var requestIDTests = []struct {
+	DeployID sous.DeployID
+	String   string
+}{
+	// repo, cluster
+	{
+		DeployID: sous.DeployID{
+			ManifestID: sous.ManifestID{
+				Source: sous.SourceLocation{
+					Repo: "github.com/user/repo",
+				},
+			},
+			Cluster: "some-cluster",
+		},
+		String: "github.com>user>repo::some-cluster",
+	},
+	// repo, dir, cluster
+	{
+		DeployID: sous.DeployID{
+			ManifestID: sous.ManifestID{
+				Source: sous.SourceLocation{
+					Repo: "github.com/user/repo",
+					Dir:  "some/offset/dir",
+				},
+			},
+			Cluster: "some-cluster",
+		},
+		String: "github.com>user>repo,some>offset>dir::some-cluster",
+	},
+	// repo, flavor, cluster
+	{
+		DeployID: sous.DeployID{
+			ManifestID: sous.ManifestID{
+				Source: sous.SourceLocation{
+					Repo: "github.com/user/repo",
+				},
+				Flavor: "tasty-flavor",
+			},
+			Cluster: "some-cluster",
+		},
+		String: "github.com>user>repo:tasty-flavor:some-cluster",
+	},
+	// repo, dir, flavor, cluster
+	{
+		DeployID: sous.DeployID{
+			ManifestID: sous.ManifestID{
+				Source: sous.SourceLocation{
+					Repo: "github.com/user/repo",
+					Dir:  "some/offset/dir",
+				},
+				Flavor: "tasty-flavor",
+			},
+			Cluster: "some-cluster",
+		},
+		String: "github.com>user>repo,some>offset>dir:tasty-flavor:some-cluster",
+	},
+}
+
+func TestMakeRequestID(t *testing.T) {
+	for _, test := range requestIDTests {
+		input := test.DeployID
+		expected := test.String
+		actual := MakeRequestID(input)
+		if actual != expected {
+			t.Errorf("%#v got %q; want %q", input, actual, expected)
+		}
+	}
+}

--- a/ext/singularity/deployment_builder.go
+++ b/ext/singularity/deployment_builder.go
@@ -175,7 +175,7 @@ func (db *deploymentBuilder) retrieveImageLabels() error {
 		posNick = nn
 		matchCount++
 
-		checkID := buildReqID(db.Target.SourceID, nn)
+		checkID := MakeRequestID(db.Target.ID())
 		sous.Log.Vomit.Printf("Trying hypothetical request ID: %s", checkID)
 		if checkID == db.request.Id {
 			db.Target.ClusterName = nn

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -35,9 +35,9 @@ func NewRectiAgent(b sous.Registry) *RectiAgent {
 	}
 }
 
-// SingMap produces a DTOMap appropriate for building a Singularity
+// mapResources produces a dtoMap appropriate for building a Singularity
 // dto.Resources struct from
-func MapResources(r sous.Resources) dtoMap {
+func mapResources(r sous.Resources) dtoMap {
 	return dtoMap{
 		"Cpus":     r.Cpus(),
 		"MemoryMb": r.Memory(),
@@ -69,7 +69,7 @@ func buildDeployRequest(dockerImage string, e sous.Env, r sous.Resources, reqID 
 		return nil, err
 	}
 
-	res, err := swaggering.LoadMap(&dtos.Resources{}, MapResources(r))
+	res, err := swaggering.LoadMap(&dtos.Resources{}, mapResources(r))
 	if err != nil {
 		return nil, err
 	}

--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -299,7 +299,7 @@ func TestDeletes(t *testing.T) {
 	if assert.Len(client.deleted, 1) {
 		req := client.deleted[0]
 		assert.Equal("cluster", req.cluster)
-		assert.Equal("reqid", req.reqid)
+		assert.Equal("reqid::", req.reqid)
 	}
 }
 
@@ -345,7 +345,7 @@ func TestCreates(t *testing.T) {
 	if assert.Len(client.created, 1) {
 		req := client.created[0]
 		assert.Equal("cluster", req.cluster)
-		assert.Equal("reqidnick", req.id)
+		assert.Equal("reqid::nick", req.id)
 		assert.Equal(12, req.count)
 	}
 }


### PR DESCRIPTION
Updates Singularity request names to use the form:

    SourceLocation:Flavor:ClusterName

With slashes in SourceLocation replaced with greater than signs.