### PR TITLE
Yo creo this completes the `sous build` client, etc.

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -64,6 +64,8 @@ type (
 	ScratchDirShell struct{ *shell.Sh }
 	// LocalDockerClient is a docker client object
 	LocalDockerClient struct{ docker_registry.Client }
+	// StateManager simply wraps the sous.StateManager interface
+	StateManager struct{ sous.StateManager }
 	// LocalStateReader wraps a storage.StateReader, and should be configured
 	// to use the current user's local storage.
 	LocalStateReader struct{ sous.StateReader }
@@ -168,8 +170,7 @@ func AddSingularity(graph adder) {
 // AddState adds state reader and writers to the graph
 func AddState(graph adder) {
 	graph.Add(
-		newLocalDiskStateManager,
-		newGitStateManager,
+		newStateManager,
 		newLocalStateReader,
 		newLocalStateWriter,
 	)
@@ -379,19 +380,23 @@ func newDockerClient() LocalDockerClient {
 	return LocalDockerClient{docker_registry.NewClient()}
 }
 
-func newLocalDiskStateManager(c LocalSousConfig) *storage.DiskStateManager {
-	return storage.NewDiskStateManager(c.StateLocation)
+func newStateManager(c LocalSousConfig) (*StateManager, error) {
+	if c.Server != "" {
+		hsm, err := sous.NewHTTPStateManager(c.Server)
+		if err != nil {
+			return nil, err
+		}
+		return &StateManager{StateManager: hsm}, nil
+	}
+	dm := storage.NewDiskStateManager(c.StateLocation)
+	return &StateManager{StateManager: storage.NewGitStateManager(dm)}, nil
 }
 
-func newGitStateManager(dm *storage.DiskStateManager) *storage.GitStateManager {
-	return storage.NewGitStateManager(dm)
-}
-
-func newLocalStateReader(sm *storage.GitStateManager) LocalStateReader {
+func newLocalStateReader(sm *StateManager) LocalStateReader {
 	return LocalStateReader{sm}
 }
 
-func newLocalStateWriter(sm *storage.GitStateManager) LocalStateWriter {
+func newLocalStateWriter(sm *StateManager) LocalStateWriter {
 	return LocalStateWriter{sm}
 }
 

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -2,12 +2,17 @@ package graph
 
 import (
 	"io/ioutil"
+	"log"
 	"testing"
 
 	"github.com/opentable/sous/config"
+	"github.com/opentable/sous/ext/storage"
+	"github.com/opentable/sous/lib"
+	"github.com/samsalisbury/psyringe"
 )
 
 func TestBuildGraph(t *testing.T) {
+	log.SetFlags(log.Flags() | log.Lshortfile)
 	g := BuildGraph(ioutil.Discard, ioutil.Discard)
 	g.Add(&config.Verbosity{})
 	g.Add(&config.DeployFilterFlags{})
@@ -18,4 +23,39 @@ func TestBuildGraph(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
+}
+
+func injectedStateManager(t *testing.T, cfg *config.Config) *StateManager {
+	g := psyringe.New()
+	g.Add(newStateManager)
+	g.Add(LocalSousConfig{Config: cfg})
+
+	smRcvr := struct {
+		Sm *StateManager
+	}{}
+	err := g.Inject(&smRcvr)
+	if err != nil {
+		t.Fatalf("Injection err: %+v", err)
+	}
+
+	if smRcvr.Sm == nil {
+		t.Fatal("StateManager not injected")
+	}
+	return smRcvr.Sm
+}
+
+func TestStateManagerSelectsServer(t *testing.T) {
+	smgr := injectedStateManager(t, &config.Config{Server: "http://example.com"})
+
+	if _, ok := smgr.StateManager.(*sous.HTTPStateManager); !ok {
+		t.Errorf("Injected %#v which isn't a HTTPStateManager", smgr)
+	}
+}
+
+func TestStateManagerSelectsGit(t *testing.T) {
+	smgr := injectedStateManager(t, &config.Config{StateLocation: "/tmp/sous"})
+
+	if _, ok := smgr.StateManager.(*storage.GitStateManager); !ok {
+		t.Errorf("Injected %#v which isn't a GitStateManager", smgr)
+	}
 }

--- a/lib/diff_concentrator_test.go
+++ b/lib/diff_concentrator_test.go
@@ -105,7 +105,6 @@ func TestRealDiffConcentration(t *testing.T) {
 		if repoThree == chVer.name.Source.Repo {
 			chNum, chVer = chVer, chNum
 		}
-		log.Printf("\n%#v\n%#v", chNum, chVer)
 		assert.Equal(repoThree, string(chNum.name.Source.Repo))
 		assert.Equal(repoThree, string(chNum.Prior.Source.Repo))
 		assert.Equal(repoThree, string(chNum.Post.Source.Repo))

--- a/test/empty.go
+++ b/test/empty.go
@@ -1,0 +1,4 @@
+package test
+
+// This package exists just to have a place to have multiple-package tests to
+// simplify import issues

--- a/test/http_state_manager_test.go
+++ b/test/http_state_manager_test.go
@@ -1,6 +1,4 @@
-// +build integration
-
-package integration
+package test
 
 import (
 	"io/ioutil"


### PR DESCRIPTION
As now the CLI commands that alter the Sous State now act as HTTP clients of the server transparently.

Still need e.g. `sous rectify` triggers, possibly, hey presto.