### PR TITLE
Diff log

### DIFF
--- a/ext/singularity/actual_deployment_set.go
+++ b/ext/singularity/actual_deployment_set.go
@@ -36,7 +36,7 @@ type (
 	retryCounter map[string]uint
 )
 
-// GetRunningDeployment collects data from the Singularity clusters and
+// RunningDeployments collects data from the Singularity clusters and
 // returns a list of actual deployments
 func (sc *deployer) RunningDeployments(clusters sous.Clusters) (deps sous.Deployments, err error) {
 	retries := make(retryCounter)
@@ -72,9 +72,9 @@ func (sc *deployer) RunningDeployments(clusters sous.Clusters) (deps sous.Deploy
 	go func() {
 		catchAndSend("closing up", errCh)
 		singWait.Wait()
-		Log.Vomit.Println("All singularities polled for requests")
+		Log.Debug.Println("All singularities polled for requests")
 		depWait.Wait()
-		Log.Vomit.Println("All deploys processed")
+		Log.Debug.Println("All deploys processed")
 
 		close(reqCh)
 		close(errCh)

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -88,7 +88,7 @@ func rectifyRecover(d interface{}, f string, err *error) {
 }
 
 func (r *deployer) RectifySingleCreate(d *sous.Deployment) (err error) {
-	Log.Debug.Printf("Rectifing create:  \n %# v", d)
+	Log.Debug.Printf("Rectifing creation %q:  \n %# v", d.ID(), d)
 	defer rectifyRecover(d, "RectifySingleCreate", &err)
 	name, err := r.ImageName(d)
 	if err != nil {
@@ -132,7 +132,7 @@ func (r *deployer) RectifyModifies(
 }
 
 func (r *deployer) RectifySingleModification(pair *sous.DeploymentPair) (err error) {
-	Log.Debug.Printf("Rectifying modify: \n  %# v \n    =>  \n  %# v", pair.Prior, pair.Post)
+	Log.Debug.Printf("Rectifying modified %q: \n  %# v \n    =>  \n  %# v", pair.ID(), pair.Prior, pair.Post)
 	defer rectifyRecover(pair, "RectifySingleModification", &err)
 	if r.changesReq(pair) {
 		Log.Debug.Printf("Scaling...")

--- a/lib/deploy_config.go
+++ b/lib/deploy_config.go
@@ -38,7 +38,10 @@ func (dc *DeployConfig) String() string {
 // Equal is used to compare DeployConfigs
 func (dc *DeployConfig) Equal(o DeployConfig) bool {
 	Log.Vomit.Printf("%+ v ?= %+ v", dc, o)
-	return (dc.NumInstances == o.NumInstances && dc.Env.Equal(o.Env) && dc.Resources.Equal(o.Resources) && dc.Volumes.Equal(o.Volumes))
+	return (dc.NumInstances == o.NumInstances &&
+		dc.Env.Equal(o.Env) &&
+		dc.Resources.Equal(o.Resources) &&
+		dc.Volumes.Equal(o.Volumes))
 }
 
 func (dc DeployConfig) Clone() (c DeployConfig) {

--- a/lib/deploy_config.go
+++ b/lib/deploy_config.go
@@ -38,10 +38,8 @@ func (dc *DeployConfig) String() string {
 // Equal is used to compare DeployConfigs
 func (dc *DeployConfig) Equal(o DeployConfig) bool {
 	Log.Vomit.Printf("%+ v ?= %+ v", dc, o)
-	return (dc.NumInstances == o.NumInstances &&
-		dc.Env.Equal(o.Env) &&
-		dc.Resources.Equal(o.Resources) &&
-		dc.Volumes.Equal(o.Volumes))
+	diff, _ := dc.Diff(o)
+	return !diff
 }
 
 // Diff returns a list of differences between this and the other DeployConfig.

--- a/lib/deploy_config.go
+++ b/lib/deploy_config.go
@@ -48,15 +48,26 @@ func (dc *DeployConfig) Diff(o DeployConfig) (bool, []string) {
 	if dc.NumInstances != o.NumInstances {
 		diffs = append(diffs, fmt.Sprintf("number of instances; this: %d; other: %d", dc.NumInstances, o.NumInstances))
 	}
-	if !dc.Env.Equal(o.Env) {
-		diffs = append(diffs, fmt.Sprintf("env; this: %v; other: %v", dc.Env, o.Env))
+	// Only compare contents if length of either > 0.
+	// This makes nil equal to zero-length map.
+	if len(dc.Env) != 0 || len(o.Env) != 0 {
+		if !dc.Env.Equal(o.Env) {
+			diffs = append(diffs, fmt.Sprintf("env; this: %v; other: %v", dc.Env, o.Env))
+		}
 	}
-	if !dc.Resources.Equal(o.Resources) {
-		diffs = append(diffs, fmt.Sprintf("resources; this: %v; other: %v", dc.Resources, o.Resources))
+	// Only compare contents if length of either > 0.
+	if len(dc.Resources) != 0 || len(o.Resources) != 0 {
+		if !dc.Resources.Equal(o.Resources) {
+			diffs = append(diffs, fmt.Sprintf("resources; this: %v; other: %v", dc.Resources, o.Resources))
+		}
 	}
-	if !dc.Volumes.Equal(o.Volumes) {
-		diffs = append(diffs, fmt.Sprintf("volumes; this: %v; other: %v", dc.Volumes, o.Volumes))
+	// Only compare contents if length of either > 0.
+	if len(dc.Volumes) != 0 || len(o.Volumes) != 0 {
+		if !dc.Volumes.Equal(o.Volumes) {
+			diffs = append(diffs, fmt.Sprintf("volumes; this: %v; other: %v", dc.Volumes, o.Volumes))
+		}
 	}
+	// TODO: Compare Args
 	return len(diffs) == 0, diffs
 }
 

--- a/lib/deploy_config.go
+++ b/lib/deploy_config.go
@@ -44,6 +44,24 @@ func (dc *DeployConfig) Equal(o DeployConfig) bool {
 		dc.Volumes.Equal(o.Volumes))
 }
 
+// Diff returns a list of differences between this and the other DeployConfig.
+func (dc *DeployConfig) Diff(o DeployConfig) (bool, []string) {
+	var diffs []string
+	if dc.NumInstances != o.NumInstances {
+		diffs = append(diffs, fmt.Sprintf("number of instances; this: %d; other: %d", dc.NumInstances, o.NumInstances))
+	}
+	if !dc.Env.Equal(o.Env) {
+		diffs = append(diffs, fmt.Sprintf("env; this: %v; other: %v", dc.Env, o.Env))
+	}
+	if !dc.Resources.Equal(o.Resources) {
+		diffs = append(diffs, fmt.Sprintf("resources; this: %v; other: %v", dc.Resources, o.Resources))
+	}
+	if !dc.Volumes.Equal(o.Volumes) {
+		diffs = append(diffs, fmt.Sprintf("volumes; this: %v; other: %v", dc.Volumes, o.Volumes))
+	}
+	return len(diffs) == 0, diffs
+}
+
 func (dc DeployConfig) Clone() (c DeployConfig) {
 	c.NumInstances = dc.NumInstances
 	c.Args = make([]string, len(dc.Args))

--- a/lib/deploy_spec.go
+++ b/lib/deploy_spec.go
@@ -32,5 +32,5 @@ type (
 
 // Equal returns true if other equals spec.
 func (spec DeploySpec) Equal(other DeploySpec) bool {
-	return spec.Version == other.Version && spec.DeployConfig.Equal(other.DeployConfig)
+	return spec.Version.Equals(other.Version) && spec.DeployConfig.Equal(other.DeployConfig)
 }

--- a/lib/deploy_spec.go
+++ b/lib/deploy_spec.go
@@ -1,6 +1,10 @@
 package sous
 
-import "github.com/samsalisbury/semv"
+import (
+	"fmt"
+
+	"github.com/samsalisbury/semv"
+)
 
 type (
 	// DeploySpecs is a collection of Deployments associated with a manifest.
@@ -32,5 +36,21 @@ type (
 
 // Equal returns true if other equals spec.
 func (spec DeploySpec) Equal(other DeploySpec) bool {
-	return spec.Version.Equals(other.Version) && spec.DeployConfig.Equal(other.DeployConfig)
+	different, _ := spec.Diff(other)
+	return !different
+}
+
+// Diff returns true and a list of differences if spec is different to other.
+// Otherwise returns false, nil.
+func (spec DeploySpec) Diff(other DeploySpec) (bool, []string) {
+	var diffs []string
+	diff := func(format string, a ...interface{}) { diffs = append(diffs, fmt.Sprintf(format, a...)) }
+	if !spec.Version.Equals(other.Version) {
+		diff("version; this: %q; other: %q", spec.Version, other.Version)
+	}
+	_, configDiffs := spec.DeployConfig.Diff(other.DeployConfig)
+	for _, d := range configDiffs {
+		diff(d)
+	}
+	return len(diffs) != 0, diffs
 }

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -141,18 +141,8 @@ func (d *Deployment) Name() DeployID {
 
 // Equal returns true if two Deployments are equal.
 func (d *Deployment) Equal(o *Deployment) bool {
-	Log.Vomit.Printf("Comparing: %+ v ?= %+ v", d, o)
-	if d.ClusterName != o.ClusterName || !d.SourceID.Equal(o.SourceID) || d.Flavor != o.Flavor || d.Kind != o.Kind {
-		Log.Debug.Printf("C: %t V: %t, K: %t, #O: %t", d.ClusterName == o.ClusterName, d.SourceID.Equal(o.SourceID), d.Kind == o.Kind, len(d.Owners) == len(o.Owners))
-		return false
-	}
-
-	for ownr := range d.Owners {
-		if _, has := o.Owners[ownr]; !has {
-			return false
-		}
-	}
-	return d.DeployConfig.Equal(o.DeployConfig)
+	diff, _ := d.Diff(o)
+	return !diff
 }
 
 // Diff returns the differences between this deployment and another.
@@ -160,7 +150,6 @@ func (d *Deployment) Diff(o *Deployment) (bool, []string) {
 	if d.ID() != o.ID() {
 		panic(fmt.Sprintf("attempt to compare deployment %q with %q", d.ID(), o.ID()))
 	}
-	//Log.Vomit.Printf("Comparing: %+ v ?= %+ v", d, o)
 	Log.Debug.Printf("Comparing two versions of deployment %q", d.ID())
 	var diffs []string
 	diff := func(format string, a ...interface{}) { diffs = append(diffs, fmt.Sprintf(format, a...)) }

--- a/lib/deployment_diff.go
+++ b/lib/deployment_diff.go
@@ -38,6 +38,11 @@ func newDiffSet() diffSet {
 	}
 }
 
+// ID returns the DeployID of this deployment pair.
+func (dp *DeploymentPair) ID() DeployID {
+	return dp.name
+}
+
 func (d *DiffChans) collect() diffSet {
 	ds := newDiffSet()
 

--- a/lib/deployment_diff.go
+++ b/lib/deployment_diff.go
@@ -124,9 +124,11 @@ func (d *differ) diff(existing Deployments) {
 		name := e[i].Name()
 		if indep, ok := d.from[name]; ok {
 			delete(d.from, name)
-			if indep.Equal(e[i]) {
+			different, differences := indep.Diff(e[i])
+			if !different {
 				d.Retained <- indep
 			} else {
+				Log.Debug.Printf("differences detected for %q: %#v", indep.ID(), differences)
 				d.Modified <- &DeploymentPair{name, indep, e[i]}
 			}
 		} else {

--- a/lib/diff_concentrator.go
+++ b/lib/diff_concentrator.go
@@ -224,17 +224,17 @@ func (dc *DiffConcentrator) dispatch(mp *ManifestPair) error {
 			return errors.Errorf("Blank manifest pair: %#v", mp)
 		}
 		dc.Created <- mp.Post
-	} else {
-		if mp.Post == nil {
-			dc.Deleted <- mp.Prior
-		} else {
-			if mp.Prior.Equal(mp.Post) {
-				dc.Retained <- mp.Post
-			} else {
-				dc.Modified <- mp
-			}
-		}
+		return nil
 	}
+	if mp.Post == nil {
+		dc.Deleted <- mp.Prior
+		return nil
+	}
+	if mp.Prior.Equal(mp.Post) {
+		dc.Retained <- mp.Post
+		return nil
+	}
+	dc.Modified <- mp
 	return nil
 }
 

--- a/lib/diff_concentrator.go
+++ b/lib/diff_concentrator.go
@@ -7,10 +7,12 @@ import (
 )
 
 type (
+	// ManifestPair is a pair of manifests.
 	ManifestPair struct {
 		name        ManifestID
 		Prior, Post *Manifest
 	}
+	// ManifestPairs is a slice of *ManifestPair.
 	ManifestPairs []*ManifestPair
 
 	// A DiffConcentrator wraps deployment DiffChans in order to produce
@@ -35,14 +37,14 @@ type (
 )
 
 // Concentrate returns a DiffConcentrator set up to concentrate the deployment
-// changes in a DiffChans into manifest changes
+// changes in a DiffChans into manifest changes.
 func (d DiffChans) Concentrate(defs Defs) DiffConcentrator {
 	c := NewConcentrator(defs, d, cap(d.Created))
 	go concentrate(d, c)
 	return c
 }
 
-// NewDiffChans constructs a DiffChans
+// NewConcentrator constructs a DiffConcentrator.
 func NewConcentrator(defs Defs, s DiffChans, sizes ...int) DiffConcentrator {
 	var size int
 	if len(sizes) > 0 {

--- a/lib/diff_concentrator_test.go
+++ b/lib/diff_concentrator_test.go
@@ -67,11 +67,11 @@ func TestRealDiffConcentration(t *testing.T) {
 		}
 	}
 
-	repoOne := "https://github.com/opentable/one"
-	repoTwo := "https://github.com/opentable/two"
-	repoThree := "https://github.com/opentable/three"
-	repoFour := "https://github.com/opentable/four"
-	repoFive := "https://github.com/opentable/five"
+	repoOne := "github.com/opentable/one"
+	repoTwo := "github.com/opentable/two"
+	repoThree := "github.com/opentable/three"
+	repoFour := "github.com/opentable/four"
+	repoFive := "github.com/opentable/five"
 
 	intended.MustAdd(makeDepl(repoOne, "111.1.1", 1)) //remove
 

--- a/lib/http_state_manager.go
+++ b/lib/http_state_manager.go
@@ -296,8 +296,9 @@ func (hsm *HTTPStateManager) del(m *Manifest) error {
 		return errors.Errorf("GET %s to delete, %s: %#v", murl, grz.Status, m)
 	}
 	rm := hsm.jsonManifest(grz.Body)
-	if !rm.Equal(m) {
-		return errors.Errorf("Remote and deleted manifests don't match: \n%#v\n%#v", rm, m)
+	different, differences := rm.Diff(m)
+	if different {
+		return errors.Errorf("Remote and deleted manifests don't match: %#v", differences)
 	}
 	etag := grz.Header.Get("Etag")
 	drq, err := http.NewRequest("DELETE", murl, nil)
@@ -336,8 +337,9 @@ func (hsm *HTTPStateManager) modify(mp *ManifestPair) error {
 		return errors.Errorf("%s: %#v", grz.Status, bf)
 	}
 	rm := hsm.jsonManifest(grz.Body)
-	if !rm.Equal(bf) {
-		return errors.Errorf("Remote and prior manifests don't match: \n%#v\n%#v", rm, bf)
+	different, differences := rm.Diff(bf)
+	if different {
+		return errors.Errorf("Remote and prior manifests don't match: %#v", differences)
 	}
 	etag := grz.Header.Get("Etag")
 

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -114,7 +114,7 @@ func (m *Manifest) Diff(o *Manifest) (bool, []string) {
 		diff("number of deployments; this: %d; other: %d", len(m.Deployments), len(o.Deployments))
 	} else {
 		for clusterName, deploySpec := range m.Deployments {
-			_, differences := deploySpec.Diff(o.Deployments[clusterName].DeployConfig)
+			_, differences := deploySpec.Diff(o.Deployments[clusterName])
 			for _, deploySpecDiff := range differences {
 				diff(deploySpecDiff)
 			}

--- a/lib/resources.go
+++ b/lib/resources.go
@@ -19,7 +19,7 @@ func (r Resources) Cpus() float64 {
 		if present {
 			Log.Warn.Printf("Could not parse value: '%s' for cpus as a float, using default: %f", cpuStr, cpus)
 		} else {
-			Log.Info.Printf("Using default value for cpus: %f", cpus)
+			Log.Vomit.Printf("Using default value for cpus: %f.", cpus)
 		}
 	}
 	return cpus
@@ -33,7 +33,7 @@ func (r Resources) Memory() float64 {
 		if present {
 			Log.Warn.Printf("Could not parse value: '%s' for memory as an int, using default: %f", memStr, memory)
 		} else {
-			Log.Info.Printf("Using default value for memory: %f", memory)
+			Log.Vomit.Printf("Using default value for memory: %f.", memory)
 		}
 	}
 	return memory
@@ -47,7 +47,7 @@ func (r Resources) Ports() int32 {
 		if present {
 			Log.Warn.Printf("Could not parse value: '%s' for ports as a int, using default: %d", portStr, ports)
 		} else {
-			Log.Info.Printf("Using default value for ports: %d", ports)
+			Log.Vomit.Printf("Using default value for ports: %d", ports)
 		}
 	}
 	return int32(ports)

--- a/lib/source_id.go
+++ b/lib/source_id.go
@@ -75,6 +75,12 @@ func (sid SourceID) RevID() string {
 
 // Equal tests the equality between this SourceID and another.
 func (sid SourceID) Equal(o SourceID) bool {
+	if !sid.Version.Equals(o.Version) {
+		return false
+	}
+	// Equalise the versions so we can do a simple equality test.
+	// This is safe because sid and o are values not pointers.
+	sid.Version = o.Version
 	return sid == o
 }
 

--- a/test/http_state_manager_test.go
+++ b/test/http_state_manager_test.go
@@ -51,8 +51,8 @@ func TestWriteState(t *testing.T) {
 		di.Add(sous.NewLogSet(os.Stderr, os.Stderr, ioutil.Discard))
 		graph.AddInternals(di)
 		di.Add(
-			func() graph.LocalStateReader { return graph.LocalStateReader{sm} },
-			func() graph.LocalStateWriter { return graph.LocalStateWriter{sm} },
+			func() graph.LocalStateReader { return graph.LocalStateReader{StateReader: sm} },
+			func() graph.LocalStateWriter { return graph.LocalStateWriter{StateWriter: sm} },
 		)
 		di.Add(&config.Verbosity{})
 		return di


### PR DESCRIPTION
Extra logging for deployment diffs + fix SourceID.Equal to correctly compare versions.

NOTE: Grep the logs for "differences detected" to see the new output.