### PR TITLE
Using the Dave Cheney errors package in shell/

### DIFF
--- a/util/shell/command.go
+++ b/util/shell/command.go
@@ -197,7 +197,7 @@ func (c *Command) Result() (*Result, error) {
 func (c *Command) SucceedResult() (*Result, error) {
 	r, err := c.Result()
 	if err != nil {
-		return r, errors.Wrapf(err, c.String())
+		return r, err
 	}
 	if r.Err != nil {
 		return r, newError(r.Err, r)
@@ -227,7 +227,7 @@ func (c *Command) Fail() error {
 func (c *Command) FailResult() (*Result, error) {
 	r, err := c.Result()
 	if err != nil {
-		return r, errors.Wrapf(err, c.String())
+		return r, err
 	}
 	if r.Err == nil {
 		return r, fmt.Errorf("command %q succeeded, expected failure", c)

--- a/util/shell/command.go
+++ b/util/shell/command.go
@@ -170,7 +170,7 @@ func (c *Command) Result() (*Result, error) {
 	command.Stdin = c.Stdin
 
 	if err := command.Start(); err != nil {
-		return nil, errors.Wrapf(err, "%s %s", c.Name, strings.Join(c.Args))
+		return nil, errors.Wrapf(err, c.String())
 	}
 	code := 0
 	err := command.Wait()

--- a/util/shell/sh.go
+++ b/util/shell/sh.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/pkg/errors"
 )
 
 type (
@@ -37,7 +39,7 @@ type (
 func Default() (*Sh, error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "sh default workdir")
 	}
 	return &Sh{
 		Cwd: wd,
@@ -82,10 +84,10 @@ func (s *Sh) CD(dir string) error {
 	s.Cwd = dir
 	f, err := os.Stat(s.Cwd)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "sh chdir")
 	}
 	if !f.IsDir() {
-		return fmt.Errorf("%s is not a directory", s.Cwd)
+		return errors.Errorf("%s is not a directory", s.Cwd)
 	}
 	return nil
 }


### PR DESCRIPTION
Upshot should be that any errors out of shell should have command context.
Worst case: no extra information, best case much faster resolution of problems