### PR TITLE
Fixes missing environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@ artifacts/
 samples/
 sous
 .agignore
-samples/
 check-compile.results
 testdata/

--- a/ext/docker/builder_test.go
+++ b/ext/docker/builder_test.go
@@ -35,7 +35,7 @@ LABEL \
   com.opentable.sous.repo_url="github.com/opentable/test" \
   com.opentable.sous.revision="abcd" \
   com.opentable.sous.version="2.3.7" \
-  com.opentable.sous.advisories="something is horribly wrong,"`, string(mddf))
+  com.opentable.sous.advisories="something is horribly wrong"`, string(mddf))
 }
 
 func TestTagStrings(t *testing.T) {

--- a/ext/docker/image_mapping.go
+++ b/ext/docker/image_mapping.go
@@ -567,6 +567,9 @@ func (nc *NameCache) dbInsert(sid sous.SourceID, in, etag string, quals []sous.Q
 	}
 
 	for _, q := range quals {
+		if q.Kind == "advisory" && q.Name == "" {
+			continue
+		}
 		nc.DB.Exec("insert into docker_image_qualities"+
 			"  (metadata_id, quality, kind)"+
 			"  values"+

--- a/ext/docker/metadataDockerfile.tmpl
+++ b/ext/docker/metadataDockerfile.tmpl
@@ -4,7 +4,7 @@ LABEL {{- range $key, $value := .Labels}} \
   {{- end -}}
   {{- with .Advisories}} \
   com.opentable.sous.advisories="
-  {{- range . -}}
-  {{.}},
+  {{- range $index, $element := . -}}
+  {{if $index}},{{end}}{{.}}
   {{- end}}"
   {{- end -}}

--- a/ext/docker/templates.go
+++ b/ext/docker/templates.go
@@ -5,5 +5,5 @@
 package docker
 
 const (
-	metadataDockerfileTmpl = "FROM {{.ImageID}}\nLABEL {{- range $key, $value := .Labels}} \\\n  {{$key}}=\"{{$value}}\"\n  {{- end -}}\n  {{- with .Advisories}} \\\n  com.opentable.sous.advisories=\"\n  {{- range . -}}\n  {{.}},\n  {{- end}}\"\n  {{- end -}}\n"
+	metadataDockerfileTmpl = "FROM {{.ImageID}}\nLABEL {{- range $key, $value := .Labels}} \\\n  {{$key}}=\"{{$value}}\"\n  {{- end -}}\n  {{- with .Advisories}} \\\n  com.opentable.sous.advisories=\"\n  {{- range $index, $element := . -}}\n  {{if $index}},{{end}}{{.}}\n  {{- end}}\"\n  {{- end -}}\n"
 )

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -77,6 +77,7 @@ func (r *deployer) ImageName(d *sous.Deployment) (string, error) {
 }
 
 func (r *deployer) RectifySingleCreate(d *sous.Deployment) error {
+	Log.Debug.Printf("Rectifing create:  \n %+ v", d)
 	name, err := r.ImageName(d)
 	if err != nil {
 		return err

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -77,7 +77,7 @@ func (r *deployer) ImageName(d *sous.Deployment) (string, error) {
 }
 
 func (r *deployer) RectifySingleCreate(d *sous.Deployment) error {
-	Log.Debug.Printf("Rectifing create:  \n %+ v", d)
+	Log.Debug.Printf("Rectifing create:  \n %# v", d)
 	name, err := r.ImageName(d)
 	if err != nil {
 		return err
@@ -110,7 +110,7 @@ func (r *deployer) RectifyModifies(
 }
 
 func (r *deployer) RectifySingleModification(pair *sous.DeploymentPair) error {
-	Log.Debug.Printf("Rectifying modify: \n  %+ v \n    =>  \n  %+ v", pair.Prior, pair.Post)
+	Log.Debug.Printf("Rectifying modify: \n  %# v \n    =>  \n  %# v", pair.Prior, pair.Post)
 	if r.changesReq(pair) {
 		Log.Debug.Printf("Scaling...")
 		if err := r.Client.Scale(

--- a/ext/storage/disk_state_manager.go
+++ b/ext/storage/disk_state_manager.go
@@ -43,6 +43,7 @@ func NewDiskStateManager(baseDir string) *DiskStateManager {
 func (dsm *DiskStateManager) ReadState() (*sous.State, error) {
 	// TODO: Allow state dir to be passed as flag in sous/cli.
 	// TODO: Consider returning a error to indicate if the state dir exists at all.
+	sous.Log.Vomit.Printf("Reading state from disk")
 	s := sous.NewState()
 	err := dsm.Codec.Read(dsm.BaseDir, s)
 	if err != nil {
@@ -66,5 +67,6 @@ func (dsm *DiskStateManager) ReadState() (*sous.State, error) {
 
 // WriteState records the entire intended state of the world to a dir.
 func (dsm *DiskStateManager) WriteState(s *sous.State) error {
+	sous.Log.Vomit.Printf("Writing state to disk")
 	return dsm.Codec.Write(dsm.BaseDir, s)
 }

--- a/lib/deploy_config.go
+++ b/lib/deploy_config.go
@@ -60,15 +60,19 @@ func (dc DeployConfig) Clone() (c DeployConfig) {
 
 // Equal compares Envs
 func (e Env) Equal(o Env) bool {
+	Log.Vomit.Printf("Envs: %+ v ?= %+ v", e, o)
 	if len(e) != len(o) {
+		Log.Vomit.Printf("Envs: %+ v != %+ v (%d != %d)", e, o, len(e), len(o))
 		return false
 	}
 
 	for name, value := range e {
 		if ov, ok := o[name]; !ok || ov != value {
+			Log.Vomit.Printf("Envs: %+ v != %+ v [%q] %q != %q", e, o, name, value, ov)
 			return false
 		}
 	}
+	Log.Vomit.Printf("Envs: %+ v == %+ v !", e, o)
 	return true
 }
 

--- a/lib/deployment_dumper.go
+++ b/lib/deployment_dumper.go
@@ -9,6 +9,7 @@ import (
 func DumpDeployments(io io.Writer, ds Deployments) {
 	w := &tabwriter.Writer{}
 	w.Init(io, 2, 4, 2, ' ', 0)
+
 	fmt.Fprintln(w, TabbedDeploymentHeaders())
 
 	for _, d := range ds.Snapshot() {

--- a/lib/logging.go
+++ b/lib/logging.go
@@ -34,17 +34,6 @@ var (
 	// Log collects various loggers to use for different levels of logging
 	Log = func() LogSet {
 		return *(NewLogSet(os.Stderr, ioutil.Discard, ioutil.Discard))
-		/*
-			warnLogger := log.New(os.Stderr, "warn: ", 0)
-			return LogSet{
-				// Debug is a logger - use log.SetOutput to get output from
-				Vomit:  log.New(ioutil.Discard, "vomit: ", log.Lshortfile),
-				Debug:  log.New(ioutil.Discard, "debug: ", log.Lshortfile),
-				Info:   warnLogger, // XXX deprecate Info
-				Notice: warnLogger, // XXX deprecate Notice
-				Warn:   warnLogger,
-			}
-		*/
 	}()
 )
 
@@ -58,8 +47,8 @@ func NewLogSet(warn, debug, vomit io.Writer) *LogSet {
 	warnLogger := log.New(warn, "warn: ", 0)
 	return &LogSet{
 		// Debug is a logger - use log.SetOutput to get output from
-		Vomit:  log.New(vomit, "vomit: ", log.Lshortfile),
-		Debug:  log.New(debug, "debug: ", log.Lshortfile),
+		Vomit:  log.New(vomit, "vomit: ", log.Lshortfile|log.Ldate|log.Ldate),
+		Debug:  log.New(debug, "debug: ", log.Lshortfile|log.Ldate|log.Ldate),
 		Info:   warnLogger, // XXX deprecate Info
 		Notice: warnLogger, // XXX deprecate Notice
 		Warn:   warnLogger,

--- a/lib/logging.go
+++ b/lib/logging.go
@@ -47,8 +47,8 @@ func NewLogSet(warn, debug, vomit io.Writer) *LogSet {
 	warnLogger := log.New(warn, "warn: ", 0)
 	return &LogSet{
 		// Debug is a logger - use log.SetOutput to get output from
-		Vomit:  log.New(vomit, "vomit: ", log.Lshortfile|log.Ldate|log.Ldate),
-		Debug:  log.New(debug, "debug: ", log.Lshortfile|log.Ldate|log.Ldate),
+		Vomit:  log.New(vomit, "vomit: ", log.Lshortfile|log.Ldate|log.Ltime),
+		Debug:  log.New(debug, "debug: ", log.Lshortfile|log.Ldate|log.Ltime),
 		Info:   warnLogger, // XXX deprecate Info
 		Notice: warnLogger, // XXX deprecate Notice
 		Warn:   warnLogger,

--- a/lib/map_state_to_deployments.go
+++ b/lib/map_state_to_deployments.go
@@ -69,7 +69,7 @@ func (ds Deployments) Manifests(defs Defs) (Manifests, error) {
 		}
 		spec := DeploySpec{
 			Version:      d.SourceID.Version,
-			DeployConfig: d.DeployConfig,
+			DeployConfig: d.DeployConfig.Clone(),
 		}
 		for k, v := range spec.DeployConfig.Env {
 			clusterVal, ok := d.Cluster.Env[k]

--- a/lib/map_state_to_deployments_test.go
+++ b/lib/map_state_to_deployments_test.go
@@ -189,12 +189,39 @@ var expectedDeployments = NewDeployments(
 	},
 )
 
+func TestState_DeploymentsCloned(t *testing.T) {
+	actualDeployments, err := makeTestState().Deployments()
+	if err != nil {
+		t.Fatal(err)
+	}
+	actualDeployments = actualDeployments.Clone()
+
+	exSnap := expectedDeployments.Snapshot()
+	if len(actualDeployments.Snapshot()) != len(exSnap) {
+		t.Error("deployments different lengths")
+	}
+	for id, expected := range exSnap {
+		actual, ok := actualDeployments.Get(id)
+		if !ok {
+			t.Errorf("missing deployment %q", id)
+			continue
+		}
+		if !actual.Equal(expected) {
+			t.Errorf("\n\ngot:\n%v\n\nwant:\n%v\n", jsonDump(actual), jsonDump(expected))
+		}
+	}
+}
+
 func TestState_Deployments(t *testing.T) {
 	actualDeployments, err := makeTestState().Deployments()
 	if err != nil {
 		t.Fatal(err)
 	}
-	for id, expected := range expectedDeployments.Snapshot() {
+	exSnap := expectedDeployments.Snapshot()
+	if len(actualDeployments.Snapshot()) != len(exSnap) {
+		t.Error("deployments different lengths")
+	}
+	for id, expected := range exSnap {
 		actual, ok := actualDeployments.Get(id)
 		if !ok {
 			t.Errorf("missing deployment %q", id)

--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -88,6 +88,9 @@ func guardImages(r Registry, gdm Deployments) error {
 		}
 		for _, q := range art.Qualities {
 			if q.Kind == `advisory` {
+				if q.Name == "" {
+					continue
+				}
 				found := false
 				var advs []string
 				if d.Cluster != nil {


### PR DESCRIPTION
There's a variety of little fixes in here; some tweaks to how advisories are
rendered and parsed that was preventing rectification on the server.

But the **real** change here, and it was a bear is in the manifest<->deployment
mappings. Because the `Deployments` is a map of pointers to Deployment, when a
`Manifests` was built from it, the step that deleted keys from the `DeploySpec`
in order to fold them out appropriately (i.e. to make sure that the Manifest
doesn't have redundant and eventually stale environment variables), those
deletes were changing the original Deployment DeploySpec. Most of the effort
involved in this PR comes down to tracking down that one fact and making the
one-line change to fix it.

I'd say that what hit us here was (effectively) global mutable state, and that
the solution would be to have the State, its continuents and related data
structures all be methodless immediate values, rather than pointers to
anything. This is certainly coming in the wake of hunting down this issue, and
I may be overstating the severity of the problem. I tend to thing that where we
turn over a rock and find a bug, there's more hiding, though.

One thing that's missing is a regression test. It's the end of my day, or I'd
write one that took a test state, copied a deployment from it, computed the
manifests from the deployments and tested that the deployment remained
unchanged.