### PR TITLE
Resource value validations

### DIFF
--- a/lib/deploy_config.go
+++ b/lib/deploy_config.go
@@ -50,7 +50,24 @@ func (dc *DeployConfig) Validate() []Flaw {
 			break
 		}
 	}
+	rezs := dc.Resources
+	if dc.Resources == nil {
+		flaws = append(flaws, NewFlaw("No Resources set for DeployConfig",
+			func() error { dc.Resources = make(Resources); return nil }))
+		rezs = make(Resources)
+	}
+
+	flaws = append(flaws, rezs.Validate()...)
+
+	for _, f := range flaws {
+		f.AddContext("deploy config", dc)
+	}
+
 	return flaws
+}
+
+// AddContext simply discards all context - NilVolumeFlaw doesn't need it
+func (nvf *NilVolumeFlaw) AddContext(string, interface{}) {
 }
 
 // Repair removes any nil entries in DeployConfig.Volumes.

--- a/lib/deploy_config_test.go
+++ b/lib/deploy_config_test.go
@@ -8,8 +8,12 @@ import (
 
 func TestValidateRepair(t *testing.T) {
 	dc := DeployConfig{
-		Volumes: Volumes{nil, &Volume{}},
+		Volumes:   Volumes{nil, &Volume{}},
+		Resources: make(Resources),
 	}
+	dc.Resources["cpus"] = "0.25"
+	dc.Resources["memory"] = "356"
+	dc.Resources["ports"] = "2"
 
 	assert.Len(t, dc.Volumes, 2)
 	flaws := dc.Validate()

--- a/lib/flaw.go
+++ b/lib/flaw.go
@@ -5,6 +5,7 @@ import "github.com/pkg/errors"
 type (
 	// A Flaw captures the digression from a validation rule
 	Flaw interface {
+		AddContext(string, interface{})
 		Repair() error
 	}
 
@@ -37,6 +38,26 @@ func RepairAll(in []Flaw) ([]Flaw, []error) {
 	return fs, es
 }
 
+// NewFlaw returns a new generic flaw with the given description and repair function
+func NewFlaw(desc string, repair func() error) GenericFlaw {
+	return GenericFlaw{
+		Desc:       desc,
+		RepairFunc: repair,
+	}
+}
+
+/*
+func FatalFlaw(fmt string, vals ...interface{}) GenericFlaw {
+	desc := fmt.Sprintf(fmt, vals...)
+	return GenericFlaw{
+		Desc: fmt.Sprintf(fmt, vals...),
+		Repair: func() error {
+			return errors.Errorf("%s: cannot be repaired.", desc)
+		},
+	}
+}
+*/
+
 // Repair implements Flaw.Repair.
 func (gf GenericFlaw) Repair() error {
 	return gf.RepairFunc()
@@ -44,6 +65,11 @@ func (gf GenericFlaw) Repair() error {
 
 func (gf GenericFlaw) String() string {
 	return gf.Desc
+}
+
+// AddContext discards the context - if you need the context, you should build
+// a specialized Flaw
+func (gf GenericFlaw) AddContext(name string, thing interface{}) {
 }
 
 func (gf GenericFlaw) Error() error {

--- a/lib/manifest.go
+++ b/lib/manifest.go
@@ -116,15 +116,16 @@ func (m *Manifest) Validate() []Flaw {
 	}
 
 	if m.Kind == "" {
-		flaws = append(flaws, GenericFlaw{
-			Desc: fmt.Sprintf("manifest %q missing Kind", m.ID()),
-			RepairFunc: func() error {
-				m.Kind = ManifestKindService
-				return nil
-			},
-		})
+		flaws = append(flaws, NewFlaw(
+			fmt.Sprintf("manifest %q missing Kind", m.ID()),
+			func() error { m.Kind = ManifestKindService; return nil },
+		))
 	} else {
 		flaws = append(flaws, m.Kind.Validate()...)
+	}
+
+	for _, f := range flaws {
+		f.AddContext("manifest", m)
 	}
 
 	return flaws

--- a/lib/resources_test.go
+++ b/lib/resources_test.go
@@ -1,0 +1,21 @@
+package sous
+
+import (
+	"testing"
+
+	"github.com/nyarly/testify/assert"
+)
+
+func TestValidateRepairResources(t *testing.T) {
+	empty := make(Resources)
+
+	flaws := empty.Validate()
+	assert.Len(t, flaws, 3)
+
+	flaws, es := RepairAll(flaws)
+	assert.Len(t, flaws, 0)
+	assert.Len(t, es, 0)
+	assert.Equal(t, empty["cpus"], "0.1")
+	assert.Equal(t, empty["memory"], "100")
+	assert.Equal(t, empty["ports"], "1")
+}

--- a/lib/state.go
+++ b/lib/state.go
@@ -154,6 +154,10 @@ func (s *State) Validate() []Flaw {
 	for _, manifest := range s.Manifests.Snapshot() {
 		flaws = append(flaws, manifest.Validate()...)
 	}
+
+	for _, f := range flaws {
+		f.AddContext("state", s)
+	}
 	return flaws
 }
 


### PR DESCRIPTION
There were some awkward false starts because I'd misremembered that the ResDefs
were defaults, not a schema.

There's also the addition of validation "contexts" - as validation gets
contructed, various pieces can tag themselves in to be used either as part of
the repair or as part of the String() method. In the end I didn't wind up using
this, but it seemed like a good enough feature to leave, as I suspect there'll
be more validations to come. One the other hand, it might just be code to
delete later.