### PR TITLE
Deployment diff concentrated into manifest diffs

### DIFF
--- a/lib/deployment_diff.go
+++ b/lib/deployment_diff.go
@@ -1,9 +1,6 @@
 package sous
 
-import (
-	"log"
-	"strings"
-)
+import "strings"
 
 type (
 	// DeploymentPair is a pair of deployments that represent a "before and after" style relationship
@@ -104,7 +101,6 @@ func newDiffer(intended Deployments) *differ {
 	for _, dep := range i {
 		startMap[dep.Name()] = dep
 	}
-	log.Printf("%v size %d", i, len(i))
 	return &differ{
 		from:      startMap,
 		DiffChans: NewDiffChans(len(i)),

--- a/lib/deployment_diff.go
+++ b/lib/deployment_diff.go
@@ -1,6 +1,9 @@
 package sous
 
-import "strings"
+import (
+	"log"
+	"strings"
+)
 
 type (
 	// DeploymentPair is a pair of deployments that represent a "before and after" style relationship
@@ -101,6 +104,7 @@ func newDiffer(intended Deployments) *differ {
 	for _, dep := range i {
 		startMap[dep.Name()] = dep
 	}
+	log.Printf("%v size %d", i, len(i))
 	return &differ{
 		from:      startMap,
 		DiffChans: NewDiffChans(len(i)),

--- a/lib/deployment_diff_test.go
+++ b/lib/deployment_diff_test.go
@@ -80,11 +80,13 @@ func TestRealDiff(t *testing.T) {
 	ds := dc.collect()
 
 	if assert.Len(ds.Gone.Snapshot(), 1, "Should have one deleted item.") {
-		//assert.Equal(string(ds.Gone.Snapshot()[0].SourceID.RepoURL), repoOne)
+		it, _ := ds.Gone.Any(func(*Deployment) bool { return true })
+		assert.Equal(string(it.SourceID.Location.Repo), repoOne)
 	}
 
 	if assert.Len(ds.Same.Snapshot(), 1, "Should have one unchanged item.") {
-		//assert.Equal(string(ds.Same.Snapshot()[0].SourceID.RepoURL), repoTwo)
+		it, _ := ds.Same.Any(func(*Deployment) bool { return true })
+		assert.Equal(string(it.SourceID.Location.Repo), repoTwo)
 	}
 
 	if assert.Len(ds.Changed, 1, "Should have one modified item.") {
@@ -96,7 +98,7 @@ func TestRealDiff(t *testing.T) {
 	}
 
 	if assert.Equal(ds.New.Len(), 1, "Should have one added item.") {
-		//assert.Equal(string(ds.New[0].SourceID.RepoURL), repoFour)
+		it, _ := ds.New.Any(func(*Deployment) bool { return true })
+		assert.Equal(string(it.SourceID.Location.Repo), repoFour)
 	}
-
 }

--- a/lib/diff_concentrator.go
+++ b/lib/diff_concentrator.go
@@ -81,6 +81,7 @@ func (dc *DiffConcentrator) collect() (concentratedDiffSet, error) {
 		return ds, err
 	}
 	for g := range dc.Deleted {
+		log.Printf("g: %#v", g)
 		ds.Gone.Add(g)
 	}
 	for n := range dc.Created {
@@ -168,6 +169,7 @@ func (db *deploymentBundle) manifestPair(defs Defs) (*ManifestPair, error) {
 
 	res := new(ManifestPair)
 	ms, err := before.Manifests(defs)
+	log.Printf("%#v", before)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +187,8 @@ func (db *deploymentBundle) manifestPair(defs Defs) (*ManifestPair, error) {
 		res.Prior = p
 	}
 
-	ms, err = before.Manifests(defs)
+	ms, err = after.Manifests(defs)
+	log.Printf("%#v", after)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/diff_concentrator.go
+++ b/lib/diff_concentrator.go
@@ -1,0 +1,178 @@
+package sous
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+type (
+	// A DiffConcentrator wraps deployment DiffChans in order to produce
+	// differences in terms of *manifests*
+	DiffConcentrator struct {
+		Defs
+		Created, Deleted, Retained chan *Manifest
+		Modified                   chan *ManifestPair
+	}
+
+	ManifestPair struct {
+		name        ManifestID
+		Prior, Post *Manifest
+	}
+
+	deploymentBundle struct {
+		consumed bool
+		*sync.RWMutex
+		pairs map[string]*DeploymentPair
+	}
+)
+
+// NewDiffChans constructs a DiffChans
+func NewConcentrator(defs Defs, s DiffChans, sizes ...int) DiffConcentrator {
+	var size int
+	if len(sizes) > 0 {
+		size = sizes[0]
+	}
+
+	return DiffConcentrator{
+		Defs:     defs,
+		Created:  make(chan *Manifest, size),
+		Deleted:  make(chan *Manifest, size),
+		Retained: make(chan *Manifest, size),
+		Modified: make(chan *ManifestPair, size),
+	}
+}
+
+func (db *deploymentBundle) add(prior, post *Deployment) error {
+	var cluster string
+	if prior != nil {
+		cluster = prior.ClusterName
+	}
+	if post != nil {
+		if prior == nil {
+			cluster = post.ClusterName
+		} else if cluster != post.ClusterName {
+			return errors.Errorf("Invariant violated: two clusters named in deploy pair: %q vs %q", prior.ClusterName, post.ClusterName)
+		}
+	}
+	if cluster == "" {
+		return errors.Errorf("Invariant violated: no cluster name given in deploy pair")
+	}
+
+	if existing, available := db.pairs[cluster]; !available {
+		return errors.Errorf(
+			"Deployment collision for cluster %q: %v vs %v,%v",
+			cluster, existing, prior, post,
+		)
+	}
+	db.Lock()
+	defer db.Unlock()
+
+	db.pairs[cluster] = &DeploymentPair{Prior: prior, Post: post}
+}
+
+func (db *deploymentBundle) clusters() []string {
+	cs := make([]string)
+	db.RLock()
+	defer db.RUnlock()
+
+	for k := range db.pairs {
+		cs = append(cs, k)
+	}
+	sort.Strings(cs)
+	return cs
+}
+
+func (db *deploymentBundle) manifestPair(defs Defs) (*ManifestPair, error) {
+	before := make(Deployments)
+	after := make(Deployments)
+	db.RLock()
+	defer db.RUnlock()
+
+	for _, v := range db.pairs {
+		if v.Prior != nil {
+			before = append(before, v.Prior)
+		}
+		if v.Post != nil {
+			after = append(after, v.Post)
+		}
+	}
+
+	var res *ManifestPair
+	ms := before.Manifests(defs)
+	switch ms.Len() {
+	default:
+		return nil, errors.Errorf(
+			"bundled deployments produced multiple manifests:\n%#v\n%#v",
+			before, ms)
+	case 0:
+	case 1:
+		res.Prior = ms.Get(ms.Keys()[0])
+	}
+
+	ms := after.Manifests(defs)
+	switch ms.Len() {
+	default:
+		return nil, errors.Errorf(
+			"bundled deployments produced multiple manifests:\n%#v\n%#v",
+			after, ms)
+	case 0:
+	case 1:
+		res.Post = ms.Get(ms.Keys()[0])
+	}
+	db.consumed = true
+	return res, nil
+}
+
+func newDepBundle() deploymentBundle {
+	return deploymentBundle{
+		consumed: false,
+		RWMutex:  new(sync.RWMutex),
+		pairs:    make(map[string]*DeploymentPair),
+	}
+}
+
+func concentrate(dc DiffChans, con DiffConcentrator) {
+	collect := make(map[ManifestID]deploymentBundle)
+	addPair = func(mid ManifestID, prior, post *Deployment) {
+		depps, present := collect[ManifestID]
+		if !present {
+			depps := newDepBundle()
+		}
+		collect[ManifestID].add(prior, post)
+
+		if len(collect[ManifestID].clusters()) == len(con.defs.Clusters) { //eh?
+			mp := collect[ManifestID].manifestPair(defs)
+			if mp.Prior == nil {
+				if mp.Post == nil {
+					//?
+				} else {
+					con.Created <- mp.Post
+				}
+			} else {
+				if mp.Post == nil {
+					con.Deleted <- mp.Post
+				} else {
+					if mp.Prior.Equal(mp.Post) {
+						con.Retained <- mp.Post
+					} else {
+						con.Modified <- mp
+					}
+				}
+			}
+		}
+	}
+
+	select {
+	case c := <-dc.Created:
+		addPair(c.ManifestID(), nil, c)
+	case d := <-dc.Deleted:
+		addPair(c.ManifestID(), d, nil)
+	case r := <-dc.Retained:
+		addPair(c.ManifestID(), r, r)
+	case m := <-dc.Modified:
+		addPair(c.ManifestID(), m.Prior, m.Post)
+	}
+
+}

--- a/lib/diff_concentrator_test.go
+++ b/lib/diff_concentrator_test.go
@@ -99,6 +99,9 @@ func TestRealDiffConcentration(t *testing.T) {
 	}
 
 	if assert.Len(ds.Changed, 1, "Should have one modified item.") {
+		log.Printf("%#v", ds.Changed[0])
+		log.Printf("%#v", ds.Changed[0].Prior)
+		log.Printf("%#v", ds.Changed[0].Post)
 		assert.Equal(repoThree, string(ds.Changed[0].name.Source.Repo))
 		assert.Equal(repoThree, string(ds.Changed[0].Prior.Source.Repo))
 		assert.Equal(repoThree, string(ds.Changed[0].Post.Source.Repo))

--- a/lib/diff_concentrator_test.go
+++ b/lib/diff_concentrator_test.go
@@ -1,0 +1,114 @@
+package sous
+
+import (
+	"log"
+	"testing"
+
+	"github.com/nyarly/testify/assert"
+	"github.com/nyarly/testify/require"
+	"github.com/samsalisbury/semv"
+)
+
+func TestEmptyDiffConcentration(t *testing.T) {
+
+	intended := NewDeployments()
+	existing := NewDeployments()
+
+	dc := intended.Diff(existing)
+	ds := dc.collect()
+
+	if ds.New.Len() != 0 {
+		t.Errorf("got %d new; want 0", ds.New.Len())
+	}
+	if ds.Gone.Len() != 0 {
+		t.Errorf("got %d gone; want 0", ds.Gone.Len())
+	}
+	if ds.Same.Len() != 0 {
+		t.Errorf("got %d same; want 0", ds.Same.Len())
+	}
+	if len(ds.Changed) != 0 {
+		t.Errorf("got %d changed; want 0", len(ds.Changed))
+	}
+}
+
+func TestRealDiffConcentration(t *testing.T) {
+	log.SetFlags(log.Flags() | log.Lshortfile)
+	assert := assert.New(t)
+	require := require.New(t)
+
+	intended := NewDeployments()
+	existing := NewDeployments()
+	defs := Defs{Clusters: map[string]*Cluster{"test": &Cluster{}}}
+
+	makeDepl := func(repo string, num int) *Deployment {
+		version, _ := semv.Parse("1.1.1-latest")
+		cl := defs.Clusters["test"]
+		owners := OwnerSet{}
+		owners.Add("judson")
+		return &Deployment{
+			SourceID: SourceID{
+				Location: SourceLocation{
+					Repo: repo,
+				},
+				Version: version,
+			},
+			Cluster:     cl,
+			ClusterName: "test",
+			DeployConfig: DeployConfig{
+				NumInstances: num,
+				Env:          map[string]string{},
+				Resources: map[string]string{
+					"cpu":    ".1",
+					"memory": "100",
+					"ports":  "1",
+				},
+			},
+			Owners: owners,
+		}
+	}
+
+	repoOne := "https://github.com/opentable/one"
+	repoTwo := "https://github.com/opentable/two"
+	repoThree := "https://github.com/opentable/three"
+	repoFour := "https://github.com/opentable/four"
+
+	intended.MustAdd(makeDepl(repoOne, 1)) //remove
+
+	existing.MustAdd(makeDepl(repoTwo, 1)) //same
+	intended.MustAdd(makeDepl(repoTwo, 1)) //same
+
+	existing.MustAdd(makeDepl(repoThree, 1)) //changed
+	intended.MustAdd(makeDepl(repoThree, 2)) //changed
+
+	existing.MustAdd(makeDepl(repoFour, 1)) //create
+
+	log.Printf("%#v %#v", intended, existing)
+	dc := intended.Diff(existing).Concentrate(defs)
+	ds, err := dc.collect()
+	require.NoError(err)
+
+	log.Printf("%#v", ds)
+	if assert.Len(ds.Gone.Snapshot(), 1, "Should have one deleted item.") {
+		it, _ := ds.Gone.Any(func(*Manifest) bool { return true })
+		assert.Equal(string(it.Source.Repo), repoOne)
+	}
+
+	if assert.Len(ds.Same.Snapshot(), 1, "Should have one unchanged item.") {
+		it, _ := ds.Same.Any(func(*Manifest) bool { return true })
+		assert.Equal(string(it.Source.Repo), repoTwo)
+	}
+
+	if assert.Len(ds.Changed, 1, "Should have one modified item.") {
+		assert.Equal(repoThree, string(ds.Changed[0].name.Source.Repo))
+		assert.Equal(repoThree, string(ds.Changed[0].Prior.Source.Repo))
+		assert.Equal(repoThree, string(ds.Changed[0].Post.Source.Repo))
+		assert.Equal(ds.Changed[0].Post.Deployments["test"].NumInstances, 1)
+		assert.Equal(ds.Changed[0].Prior.Deployments["test"].NumInstances, 2)
+	}
+
+	if assert.Equal(ds.New.Len(), 1, "Should have one added item.") {
+		it, _ := ds.New.Any(func(*Manifest) bool { return true })
+		assert.Equal(string(it.Source.Repo), repoFour)
+	}
+
+}

--- a/lib/diff_concentrator_test.go
+++ b/lib/diff_concentrator_test.go
@@ -82,12 +82,10 @@ func TestRealDiffConcentration(t *testing.T) {
 
 	existing.MustAdd(makeDepl(repoFour, 1)) //create
 
-	log.Printf("%#v %#v", intended, existing)
 	dc := intended.Diff(existing).Concentrate(defs)
 	ds, err := dc.collect()
 	require.NoError(err)
 
-	log.Printf("%#v", ds)
 	if assert.Len(ds.Gone.Snapshot(), 1, "Should have one deleted item.") {
 		it, _ := ds.Gone.Any(func(*Manifest) bool { return true })
 		assert.Equal(string(it.Source.Repo), repoOne)
@@ -99,9 +97,6 @@ func TestRealDiffConcentration(t *testing.T) {
 	}
 
 	if assert.Len(ds.Changed, 1, "Should have one modified item.") {
-		log.Printf("%#v", ds.Changed[0])
-		log.Printf("%#v", ds.Changed[0].Prior)
-		log.Printf("%#v", ds.Changed[0].Post)
 		assert.Equal(repoThree, string(ds.Changed[0].name.Source.Repo))
 		assert.Equal(repoThree, string(ds.Changed[0].Prior.Source.Repo))
 		assert.Equal(repoThree, string(ds.Changed[0].Post.Source.Repo))

--- a/server/routemap_test.go
+++ b/server/routemap_test.go
@@ -1,0 +1,33 @@
+package server
+
+import "testing"
+
+type pm map[string]string
+
+func TestSousRoutes(t *testing.T) {
+	test := func(er string, name string, kvs ...KV) {
+		ar, err := SousRouteMap.PathFor(name, kvs...)
+		if err != nil {
+			t.Fatalf("Error getting a path: %#v", err)
+		}
+		if ar != er {
+			t.Errorf("Route bad: expected %q got %q", er, ar)
+		}
+
+	}
+	test(
+		"/manifest?flavor=sweet&offset=alt&repo=github.com%2Fopentable%2Fsous",
+
+		"manifest",
+		KV{"repo", "github.com/opentable/sous"},
+		KV{"offset", "alt"},
+		KV{"flavor", "sweet"},
+	)
+	test(
+		"/manifest?offset=alt&repo=github.com%2Fopentable%2Fsous",
+
+		"manifest",
+		KV{"repo", "github.com/opentable/sous"},
+		KV{"offset", "alt"},
+	)
+}


### PR DESCRIPTION
Using the existing deployment differ: concentrates deployment hunks into
manifest hunks. This is a precursor to doing an HTTP state manager: we'll check
for differences to the local understanding of the GDM, and push those diffs as
PUTs and DELETEs to manifests.