### PR TITLE
Adds a image name inserter interface and HTTP implementation

### DIFF
--- a/ext/docker/builder.go
+++ b/ext/docker/builder.go
@@ -16,7 +16,7 @@ import (
 type (
 	// Builder represents a single build of a project.
 	Builder struct {
-		ImageMapper               *NameCache
+		ImageMapper               sous.Inserter
 		DockerRegistryHost        string
 		SourceShell, ScratchShell shell.Shell
 		Pack                      sous.Buildpack
@@ -31,7 +31,7 @@ type (
 // NewBuilder creates a new build using source code in the working
 // directory of sourceShell, and using the working dir of scratchShell as
 // temporary storage.
-func NewBuilder(nc *NameCache, drh string, sourceShell, scratchShell shell.Shell) (*Builder, error) {
+func NewBuilder(nc sous.Inserter, drh string, sourceShell, scratchShell shell.Shell) (*Builder, error) {
 	b := &Builder{
 		ImageMapper:        nc,
 		DockerRegistryHost: drh,
@@ -119,7 +119,7 @@ func (b *Builder) recordName(br *sous.BuildResult, bc *sous.BuildContext) error 
 	for _, adv := range br.Advisories {
 		qs = append(qs, sous.Quality{Name: adv, Kind: "advisory"})
 	}
-	return b.ImageMapper.insert(sv, in, "", qs)
+	return b.ImageMapper.Insert(sv, in, "", qs)
 }
 
 // VersionTag computes an image tag from a SourceVersion's version

--- a/ext/docker/image_mapping.go
+++ b/ext/docker/image_mapping.go
@@ -51,6 +51,7 @@ type (
 
 // NewBuildArtifact creates a new sous.BuildArtifact representing a Docker
 // image.
+// XXX this should be removed in favor of sous.NewBuildArtifact
 func NewBuildArtifact(imageName string, qstrs strpairs) *sous.BuildArtifact {
 	var qs []sous.Quality
 	for _, qstr := range qstrs {
@@ -240,7 +241,7 @@ func (nc *NameCache) GetCanonicalName(in string) (string, error) {
 
 // Insert puts a given SourceID/image name pair into the name cache
 // used by Builder at the moment to register after a build
-func (nc *NameCache) insert(sid sous.SourceID, in, etag string, qs []sous.Quality) error {
+func (nc *NameCache) Insert(sid sous.SourceID, in, etag string, qs []sous.Quality) error {
 	return nc.dbInsert(sid, in, etag, qs)
 }
 

--- a/ext/docker/image_mapping_test.go
+++ b/ext/docker/image_mapping_test.go
@@ -142,7 +142,7 @@ func TestRoundTrip(t *testing.T) {
 	base := "ot/wackadoo"
 	in := base + ":version-1.2.3"
 	digest := "sha256:012345678901234567890123456789AB012345678901234567890123456789AB"
-	err := nc.insert(sv, in, digest, []sous.Quality{})
+	err := nc.Insert(sv, in, digest, []sous.Quality{})
 	assert.NoError(err)
 
 	cn, err := nc.GetCanonicalName(in)
@@ -337,7 +337,7 @@ func TestRecordAdvisories(t *testing.T) {
 
 	qs := []sous.Quality{{"ephemeral_tag", "advisory"}}
 
-	err := nc.insert(sv, cn, digest, qs)
+	err := nc.Insert(sv, cn, digest, qs)
 	assert.NoError(err)
 
 	arty, err := nc.GetArtifact(sv)

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -372,6 +372,7 @@ func newRegistrar(db *docker.Builder) sous.Registrar {
 func newRegistry(cfg LocalSousConfig, cl LocalDockerClient) (sous.Registry, error) {
 	return makeDockerRegistry(cfg, cl)
 }
+
 func newDeployer(r sous.Registry) sous.Deployer {
 	// Eventually, based on configuration, we may make different decisions here.
 	return singularity.NewDeployer(r, singularity.NewRectiAgent(r))
@@ -430,6 +431,13 @@ func makeDockerRegistry(cfg LocalSousConfig, cl LocalDockerClient) (*docker.Name
 		return nil, errors.Wrap(err, "building name cache DB")
 	}
 	return docker.NewNameCache(cl.Client, db), nil
+}
+
+func makeInserter(cfg LocalSousConfig, cl LocalDockerClient) (sous.Inserter, error) {
+	if cfg.Server == "" {
+		return makeDockerRegistry(cfg, cl)
+	}
+	return sous.NewHTTPNameInserter(cfg.Server)
 }
 
 // initErr returns nil if error is nil, otherwise an initialisation error.

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -199,6 +199,7 @@ func AddInternals(graph adder) {
 		newUserSelectedOTPLDeploySpecs,
 		newTargetManifestID,
 		newAutoResolver,
+		newInserter,
 	)
 }
 
@@ -433,7 +434,7 @@ func makeDockerRegistry(cfg LocalSousConfig, cl LocalDockerClient) (*docker.Name
 	return docker.NewNameCache(cl.Client, db), nil
 }
 
-func makeInserter(cfg LocalSousConfig, cl LocalDockerClient) (sous.Inserter, error) {
+func newInserter(cfg LocalSousConfig, cl LocalDockerClient) (sous.Inserter, error) {
 	if cfg.Server == "" {
 		return makeDockerRegistry(cfg, cl)
 	}

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -62,7 +62,7 @@ func TestStateManagerSelectsGit(t *testing.T) {
 }
 
 func testBuildInserter(t *testing.T, serverStr string) sous.Inserter {
-	ins, err := makeInserter(LocalSousConfig{Config: &config.Config{
+	ins, err := newInserter(LocalSousConfig{Config: &config.Config{
 		Server: serverStr,
 		Docker: docker.Config{
 			DatabaseDriver:     "sqlite3",

--- a/lib/buildpack.go
+++ b/lib/buildpack.go
@@ -25,6 +25,9 @@ type (
 		Register(*BuildResult, *BuildContext) error
 	}
 
+	Strpairs []Strpair
+	Strpair  [2]string
+
 	// BuildArtifact describes the actual built binary Sous will deploy
 	BuildArtifact struct {
 		Name, Type string
@@ -84,4 +87,15 @@ func (br *BuildResult) String() string {
 		str = str + "\nAdvisories:\n  " + strings.Join(br.Advisories, "  \n")
 	}
 	return fmt.Sprintf("%s\nElapsed: %s", str, br.Elapsed)
+}
+
+// NewBuildArtifact creates a new BuildArtifact representing a Docker
+// image.
+func NewBuildArtifact(imageName string, qstrs Strpairs) *BuildArtifact {
+	var qs []Quality
+	for _, qstr := range qstrs {
+		qs = append(qs, Quality{Name: qstr[0], Kind: qstr[1]})
+	}
+
+	return &BuildArtifact{Name: imageName, Type: "docker", Qualities: qs}
 }

--- a/lib/http_name_inserter.go
+++ b/lib/http_name_inserter.go
@@ -1,0 +1,54 @@
+package sous
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+// An HTTPNameInserter sends its inserts to the configured HTTP server
+type HTTPNameInserter struct {
+	serverURL *url.URL
+	http.Client
+}
+
+// NewHTTPNameInserter creates a new HTTPNameInserter
+func NewHTTPNameInserter(server string) (*HTTPNameInserter, error) {
+	u, err := url.Parse(server)
+	return &HTTPNameInserter{
+		serverURL: u,
+	}, errors.Wrapf(err, "new state manager")
+}
+
+// Insert implements Inserter for HTTPNameInserter
+func (hni *HTTPNameInserter) Insert(sid SourceID, in, etag string, qs []Quality) error {
+	url, err := hni.serverURL.Parse("./artifact")
+	if err != nil {
+		return errors.Wrapf(err, "http insert name: %s for %v", in, sid)
+	}
+	url.RawQuery = sid.QueryValues().Encode()
+	art := &BuildArtifact{Name: in, Type: "docker", Qualities: qs}
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	err = enc.Encode(art)
+	if err != nil {
+		return errors.Wrapf(err, "http insert name %s, encoding %v", in, art)
+	}
+
+	req, err := http.NewRequest("PUT", url.String(), buf)
+	if err != nil {
+		return errors.Wrapf(err, "http insert name %s, building request for %s/%v", in, url, art)
+	}
+
+	rz, err := hni.Client.Do(req)
+	if err != nil {
+		return errors.Wrapf(err, "http insert name %s, sending %v", in, req)
+	}
+	if rz.StatusCode >= 200 && rz.StatusCode < 300 {
+		return nil
+	}
+	return errors.Errorf("Received %s when attempting %v", rz.Status, req)
+}

--- a/lib/http_name_inserter_test.go
+++ b/lib/http_name_inserter_test.go
@@ -1,0 +1,52 @@
+package sous
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/samsalisbury/semv"
+)
+
+func TestHTTPNameInserter(t *testing.T) {
+
+	reqd := false
+	h := func(rw http.ResponseWriter, r *http.Request) {
+		if meth := r.Method; strings.ToUpper(meth) != "PUT" {
+			t.Errorf("Method should be PUT was: %s", meth)
+		}
+		if path := r.URL.Path; path != "/artifact" {
+			t.Errorf("Path should be '/artifact' but was: %s", path)
+		}
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		if len(body) <= 0 {
+			t.Errorf("Empty body")
+		}
+		rw.WriteHeader(200)
+		reqd = true
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(h))
+
+	hni, err := NewHTTPNameInserter(srv.URL)
+	if err != nil {
+		t.Error(err)
+	}
+	err = hni.Insert(
+		SourceID{Location: SourceLocation{Repo: "a-repo", Dir: "offset"}, Version: semv.MustParse("5.5.5")},
+		"dockerthin.com/repo/latest",
+		"",
+		[]Quality{},
+	)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reqd {
+		t.Errorf("No request issued")
+	}
+}

--- a/lib/registry.go
+++ b/lib/registry.go
@@ -23,4 +23,11 @@ type (
 		//ImageLabels finds the sous (docker) labels for a given image name
 		ImageLabels(imageName string) (labels map[string]string, err error)
 	}
+
+	// An Inserter puts data into a registry.
+	Inserter interface {
+		// Insert pairs a SourceID with an imagename, and tags the pairing with Qualities
+		// The etag can be (usually will be) the empty string
+		Insert(sid SourceID, in, etag string, qs []Quality) error
+	}
 )

--- a/lib/source_id.go
+++ b/lib/source_id.go
@@ -2,6 +2,7 @@ package sous
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/samsalisbury/semv"
@@ -51,6 +52,15 @@ func (sid SourceID) String() string {
 		return fmt.Sprintf("%s,%s", sid.Location.Repo, sid.Version)
 	}
 	return fmt.Sprintf("%s,%s,%s", sid.Location.Repo, sid.Version, sid.Location.Dir)
+}
+
+// QueryValues returns the url.Values for this SourceIDs
+func (sid SourceID) QueryValues() url.Values {
+	v := url.Values{}
+	v.Set("repo", sid.Location.Repo)
+	v.Set("offset", sid.Location.Dir)
+	v.Set("version", sid.Version.String())
+	return v
 }
 
 // Tag returns the version tag for this source ID.

--- a/server/handle_artifact.go
+++ b/server/handle_artifact.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/firsterr"
+	"github.com/samsalisbury/semv"
+)
+
+type (
+	ArtifactResource struct{}
+
+	PUTArtifactHandler struct {
+		*http.Request
+		*QueryValues
+		sous.Inserter
+	}
+)
+
+func (ar *ArtifactResource) Put() *PUTArtifactHandler { return &PUTArtifactHandler{} }
+
+func (pah *PUTArtifactHandler) Exchange() (interface{}, int) {
+	ba := sous.BuildArtifact{}
+	dec := json.NewDecoder(pah.Request.Body)
+	err := dec.Decode(&ba)
+	if err != nil {
+		return err, http.StatusNotAcceptable
+	}
+
+	sid, err := sourceIDFromValues(pah.QueryValues)
+	if err != nil {
+		return err, http.StatusNotAcceptable
+	}
+
+	err = pah.Inserter.Insert(sid, ba.Name, "", ba.Qualities)
+	if err != nil {
+		return err, http.StatusNotAcceptable
+	}
+
+	return "", http.StatusOK
+}
+
+func sourceIDFromValues(qv *QueryValues) (sous.SourceID, error) {
+	var r, o, vs string
+	var v semv.Version
+	var err error
+	var sid sous.SourceID
+
+	return sid, firsterr.Returned(
+		func() error { r, err = qv.Single("repo"); return err },
+		func() error { o, err = qv.Single("offset", ""); return err },
+		func() error { vs, err = qv.Single("version", ""); return err },
+		func() error { v, err = semv.Parse(vs); return err },
+		func() error {
+			sid = sous.SourceID{
+				Location: sous.SourceLocation{
+					Repo: r,
+					Dir:  o,
+				},
+				Version: v,
+			}
+			return nil
+		},
+	)
+}

--- a/server/handle_artifact_test.go
+++ b/server/handle_artifact_test.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	sous "github.com/opentable/sous/lib"
+)
+
+type artifactTestInserter struct {
+	insFunc func(sous.SourceID, string, string, []sous.Quality) error
+}
+
+func (ati *artifactTestInserter) Insert(sid sous.SourceID, in, etag string, qs []sous.Quality) error {
+	return ati.insFunc(sid, in, etag, qs)
+}
+
+func TestPUTArtifact(t *testing.T) {
+	art := sous.NewBuildArtifact("test.reg.com/repo/test", sous.Strpairs{})
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.Encode(art)
+	req, err := http.NewRequest("PUT", "", buf)
+	if err != nil {
+		t.Fatal("error building request", err)
+	}
+
+	q, err := url.ParseQuery("repo=github.com/opentable/test&offset=&version=1.2.3")
+	if err != nil {
+		t.Fatal("error parsing query", err)
+	}
+
+	var inSid sous.SourceID
+	var inName string
+
+	pah := &PUTArtifactHandler{
+		Request:     req,
+		QueryValues: &QueryValues{q},
+		Inserter: &artifactTestInserter{
+			insFunc: func(s sous.SourceID, in, et string, qz []sous.Quality) error {
+				inSid = s
+				inName = in
+				return nil
+			},
+		},
+	}
+
+	_, status := pah.Exchange()
+	if status != 200 {
+		t.Errorf("status should be 200, was %d", status)
+	}
+	if inSid.Location.Repo != "github.com/opentable/test" {
+		t.Errorf("inserted SID repo was %s, should be github.com/opentable/test", inSid.Location.Repo)
+	}
+	if inName != "test.reg.com/repo/test" {
+		t.Errorf("inserted artifact name was %s, should be test.reg.com/repo/test", inName)
+	}
+}

--- a/server/handle_gdm.go
+++ b/server/handle_gdm.go
@@ -1,8 +1,6 @@
 package server
 
 import (
-	"log"
-
 	"github.com/opentable/sous/graph"
 	"github.com/opentable/sous/lib"
 )
@@ -27,7 +25,6 @@ func (gr *GDMResource) Get() Exchanger { return &GDMHandler{} }
 // Exchange implements the Handler interface
 func (h *GDMHandler) Exchange() (interface{}, int) {
 	data := gdmWrapper{Deployments: make([]*sous.Deployment, 0)}
-	log.Printf("%#v", h.GDM)
 	for _, d := range h.GDM.Snapshot() {
 		data.Deployments = append(data.Deployments, d)
 	}

--- a/server/router.go
+++ b/server/router.go
@@ -19,7 +19,7 @@ type (
 	// The MetaHandler collects common behavior for route handlers
 	MetaHandler struct {
 		router        *httprouter.Router
-		graphFac      GraphFactory
+		graphFac      GraphFactory //XXX This is a workaround for a bug in psyringe.Clone()
 		statusHandler *StatusHandler
 	}
 
@@ -107,7 +107,7 @@ func (mh *MetaHandler) InstallPanicHandler() {
 
 }
 
-func (mh *MetaHandler) exchangeGraph(w http.ResponseWriter, r *http.Request, p httprouter.Params) Injector {
+func (mh *MetaHandler) ExchangeGraph(w http.ResponseWriter, r *http.Request, p httprouter.Params) Injector {
 	g := mh.graphFac()
 	g.Add(&ResponseWriter{ResponseWriter: w}, r, p)
 	g.Add(parseQueryValues)
@@ -117,7 +117,7 @@ func (mh *MetaHandler) exchangeGraph(w http.ResponseWriter, r *http.Request, p h
 func (mh *MetaHandler) injectedHandler(factory ExchangeFactory, w http.ResponseWriter, r *http.Request, p httprouter.Params) Exchanger {
 	h := factory()
 
-	mh.exchangeGraph(w, r, p).Inject(h)
+	mh.ExchangeGraph(w, r, p).Inject(h)
 
 	return h
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -6,5 +6,6 @@ var (
 		{"gdm", "/gdm", &GDMResource{}},
 		{"defs", "/defs", &StateDefResource{}},
 		{"manifest", "/manifest", &ManifestResource{}},
+		{"artifact", "/artifact", &ArtifactResource{}},
 	}
 )

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -20,7 +20,10 @@ func testInject(thing interface{}) error {
 	}
 	mh := &MetaHandler{graphFac: gf}
 	w := httptest.NewRecorder()
-	r := http.NewRequest("GET", "/test", nil)
+	r, err := http.NewRequest("GET", "/test", nil)
+	if err != nil {
+		panic(err)
+	}
 	p := httprouter.Params{}
 
 	return mh.ExchangeGraph(w, r, p).Inject(thing)

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"log"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/opentable/sous/config"
+	"github.com/opentable/sous/graph"
+)
+
+func testInject(thing interface{}) error {
+	gf := func() Injector {
+		g := graph.BuildGraph(os.Stdout, os.Stdout)
+		g.Add(&config.Verbosity{})
+		return g
+	}
+	mh := &MetaHandler{graphFac: gf}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/test", nil)
+	p := httprouter.Params{}
+
+	return mh.ExchangeGraph(w, r, p).Inject(thing)
+}
+
+func TestInjectsArtifactHandler(t *testing.T) {
+	log.SetFlags(log.Flags() | log.Lshortfile)
+	pah := &PUTArtifactHandler{}
+	testInject(pah)
+	if pah.Inserter == nil {
+		t.Errorf("pah.Inserter nil: %#v", pah)
+	}
+	if pah.QueryValues == nil {
+		t.Errorf("pah.QueryValues nil: %#v", pah)
+	}
+	if pah.Request == nil {
+		t.Errorf("pah.Request nil: %#v", pah)
+	}
+}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"log"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
@@ -19,7 +20,7 @@ func testInject(thing interface{}) error {
 	}
 	mh := &MetaHandler{graphFac: gf}
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/test", nil)
+	r := http.NewRequest("GET", "/test", nil)
 	p := httprouter.Params{}
 
 	return mh.ExchangeGraph(w, r, p).Inject(thing)


### PR DESCRIPTION
The Docker registry search component needs to be informed by anything that does
`sous build` of the association betwen an image name and the associated source
version (repo,offset,version) triple.  This requirement is the result if how
the Docker v2 registries work. Until now, the assumption was that the server
would be doing the builds, but it's increasingly clear that this won't always
be the case. In line with the HTTPStateManager, this PR adds an "Inserter"
interface, and a second implementation that sends assocations over HTTP to the
server. The existing, direct Sqlite Inserter or the new HTTP Inserter are
selected based on whether a Server URL is configured.

If a Server is configured, the HTTPNameInserter is used transparently by `sous
build` to notify the server of the docker images that Sous builds