### PR TITLE
Do not delete

### DIFF
--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -84,7 +84,7 @@ func (r *deployer) RectifySingleCreate(d *sous.Deployment) (err error) {
 		if r := recover(); r != nil {
 			sous.Log.Warn.Printf("Panic in RectifySingleCreate with %# v", fd)
 			sous.Log.Warn.Printf("  %v", r)
-			sous.Log.Warn.Print(debug.Stack())
+			sous.Log.Warn.Print(string(debug.Stack()))
 			err = errors.Errorf("Panicked")
 		}
 	}(d)
@@ -114,7 +114,7 @@ func (r *deployer) RectifySingleDelete(d *sous.Deployment) (err error) {
 		if r := recover(); r != nil {
 			sous.Log.Warn.Printf("Panic in RectifySingleDelete with %# v", fd)
 			sous.Log.Warn.Printf("  %v", r)
-			sous.Log.Warn.Print(debug.Stack())
+			sous.Log.Warn.Print(string(debug.Stack()))
 			err = errors.Errorf("Panicked")
 		}
 	}(d)
@@ -136,7 +136,7 @@ func (r *deployer) RectifySingleModification(pair *sous.DeploymentPair) (err err
 		if r := recover(); r != nil {
 			sous.Log.Warn.Printf("Panic in RectifySingleModification with %# v", fp)
 			sous.Log.Warn.Printf("  %v", r)
-			sous.Log.Warn.Print(debug.Stack())
+			sous.Log.Warn.Print(string(debug.Stack()))
 			err = errors.Errorf("Panicked")
 		}
 	}(pair)

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -113,7 +113,13 @@ func (r *deployer) RectifyDeletes(dc <-chan *sous.Deployment, errs chan<- sous.R
 
 func (r *deployer) RectifySingleDelete(d *sous.Deployment) (err error) {
 	defer rectifyRecover(d, "RectifySingleDelete", &err)
-	return r.Client.DeleteRequest(d.Cluster.BaseURL, computeRequestID(d), "deleting request for removed manifest")
+	requestID := computeRequestID(d)
+	// TODO: Alert the owner of this request that there is no manifest for it;
+	// they should either delete the request manually, or else add the manifest back.
+	sous.Log.Warn.Printf("NOT DELETING REQUEST %q (FOR: %q)", requestID, d.ID())
+	return nil
+	// The following line deletes requests when it is not commented out.
+	//return r.Client.DeleteRequest(d.Cluster.BaseURL, requestID, "deleting request for removed manifest")
 }
 
 func (r *deployer) RectifyModifies(

--- a/ext/singularity/deployer_test.go
+++ b/ext/singularity/deployer_test.go
@@ -74,3 +74,19 @@ func TestMakeRequestID(t *testing.T) {
 		}
 	}
 }
+
+func TestRectifyRecover(t *testing.T) {
+	var err error
+	expected := "Panicked"
+	func() {
+		defer rectifyRecover("something", "TestRectifyRecover", &err)
+		panic("What's that coming over the hill?!")
+	}()
+	if err == nil {
+		t.Fatalf("got nil, want error %q", expected)
+	}
+	actual := err.Error()
+	if actual != expected {
+		t.Errorf("got error %q; want %q", actual, expected)
+	}
+}

--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -296,10 +296,15 @@ func TestDeletes(t *testing.T) {
 	assert.Len(client.Deployed, 0)
 	assert.Len(client.Created, 0)
 
-	if assert.Len(client.Deleted, 1) {
-		req := client.Deleted[0]
-		assert.Equal("cluster", req.Cluster)
-		assert.Equal("reqid::", req.Reqid)
+	// We no longer expect any deletions; See deployer.RectifySingleDelete.
+	//expectedDeletions := 1
+	expectedDeletions := 0
+
+	if assert.Len(client.Deleted, expectedDeletions) {
+		// We no longer expect any deletions; See deployer.RectifySingleDelete.
+		//req := client.Deleted[0]
+		//assert.Equal("cluster", req.Cluster)
+		//assert.Equal("reqid::", req.Reqid)
 	}
 }
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -244,9 +244,13 @@ func TestResolve(t *testing.T) {
 		}
 	}
 
+	// We no longer expect any deletions; See deployer.RectifySingleDelete.
+	//expectedInstances := 0
+	expectedInstances := 1
+
 	which = findRepo(ds, repoOne)
 	if which != none {
-		assert.Equal(0, deps[which].NumInstances)
+		assert.Equal(expectedInstances, deps[which].NumInstances)
 	}
 
 }


### PR DESCRIPTION
Includes #193; comments out line deleting Singularity requests.

This is not at all pretty; but I would like to get server back up-and-running ASAP, and people are relying on Sous in production now, so I want to avoid the possibility of catastrophe from this source.

For deleting things, we need to alert the owner of the deleted manifest that they have an unowned request that needs cleaning up, or else they need to add their manifest back.