### PR TITLE
Changes to Singularity client

### DIFF
--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -33,10 +33,7 @@ type (
 		Deploy(cluster, depID, reqID, dockerImage string, r sous.Resources, e sous.Env, vols sous.Volumes) error
 
 		// PostRequest sends a request to a Singularity cluster to initiate
-		PostRequest(cluster, reqID string, instanceCount int) error
-
-		// Scale updates the instanceCount associated with a request
-		Scale(cluster, reqID string, instanceCount int, message string) error
+		PostRequest(cluster, reqID string, instanceCount int, kind sous.ManifestKind, owners sous.OwnerSet) error
 
 		// DeleteRequest instructs Singularity to delete a particular request
 		DeleteRequest(cluster, reqID, message string) error
@@ -135,12 +132,12 @@ func (r *deployer) RectifySingleModification(pair *sous.DeploymentPair) (err err
 	Log.Debug.Printf("Rectifying modified %q: \n  %# v \n    =>  \n  %# v", pair.ID(), pair.Prior, pair.Post)
 	defer rectifyRecover(pair, "RectifySingleModification", &err)
 	if r.changesReq(pair) {
-		Log.Debug.Printf("Scaling...")
-		if err := r.Client.Scale(
+		Log.Debug.Printf("Updating Request...")
+		if err := r.Client.PostRequest(
 			pair.Post.Cluster.BaseURL,
 			computeRequestID(pair.Post),
 			pair.Post.NumInstances,
-			"rectified scaling"); err != nil {
+		); err != nil {
 			return err
 		}
 	}

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -92,7 +92,7 @@ func (r *deployer) RectifySingleCreate(d *sous.Deployment) (err error) {
 		return err
 	}
 	reqID := computeRequestID(d)
-	if err = r.Client.PostRequest(d.Cluster.BaseURL, reqID, d.NumInstances); err != nil {
+	if err = r.Client.PostRequest(d.Cluster.BaseURL, reqID, d.NumInstances, d.Kind, d.Owners); err != nil {
 		return err
 	}
 	return r.Client.Deploy(
@@ -137,6 +137,8 @@ func (r *deployer) RectifySingleModification(pair *sous.DeploymentPair) (err err
 			pair.Post.Cluster.BaseURL,
 			computeRequestID(pair.Post),
 			pair.Post.NumInstances,
+			pair.Post.Kind,
+			pair.Post.Owners,
 		); err != nil {
 			return err
 		}

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -128,6 +128,7 @@ func (ra *RectiAgent) PostRequest(cluster, reqID string, instanceCount int, kind
 		"Id":          reqID,
 		"RequestType": reqType,
 		"Instances":   int32(instanceCount),
+		"Owners":      swaggering.StringList(owners.Slice()),
 	})
 
 	if err != nil {
@@ -142,7 +143,7 @@ func (ra *RectiAgent) PostRequest(cluster, reqID string, instanceCount int, kind
 func determineRequestType(kind sous.ManifestKind) (dtos.SingularityRequestRequestType, error) {
 	switch kind {
 	default:
-		return dtos.SingularityRequestRequestType{}, fmt.Errorf("Unrecognized Sous manifest kind: %v", kind)
+		return dtos.SingularityRequestRequestType(""), fmt.Errorf("Unrecognized Sous manifest kind: %v", kind)
 	case sous.ManifestKindService:
 		return dtos.SingularityRequestRequestTypeSERVICE, nil
 	case sous.ManifestKindWorker:

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -1,6 +1,7 @@
 package singularity
 
 import (
+	"fmt"
 	"regexp"
 	"sync"
 
@@ -117,11 +118,15 @@ func buildDeployRequest(dockerImage string, e sous.Env, r sous.Resources, reqID 
 }
 
 // PostRequest sends requests to Singularity to create a new Request
-func (ra *RectiAgent) PostRequest(cluster, reqID string, instanceCount int) error {
+func (ra *RectiAgent) PostRequest(cluster, reqID string, instanceCount int, kind sous.ManifestKind, owners sous.OwnerSet) error {
 	Log.Debug.Printf("Creating application %s %s %d", cluster, reqID, instanceCount)
+	reqType, err := determineRequestType(kind)
+	if err != nil {
+		return err
+	}
 	req, err := swaggering.LoadMap(&dtos.SingularityRequest{}, dtoMap{
 		"Id":          reqID,
-		"RequestType": dtos.SingularityRequestRequestTypeSERVICE,
+		"RequestType": reqType,
 		"Instances":   int32(instanceCount),
 	})
 
@@ -132,6 +137,23 @@ func (ra *RectiAgent) PostRequest(cluster, reqID string, instanceCount int) erro
 	Log.Debug.Printf("Create Request: %+ v", req)
 	_, err = ra.singularityClient(cluster).PostRequest(req.(*dtos.SingularityRequest))
 	return err
+}
+
+func determineRequestType(kind sous.ManifestKind) (dtos.SingularityRequestRequestType, error) {
+	switch kind {
+	default:
+		return dtos.SingularityRequestRequestType{}, fmt.Errorf("Unrecognized Sous manifest kind: %v", kind)
+	case sous.ManifestKindService:
+		return dtos.SingularityRequestRequestTypeSERVICE, nil
+	case sous.ManifestKindWorker:
+		return dtos.SingularityRequestRequestTypeWORKER, nil
+	case sous.ManifestKindOnDemand:
+		return dtos.SingularityRequestRequestTypeON_DEMAND, nil
+	case sous.ManifestKindScheduled:
+		return dtos.SingularityRequestRequestTypeSCHEDULED, nil
+	case sous.ManifestKindOnce:
+		return dtos.SingularityRequestRequestTypeRUN_ONCE, nil
+	}
 }
 
 // DeleteRequest sends a request to Singularity to delete a request

--- a/ext/singularity/recti-agent_test.go
+++ b/ext/singularity/recti-agent_test.go
@@ -1,0 +1,35 @@
+package singularity
+
+import (
+	"testing"
+
+	"github.com/opentable/go-singularity/dtos"
+	sous "github.com/opentable/sous/lib"
+)
+
+func TestDetermineRequestType(t *testing.T) {
+	pairs := []struct {
+		sous.ManifestKind
+		dtos.SingularityRequestRequestType
+	}{
+		{sous.ManifestKindService, dtos.SingularityRequestRequestTypeSERVICE},
+		{sous.ManifestKindWorker, dtos.SingularityRequestRequestTypeWORKER},
+		{sous.ManifestKindOnDemand, dtos.SingularityRequestRequestTypeON_DEMAND},
+		{sous.ManifestKindScheduled, dtos.SingularityRequestRequestTypeSCHEDULED},
+		{sous.ManifestKindOnce, dtos.SingularityRequestRequestTypeRUN_ONCE},
+	}
+
+	for _, pair := range pairs {
+		srrt, err := determineRequestType(pair.ManifestKind)
+		if err != nil {
+			t.Errorf("Error from determineRequestType: %v", err)
+			continue
+		}
+		if srrt != pair.SingularityRequestRequestType {
+			t.Errorf("Got %v expected %v.", srrt, pair.SingularityRequestRequestType)
+		}
+
+		// Should test determineManifestKind, but it's more annoying
+
+	}
+}

--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -81,10 +81,8 @@ func TestModifyScale(t *testing.T) {
 	}
 
 	assert.Len(client.Deployed, 0)
-	assert.Len(client.Created, 0)
-
-	if assert.Len(client.Scaled, 1) {
-		assert.Equal(24, client.Scaled[0].Count)
+	if assert.Len(client.Created, 1) {
+		assert.Equal(24, client.Created[0].Count)
 	}
 }
 
@@ -132,7 +130,6 @@ func TestModifyImage(t *testing.T) {
 	}
 
 	assert.Len(client.Created, 0)
-	assert.Len(client.Scaled, 0)
 
 	if assert.Len(client.Deployed, 1) {
 		assert.Regexp("2.3.4", client.Deployed[0].ImageName)
@@ -246,7 +243,9 @@ func TestModify(t *testing.T) {
 		t.Error(e)
 	}
 
-	assert.Len(client.Created, 0)
+	if assert.Len(client.Created, 1) {
+		assert.Equal(24, client.Created[0].Count)
+	}
 
 	if assert.Len(client.Deployed, 1) {
 		assert.Regexp("2.3.4", client.Deployed[0].ImageName)
@@ -254,9 +253,6 @@ func TestModify(t *testing.T) {
 		assert.Equal("RW", string(client.Deployed[0].Vols[0].Mode))
 	}
 
-	if assert.Len(client.Scaled, 1) {
-		assert.Equal(24, client.Scaled[0].Count)
-	}
 }
 
 func TestDeletes(t *testing.T) {
@@ -340,7 +336,6 @@ func TestCreates(t *testing.T) {
 		t.Error(e)
 	}
 
-	assert.Len(client.Scaled, 0)
 	if assert.Len(client.Deployed, 1) {
 		dep := client.Deployed[0]
 		assert.Equal("cluster", dep.Cluster)

--- a/lib/dummy_rectification_client.go
+++ b/lib/dummy_rectification_client.go
@@ -10,7 +10,6 @@ type (
 		nameCache Registry
 		Created   []dummyRequest
 		Deployed  []dummyDeploy
-		Scaled    []dummyScale
 		Deleted   []dummyDelete
 	}
 
@@ -28,12 +27,8 @@ type (
 		Cluster string
 		ID      string
 		Count   int
-	}
-
-	dummyScale struct {
-		Cluster, Reqid string
-		Count          int
-		Message        string
+		Kind    ManifestKind
+		Owners  OwnerSet
 	}
 
 	dummyDelete struct {
@@ -74,17 +69,12 @@ func (t *DummyRectificationClient) Deploy(
 
 // PostRequest (cluster, request id, instance count)
 func (t *DummyRectificationClient) PostRequest(
-	cluster, id string, count int) error {
-	t.logf("Creating application %s %s %d", cluster, id, count)
-	t.Created = append(t.Created, dummyRequest{cluster, id, count})
-	return nil
-}
-
-//Scale (cluster url, request id, instance count, message)
-func (t *DummyRectificationClient) Scale(
-	cluster, reqid string, count int, message string) error {
-	t.logf("Scaling %s %s %d %s", cluster, reqid, count, message)
-	t.Scaled = append(t.Scaled, dummyScale{cluster, reqid, count, message})
+	cluster, id string, count int,
+	kind ManifestKind,
+	owners OwnerSet,
+) error {
+	t.logf("Creating application %s %s %d %v %v", cluster, id, count, kind, owners)
+	t.Created = append(t.Created, dummyRequest{cluster, id, count, kind, owners})
 	return nil
 }
 

--- a/lib/owner_set.go
+++ b/lib/owner_set.go
@@ -35,3 +35,11 @@ func (os OwnerSet) Equal(o OwnerSet) bool {
 
 	return true
 }
+
+func (os OwnerSet) Slice() []string {
+	slice := make([]string, 0, len(os))
+	for owner, _ := range os {
+		slice = append(slice, owner)
+	}
+	return slice
+}

--- a/lib/owner_set_test.go
+++ b/lib/owner_set_test.go
@@ -1,0 +1,18 @@
+package sous
+
+import (
+	"testing"
+
+	"github.com/nyarly/testify/assert"
+)
+
+func TestOwnerSet(t *testing.T) {
+	set := NewOwnerSet("one")
+	set.Add("two")
+	set.Add("one")
+	slice := set.Slice()
+	assert.Len(t, slice, 2)
+	assert.Contains(t, slice, "one")
+	assert.Contains(t, slice, "two")
+	assert.True(t, set.Equal(NewOwnerSet("two", "one")))
+}


### PR DESCRIPTION
Removes the Scale method, because POSTs to the /api/requests endpoint will
update an existing Singularity Request if one exists.

Adds parameters to the PostRequest methods for the kind and owners list, so
that they can likewise be updated.

All in all, this should close the loop in terms of state we care to record in
Singularity.