### PR TITLE
Adds -cluster to `sous server`

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/nyarly/testify/assert"
 	"github.com/nyarly/testify/require"
+	"github.com/opentable/sous/ext/docker"
+	sous "github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/cmdr"
 	"github.com/samsalisbury/semv"
 )
@@ -285,21 +287,26 @@ func TestInvokeRectifyDryruns(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	testDryRun := func(which string) {
+	testDryRun := func(which string) (sous.Deployer, sous.Registry) {
 		exe := justCommand(t, []string{`sous`, `rectify`, `-dry-run`, which, `-repo`, `github.com/somewhere`})
 		assert.Len(exe.Args, 0)
 		require.IsType(&SousRectify{}, exe.Cmd)
 		rect := exe.Cmd.(*SousRectify)
-		res, err := rect.buildResolver()
-		require.NoError(err)
-		assert.Equal(rect.Deployer, res.Deployer)
-		assert.Equal(rect.Registry, res.Registry)
+		// currently no easy way to tell if the deploy client is live or dummy
+		return nil, rect.Registry
 	}
 
-	testDryRun("both")
-	testDryRun("none")
-	testDryRun("scheduler")
-	testDryRun("registry")
+	_, r := testDryRun("both")
+	assert.IsType(&sous.DummyRegistry{}, r)
+
+	_, r = testDryRun("none")
+	assert.IsType(&docker.NameCache{}, r)
+
+	_, r = testDryRun("scheduler")
+	assert.IsType(&docker.NameCache{}, r)
+
+	_, r = testDryRun("registry")
+	assert.IsType(&sous.DummyRegistry{}, r)
 }
 
 /*

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -152,6 +152,14 @@ func TestInvokeQuery(t *testing.T) {
 	assert.NotNil(exe)
 }
 
+func TestInvokeServer(t *testing.T) {
+	exe := justCommand(t, []string{`sous`, `server`})
+	assert.NotNil(t, exe)
+
+	exe = justCommand(t, []string{`sous`, `server`, `-cluster`, `test`})
+	assert.NotNil(t, exe)
+}
+
 /*
 usage: sous version
 

--- a/cli/deploy_filter_flags.go
+++ b/cli/deploy_filter_flags.go
@@ -109,6 +109,8 @@ const (
 )
 
 var (
+	// ClusterFilterFlagsHelp just exposes the -cluster flag (for server)
+	ClusterFilterFlagsHelp = clusterFlagHelp
 	// SourceFlagsHelp is the text (and config) for source flags
 	SourceFlagsHelp = repoFlagHelp + offsetFlagHelp + flavorFlagHelp + tagFlagHelp + revisionFlagHelp
 	// RectifyFilterFlagsHelp is the text (and config) for rectification flags

--- a/cli/flags_source_test.go
+++ b/cli/flags_source_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/opentable/sous/config"
@@ -30,34 +31,34 @@ var buildPredicateErrorTests = []struct {
 			Source: "hello",
 			All:    true,
 		},
-		Error: "you cannot specify both -source and -all",
+		Error: "You cannot specify both -all and filtering options",
 	},
 	{
 		Flags: config.DeployFilterFlags{
 			All:  true,
 			Repo: "hello",
 		},
-		Error: "you cannot specify both -all and -repo",
+		Error: "You cannot specify both -all and filtering options",
 	},
 	{
 		Flags: config.DeployFilterFlags{
 			All:    true,
 			Offset: "hello",
 		},
-		Error: "you cannot specify both -all and -offset",
+		Error: "You cannot specify both -all and filtering options",
 	},
 	{
 		Flags: config.DeployFilterFlags{
 			All:    true,
 			Flavor: "hello",
 		},
-		Error: "you cannot specify both -all and -flavor",
+		Error: "You cannot specify both -all and filtering options",
 	},
 }
 
 func TestBuildPredicate_errors(t *testing.T) {
 	parseSL := func(s string) (sous.SourceLocation, error) {
-		return sous.SourceLocation{}, nil
+		return sous.SourceLocation{Repo: "github.com/somewhere"}, nil
 	}
 	for _, test := range buildPredicateErrorTests {
 		input := test.Flags
@@ -71,7 +72,7 @@ func TestBuildPredicate_errors(t *testing.T) {
 			continue
 		}
 		actual := actualErr.Error()
-		if actual != expected {
+		if !strings.Contains(actual, expected) {
 			t.Errorf("%#v got error %q; want %q", input, actual, expected)
 		}
 	}

--- a/cli/rectify_test.go
+++ b/cli/rectify_test.go
@@ -41,7 +41,10 @@ func TestPredicateBuilder(t *testing.T) {
 	//	}
 	//
 	f := config.DeployFilterFlags{}
-	assert.Nil(f.BuildPredicate(parseSL))
+
+	rf, err := f.BuildFilter(parseSL)
+	assert.NoError(err)
+	assert.True(rf.All())
 
 	f.Repo = string(rs[0])
 	pd, err := f.BuildPredicate(parseSL)

--- a/cli/sous_harvest.go
+++ b/cli/sous_harvest.go
@@ -26,6 +26,10 @@ usage: sous harvest <repo>...
 // Help prints the help
 func (*SousHarvest) Help() string { return sousHarvestHelp }
 
+func (*SousHarvest) RegisterOn(psy Addable) {
+	psy.Add(graph.DryrunNeither)
+}
+
 // Execute defines the behavior of `sous query gdm`
 func (sh *SousHarvest) Execute(args []string) cmdr.Result {
 	if len(args) == 0 {

--- a/cli/sous_query_ads.go
+++ b/cli/sous_query_ads.go
@@ -32,6 +32,10 @@ This should resemble the manifest that was used to establish the current state o
 // Help prints the help
 func (*SousQueryAds) Help() string { return sousBuildHelp }
 
+func (*SousQueryAds) RegisterOn(psy Addable) {
+	psy.Add(graph.DryrunOption("none"))
+}
+
 // Execute defines the behavior of `sous query ads`
 func (sb *SousQueryAds) Execute(args []string) cmdr.Result {
 	ads, err := sb.Deployer.RunningDeployments(sb.State.Defs.Clusters)

--- a/cli/sous_query_gdm.go
+++ b/cli/sous_query_gdm.go
@@ -28,6 +28,10 @@ This should resemble the manifest that was used to establish the intended state 
 // Help prints the help
 func (*SousQueryGDM) Help() string { return sousQueryGDMHelp }
 
+func (*SousQueryGDM) RegisterOn(psy Addable) {
+	psy.Add(graph.DryrunOption("none"))
+}
+
 // Execute defines the behavior of `sous query gdm`
 func (sb *SousQueryGDM) Execute(args []string) cmdr.Result {
 	sous.Log.Vomit.Printf("%v", sb.GDM.Snapshot())

--- a/cli/sous_server.go
+++ b/cli/sous_server.go
@@ -16,7 +16,7 @@ import (
 
 // A SousServer represents the `sous server` command.
 type SousServer struct {
-	Sous Sous
+	Sous *Sous
 	*config.Verbosity
 	*sous.AutoResolver
 	Config graph.LocalSousConfig

--- a/cli/sous_server.go
+++ b/cli/sous_server.go
@@ -18,10 +18,13 @@ import (
 type SousServer struct {
 	Sous *Sous
 	*config.Verbosity
+	config.DeployFilterFlags
 	*sous.AutoResolver
+
 	Config graph.LocalSousConfig
 	Log    *sous.LogSet
 	flags  struct {
+		dryrun,
 		// laddr is the listen address in the form [host]:port
 		laddr,
 		// gdmRepo is a repository to clone into config.SourceLocation
@@ -45,8 +48,19 @@ func (ss *SousServer) Help() string {
 
 // AddFlags is part of the cmdr.Command interfaces(s).
 func (ss *SousServer) AddFlags(fs *flag.FlagSet) {
+	MustAddFlags(fs, &ss.DeployFilterFlags, ClusterFilterFlagsHelp)
+	fs.StringVar(&ss.flags.dryrun, "dry-run", "none",
+		"prevent rectify from actually changing things - "+
+			"values are none,scheduler,registry,both")
 	fs.StringVar(&ss.flags.laddr, `listen`, `:80`, "The address to listen on, like '127.0.0.1:https'")
 	fs.StringVar(&ss.flags.gdmRepo, "gdm-repo", "", "Git repo containing the GDM (cloned into config.SourceLocation)")
+}
+
+// RegisterOn adds the DeploymentConfig to the psyringe to configure the
+// labeller and registrar.
+func (ss *SousServer) RegisterOn(psy Addable) {
+	psy.Add(graph.DryrunOption(ss.flags.dryrun))
+	psy.Add(&ss.DeployFilterFlags)
 }
 
 // Execute is part of the cmdr.Command interface(s).

--- a/ext/singularity/actual_deployment_set.go
+++ b/ext/singularity/actual_deployment_set.go
@@ -89,6 +89,7 @@ func (sc *deployer) RunningDeployments(clusters sous.Clusters) (deps sous.Deploy
 			depWait.Done()
 		case err, cont = <-errCh:
 			if !cont {
+				Log.Debug.Printf("Errors channel closed. Finishing up.")
 				return
 			}
 			if isMalformed(err) {
@@ -97,7 +98,7 @@ func (sc *deployer) RunningDeployments(clusters sous.Clusters) (deps sous.Deploy
 			} else {
 				retried := retries.maybe(err, reqCh)
 				if !retried {
-					Log.Notice.Print("Cannot retry: ", err)
+					Log.Notice.Printf("Cannot retry: %v. Exiting", err)
 					return
 				}
 			}
@@ -144,7 +145,7 @@ func dontrecover() error {
 
 func catchAndSend(from string, errs chan error) {
 	defer catchAll(from)
-	if err := dontrecover(); err != nil {
+	if err := recover(); err != nil {
 		Log.Debug.Printf("from = %s err = %+v\n", from, err)
 		Log.Debug.Printf("debug.Stack() = %+v\n", string(debug.Stack()))
 		switch err := err.(type) {

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -16,6 +16,7 @@ import (
 func TestBuildGraph(t *testing.T) {
 	log.SetFlags(log.Flags() | log.Lshortfile)
 	g := BuildGraph(ioutil.Discard, ioutil.Discard)
+	g.Add(DryrunBoth)
 	g.Add(&config.Verbosity{})
 	g.Add(&config.DeployFilterFlags{})
 	g.Add(&config.PolicyFlags{}) //provided by SousBuild

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -108,7 +108,7 @@ func TestMissingImage(t *testing.T) {
 	client := singularity.NewRectiAgent(nc)
 	deployer := singularity.NewDeployer(nc, client)
 
-	r := sous.NewResolver(deployer, nc)
+	r := sous.NewResolver(deployer, nc, &sous.ResolveFilter{})
 
 	deploymentsOne, err := stateOne.Deployments()
 	if err != nil {
@@ -181,7 +181,7 @@ func TestResolve(t *testing.T) {
 	client := singularity.NewRectiAgent(nc)
 	deployer := singularity.NewDeployer(nc, client)
 
-	r := sous.NewResolver(deployer, nc)
+	r := sous.NewResolver(deployer, nc, &sous.ResolveFilter{})
 
 	err = r.Resolve(deploymentsOneTwo, clusterDefs.Clusters)
 	if err != nil {
@@ -213,7 +213,7 @@ func TestResolve(t *testing.T) {
 		client := singularity.NewRectiAgent(nc)
 		deployer := singularity.NewDeployer(nc, client)
 
-		r := sous.NewResolver(deployer, nc)
+		r := sous.NewResolver(deployer, nc, &sous.ResolveFilter{})
 
 		err := r.Resolve(deploymentsTwoThree, clusterDefs.Clusters)
 		if err != nil {

--- a/lib/auto_resolver_test.go
+++ b/lib/auto_resolver_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func dummyResolver() *Resolver {
-	return NewResolver(NewDummyDeployer(), NewDummyRegistry())
+	return NewResolver(NewDummyDeployer(), NewDummyRegistry(), &ResolveFilter{})
 }
 
 func setupAR() *AutoResolver {

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -52,11 +52,6 @@ type (
 		RequestID string
 	}
 
-	// DeploymentPredicate takes a *Deployment and returns true if the
-	// deployment matches the predicate. Used by Filter to select a subset of a
-	// Deployments.
-	DeploymentPredicate func(*Deployment) bool
-
 	// A DeployID identifies a deployment.
 	DeployID struct {
 		ManifestID ManifestID

--- a/lib/state.go
+++ b/lib/state.go
@@ -4,7 +4,6 @@ type (
 	// State contains the mutable state of an organisation's deployments.
 	// State is also known as the "Global Deploy Manifest" or GDM.
 	State struct {
-		singleCluster string
 		// Defs contains global definitions for this organisation.
 		Defs Defs `hy:"defs"`
 		// Manifests contains a mapping of source code repositories to global
@@ -99,19 +98,12 @@ func (s *State) Clone() (c *State) {
 	return
 }
 
-// OnlyCluster sets a contraint on the State such that it will only consider a particular cluster
-func (s *State) OnlyCluster(nick string) {
-	s.singleCluster = nick
-}
-
 // ClusterMap returns the nicknames for all the clusters referred to in this state
 // paired with the URL for the named cluster
 func (s *State) ClusterMap() map[string]string {
 	m := make(map[string]string, len(s.Defs.Clusters))
 	for name, cluster := range s.Defs.Clusters {
-		if s.singleCluster == "" || s.singleCluster == name {
-			m[name] = cluster.BaseURL
-		}
+		m[name] = cluster.BaseURL
 	}
 	return m
 }

--- a/lib/state_test.go
+++ b/lib/state_test.go
@@ -23,9 +23,4 @@ func TestClusterMap(t *testing.T) {
 	assert.Contains(m, "one")
 	assert.Contains(m, "two")
 
-	s.singleCluster = "one"
-	m = s.ClusterMap()
-	assert.Len(m, 1)
-	assert.Contains(m, "one")
-
 }


### PR DESCRIPTION
Turns out, that was the smallest change... after refactoring the cluster
behavior so that it could be pushed up from `sous rectify` and into the graph
package. In theory it should now be even more trivial to add behavior across
commands.

I'm pretty sure, but have not proven, that this also add -dry-run to server,
which could be used as an "audit mode" - the only problem is that the changes
that *should* be made will be reported as happenning, so there's still some
interpretation to do. We could maybe do something to change how those changes
are logged, at which point this becomes, IMO a complete solution for audit
mode.