### PR TITLE
Rejects null volumes in manifests

### DIFF
--- a/lib/deploy_config_test.go
+++ b/lib/deploy_config_test.go
@@ -1,0 +1,21 @@
+package sous
+
+import (
+	"testing"
+
+	"github.com/nyarly/testify/assert"
+)
+
+func TestValidateRepair(t *testing.T) {
+	dc := DeployConfig{
+		Volumes: Volumes{nil, &Volume{}},
+	}
+
+	assert.Len(t, dc.Volumes, 2)
+	flaws := dc.Validate()
+	assert.Len(t, flaws, 1)
+	fs, es := RepairAll(flaws)
+	assert.Len(t, fs, 0)
+	assert.Len(t, es, 0)
+	assert.Len(t, dc.Volumes, 1)
+}

--- a/lib/deploy_spec.go
+++ b/lib/deploy_spec.go
@@ -3,6 +3,7 @@ package sous
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/samsalisbury/semv"
 )
 
@@ -33,6 +34,18 @@ type (
 		clusterName string
 	}
 )
+
+// Validate implements Flawed for State
+func (spec DeploySpec) Validate() []Flaw {
+	var flaws []Flaw
+
+	return append(flaws, spec.DeployConfig.Validate()...)
+}
+
+// Repair implements Flawed for State
+func (spec DeploySpec) Repair(fs []Flaw) error {
+	return errors.Errorf("Can't do nuffin with flaws yet")
+}
 
 // Equal returns true if other equals spec.
 func (spec DeploySpec) Equal(other DeploySpec) bool {

--- a/lib/flaw.go
+++ b/lib/flaw.go
@@ -1,0 +1,30 @@
+package sous
+
+type (
+	// A Flaw captures the digression from a validation rule
+	Flaw interface {
+		Repair() error
+	}
+
+	// Flawed covers types that can be validated and have flaws
+	// Be kind to them, because aren't we all flawed somehow?
+	Flawed interface {
+		// Validate returns a list of flaws that enumerate problems with the Flawed
+		Validate() []Flaw
+	}
+)
+
+// RepairAll attempts to repair all the flaws in a slice, and returns errors
+// and flaws when any of the flaws return errors
+func RepairAll(in []Flaw) ([]Flaw, []error) {
+	var fs []Flaw
+	var es []error
+
+	for _, f := range in {
+		if e := f.Repair(); e != nil {
+			es = append(es, e)
+			fs = append(fs, f)
+		}
+	}
+	return fs, es
+}

--- a/lib/http_state_manager.go
+++ b/lib/http_state_manager.go
@@ -11,6 +11,8 @@ import (
 )
 
 type (
+	// An HTTPStateManager gets state from a Sous server and transmits updates
+	// back to that server
 	HTTPStateManager struct {
 		serverURL *url.URL
 		cached    *State
@@ -35,6 +37,7 @@ func (g *gdmWrapper) fromJSON(reader io.Reader) {
 	dec.Decode(g)
 }
 
+// NewHTTPStateManager creates a new HTTPStateManager
 func NewHTTPStateManager(us string) (*HTTPStateManager, error) {
 	u, err := url.Parse(us)
 	return &HTTPStateManager{
@@ -93,6 +96,10 @@ func (hsm *HTTPStateManager) ReadState() (*State, error) {
 
 // WriteState implements StateWriter for HTTPStateManager
 func (hsm *HTTPStateManager) WriteState(ws *State) error {
+	flaws := ws.Validate()
+	if len(flaws) > 0 {
+		return errors.Errorf("Invalid update to state: %v", flaws)
+	}
 	if hsm.cached == nil {
 		_, err := hsm.ReadState()
 		if err != nil {

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -3,6 +3,8 @@ package sous
 import (
 	"fmt"
 	"path/filepath"
+
+	"github.com/pkg/errors"
 )
 
 //go:generate ggen cmap.CMap(cmap.go) sous.Manifests(manifests.go) CMKey:ManifestID Value:*Manifest
@@ -127,4 +129,19 @@ func (m *Manifest) Diff(o *Manifest) (bool, []string) {
 func (m *Manifest) Equal(o *Manifest) bool {
 	diff, _ := m.Diff(o)
 	return !diff
+}
+
+// Validate implements Flawed for State
+func (m *Manifest) Validate() []Flaw {
+	var flaws []Flaw
+
+	for _, depSpec := range m.Deployments {
+		flaws = append(flaws, depSpec.Validate()...)
+	}
+	return flaws
+}
+
+// Repair implements Flawed for State
+func (m *Manifest) Repair(fs []Flaw) error {
+	return errors.Errorf("Can't do nuffin with flaws yet")
 }

--- a/lib/state.go
+++ b/lib/state.go
@@ -1,5 +1,7 @@
 package sous
 
+import "github.com/pkg/errors"
+
 type (
 	// State contains the mutable state of an organisation's deployments.
 	// State is also known as the "Global Deploy Manifest" or GDM.
@@ -116,4 +118,19 @@ func (s *State) BaseURLs() []string {
 		urls = append(urls, cluster.BaseURL)
 	}
 	return urls
+}
+
+// Validate implements Flawed for State
+func (s *State) Validate() []Flaw {
+	var flaws []Flaw
+
+	for _, manifest := range s.Manifests.Snapshot() {
+		flaws = append(flaws, manifest.Validate()...)
+	}
+	return flaws
+}
+
+// Repair implements Flawed for State
+func (s *State) Repair(fs []Flaw) error {
+	return errors.Errorf("Can't do nuffin with flaws yet")
 }

--- a/server/handle_manifest.go
+++ b/server/handle_manifest.go
@@ -82,6 +82,10 @@ func (pmh *PUTManifestHandler) Exchange() (interface{}, int) {
 	dec := json.NewDecoder(pmh.Request.Body)
 	m := &sous.Manifest{}
 	dec.Decode(m)
+	flaws := m.Validate()
+	if len(flaws) > 0 {
+		return "", http.StatusBadRequest
+	}
 	pmh.State.Manifests.Set(mid, m)
 	if err := pmh.StateWriter.WriteState(pmh.State); err != nil {
 		return err, http.StatusConflict


### PR DESCRIPTION
Primarily, the addition here is adding the concept of Validation to States and
their components.  Flawed.Validate() returns a list of Flaws, which can then
each be Flaw.Repaired.

The disk state manager does a full attempt to repair the state on load and
store, so existing GDMs should be fixed up automatically.

The HTTP state manager checks for flaws but rejects changes that would
introduce them, forcing the user to take considered action. Maybe this is worth
relaxing, but I wanted to aviod "fixing" bad input automatically when we have a
human being at hand.

The server component that receives HTTP state manager manifest updates
Validates the manifests, and rejects with 400 if the update is invalid. It does
not, at present, render an error body describing the error, however. I wanted
to carefully consider the data leaked in such an error against the potential
value for UI. Also: less work not to provide the error body.