### PR TITLE
Adds `sous manifest get` and `sous manifest set`

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -72,8 +72,8 @@ func (cli *CLI) Plumbing(cmd cmdr.Executor, args []string) cmdr.Result {
 }
 
 // BuildCLIGraph builds the CLI DI graph.
-func BuildCLIGraph(cli *CLI, root *Sous, out, err io.Writer) *graph.SousGraph {
-	g := graph.BuildGraph(out, err)
+func BuildCLIGraph(cli *CLI, root *Sous, in io.Reader, out, err io.Writer) *graph.SousGraph {
+	g := graph.BuildGraph(in, out, err)
 	g.Add(cli)
 	g.Add(root)
 	g.Add(func(c *CLI) graph.Out {
@@ -88,7 +88,7 @@ func BuildCLIGraph(cli *CLI, root *Sous, out, err io.Writer) *graph.SousGraph {
 }
 
 // NewSousCLI creates a new Sous cli app.
-func NewSousCLI(s *Sous, out, errout io.Writer) (*CLI, error) {
+func NewSousCLI(s *Sous, in io.Reader, out, errout io.Writer) (*CLI, error) {
 
 	stdout := cmdr.NewOutput(out)
 	stderr := cmdr.NewOutput(errout)
@@ -110,7 +110,7 @@ func NewSousCLI(s *Sous, out, errout io.Writer) (*CLI, error) {
 	var chain []cmdr.Command
 
 	cli.Hooks.Startup = func(*cmdr.CLI) error {
-		g = BuildCLIGraph(cli, s, out, errout)
+		g = BuildCLIGraph(cli, s, in, out, errout)
 		chain = make([]cmdr.Command, 0)
 		return nil
 	}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -156,16 +156,24 @@ func TestInvokeQuery(t *testing.T) {
 func TestInvokeMetadataGet(t *testing.T) {
 	assert := assert.New(t)
 	exe := justCommand(t, []string{`sous`, `metadata`, `get`, `-repo`, `github.com/opentable/sous`})
-	t.Logf("%#v", exe)
-	t.Logf("%#v", exe.Cmd)
 	assert.NotNil(exe)
 }
 
 func TestInvokeMetadataSet(t *testing.T) {
 	assert := assert.New(t)
 	exe := justCommand(t, []string{`sous`, `metadata`, `set`, `-repo`, `github.com/opentable/sous`, `BuildBranch`, `master`})
-	t.Logf("%#v", exe)
-	t.Logf("%#v", exe.Cmd)
+	assert.NotNil(exe)
+}
+
+func TestInvokeManifestGet(t *testing.T) {
+	assert := assert.New(t)
+	exe := justCommand(t, []string{`sous`, `manifest`, `get`, `-repo`, `github.com/opentable/sous`})
+	assert.NotNil(exe)
+}
+
+func TestInvokeManifestSet(t *testing.T) {
+	assert := assert.New(t)
+	exe := justCommand(t, []string{`sous`, `manifest`, `set`, `-repo`, `github.com/opentable/sous`})
 	assert.NotNil(exe)
 }
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -17,11 +17,12 @@ import (
 func prepareCommand(t *testing.T, cl []string) (*CLI, *cmdr.PreparedExecution, fmt.Stringer, fmt.Stringer) {
 	require := require.New(t)
 
+	stdin := &bytes.Buffer{}
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
 	s := &Sous{Version: semv.MustParse(`1.2.3`)}
-	c, err := NewSousCLI(s, stdout, stderr)
+	c, err := NewSousCLI(s, stdin, stdout, stderr)
 	require.NoError(err)
 
 	exe, err := c.Prepare(cl)
@@ -155,12 +156,16 @@ func TestInvokeQuery(t *testing.T) {
 func TestInvokeMetadataGet(t *testing.T) {
 	assert := assert.New(t)
 	exe := justCommand(t, []string{`sous`, `metadata`, `get`, `-repo`, `github.com/opentable/sous`})
+	t.Logf("%#v", exe)
+	t.Logf("%#v", exe.Cmd)
 	assert.NotNil(exe)
 }
 
 func TestInvokeMetadataSet(t *testing.T) {
 	assert := assert.New(t)
 	exe := justCommand(t, []string{`sous`, `metadata`, `set`, `-repo`, `github.com/opentable/sous`, `BuildBranch`, `master`})
+	t.Logf("%#v", exe)
+	t.Logf("%#v", exe.Cmd)
 	assert.NotNil(exe)
 }
 
@@ -271,11 +276,12 @@ func TestInvokeWithUnknownFlags(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
+	stdin := &bytes.Buffer{}
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
 	s := &Sous{Version: semv.MustParse(`1.2.3`)}
-	c, err := NewSousCLI(s, stdout, stderr)
+	c, err := NewSousCLI(s, stdin, stdout, stderr)
 	require.NoError(err)
 
 	c.Invoke([]string{`sous`, `-cobblers`})

--- a/cli/deploy_filter_flags.go
+++ b/cli/deploy_filter_flags.go
@@ -111,6 +111,8 @@ const (
 var (
 	// ClusterFilterFlagsHelp just exposes the -cluster flag (for server)
 	ClusterFilterFlagsHelp = clusterFlagHelp
+	// ManifestFilterFlagsHelp the text/config for selecting manifests
+	ManifestFilterFlagsHelp = repoFlagHelp + offsetFlagHelp
 	// MetadataFilterFlagsHelp the the text/config for metadata commands
 	MetadataFilterFlagsHelp = repoFlagHelp + offsetFlagHelp + flavorFlagHelp + clusterFlagHelp
 	// SourceFlagsHelp is the text (and config) for source flags

--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -12,13 +12,12 @@ import (
 // SousInit is the command description for `sous init`
 type SousInit struct {
 	config.DeployFilterFlags
-	Flags         config.OTPLFlags
-	Target        graph.TargetManifest
-	SourceContext *sous.SourceContext
-	WD            graph.LocalWorkDirShell
-	GDM           graph.CurrentGDM
-	State         *sous.State
-	StateWriter   graph.LocalStateWriter
+	Flags       config.OTPLFlags
+	Target      graph.TargetManifest
+	WD          graph.LocalWorkDirShell
+	GDM         graph.CurrentGDM
+	State       *sous.State
+	StateWriter graph.LocalStateWriter
 }
 
 func init() { TopLevelCommands["init"] = &SousInit{} }

--- a/cli/sous_manifest.go
+++ b/cli/sous_manifest.go
@@ -1,0 +1,25 @@
+package cli
+
+import "github.com/opentable/sous/util/cmdr"
+
+type SousManifest struct{}
+
+var ManifestSubcommands = cmdr.Commands{}
+
+func init() { TopLevelCommands["manifest"] = &SousManifest{} }
+
+const sousManifestHelp = `
+query and manipulate deployment manifests
+`
+
+func (SousManifest) Subcommands() cmdr.Commands {
+	return ManifestSubcommands
+}
+
+func (*SousManifest) Help() string { return sousManifestHelp }
+
+func (sm *SousManifest) Execute(args []string) cmdr.Result {
+	err := UsageErrorf("usage: sous manifest [options] <command>")
+	err.Tip = "try `sous manifest help` for a list of commands"
+	return err
+}

--- a/cli/sous_manifest_get.go
+++ b/cli/sous_manifest_get.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"flag"
+
+	"github.com/opentable/sous/config"
+	"github.com/opentable/sous/graph"
+	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/cmdr"
+	"github.com/pkg/errors"
+	"github.com/samsalisbury/yaml"
+)
+
+type SousManifestGet struct {
+	config.DeployFilterFlags
+	graph.TargetManifestID
+	*sous.State
+	graph.OutWriter
+}
+
+func init() { ManifestSubcommands["get"] = &SousManifestGet{} }
+
+const sousManifestGetHelp = `
+query deployment manifest
+`
+
+func (*SousManifestGet) Help() string { return sousManifestHelp }
+
+func (smg *SousManifestGet) AddFlags(fs *flag.FlagSet) {
+	MustAddFlags(fs, &smg.DeployFilterFlags, ManifestFilterFlagsHelp)
+}
+
+func (smg *SousManifestGet) RegisterOn(psy Addable) {
+	psy.Add(&smg.DeployFilterFlags)
+}
+
+func (smg *SousManifestGet) Execute(args []string) cmdr.Result {
+	mid := sous.ManifestID(smg.TargetManifestID)
+
+	mani, present := smg.State.Manifests.Get(mid)
+	if !present {
+		return EnsureErrorResult(errors.Errorf("No manifest for %v yet. See `sous init`", smg.DeployFilterFlags))
+	}
+
+	yml, err := yaml.Marshal(mani)
+	if err != nil {
+		return EnsureErrorResult(err)
+	}
+	smg.OutWriter.Write(yml)
+	return Success()
+}

--- a/cli/sous_manifest_get.go
+++ b/cli/sous_manifest_get.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"flag"
+	"log"
 
 	"github.com/opentable/sous/config"
 	"github.com/opentable/sous/graph"
@@ -37,6 +38,7 @@ func (smg *SousManifestGet) RegisterOn(psy Addable) {
 func (smg *SousManifestGet) Execute(args []string) cmdr.Result {
 	mid := sous.ManifestID(smg.TargetManifestID)
 
+	log.Printf("%#v", mid)
 	mani, present := smg.State.Manifests.Get(mid)
 	if !present {
 		return EnsureErrorResult(errors.Errorf("No manifest for %v yet. See `sous init`", smg.DeployFilterFlags))

--- a/cli/sous_manifest_get.go
+++ b/cli/sous_manifest_get.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"flag"
-	"log"
 
 	"github.com/opentable/sous/config"
 	"github.com/opentable/sous/graph"
@@ -38,7 +37,6 @@ func (smg *SousManifestGet) RegisterOn(psy Addable) {
 func (smg *SousManifestGet) Execute(args []string) cmdr.Result {
 	mid := sous.ManifestID(smg.TargetManifestID)
 
-	log.Printf("%#v", mid)
 	mani, present := smg.State.Manifests.Get(mid)
 	if !present {
 		return EnsureErrorResult(errors.Errorf("No manifest for %v yet. See `sous init`", smg.DeployFilterFlags))

--- a/cli/sous_manifest_set.go
+++ b/cli/sous_manifest_set.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"flag"
+	"io/ioutil"
+
+	"github.com/opentable/sous/config"
+	"github.com/opentable/sous/graph"
+	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/cmdr"
+	"github.com/pkg/errors"
+	"github.com/samsalisbury/yaml"
+)
+
+type SousManifestSet struct {
+	config.DeployFilterFlags
+	graph.TargetManifestID
+	*sous.State
+	sous.StateWriter
+	graph.InReader
+}
+
+func init() { ManifestSubcommands["set"] = &SousManifestSet{} }
+
+const sousManifestSetHelp = `
+replace a deployment manifest
+do note: this does *replace* the manifest;
+there's some validation, but you can make drastic changes easily
+`
+
+func (*SousManifestSet) Help() string { return sousManifestHelp }
+
+func (smg *SousManifestSet) AddFlags(fs *flag.FlagSet) {
+	MustAddFlags(fs, &smg.DeployFilterFlags, ManifestFilterFlagsHelp)
+}
+
+func (smg *SousManifestSet) RegisterOn(psy Addable) {
+	psy.Add(&smg.DeployFilterFlags)
+}
+
+func (smg *SousManifestSet) Execute(args []string) cmdr.Result {
+	mid := sous.ManifestID(smg.TargetManifestID)
+
+	_, present := smg.State.Manifests.Get(mid)
+	if !present {
+		return EnsureErrorResult(errors.Errorf("No manifest for %v yet. See `sous init`", smg.DeployFilterFlags))
+	}
+
+	yml := sous.Manifest{}
+	bytes, err := ioutil.ReadAll(smg.InReader)
+	if err != nil {
+		return EnsureErrorResult(err)
+	}
+	err = yaml.Unmarshal(bytes, &yml)
+	if err != nil {
+		return EnsureErrorResult(err)
+	}
+	smg.State.Manifests.Set(mid, &yml)
+	err = smg.StateWriter.WriteState(smg.State)
+	if err != nil {
+		return EnsureErrorResult(err)
+	}
+
+	return Success()
+}

--- a/cli/sous_manifest_test.go
+++ b/cli/sous_manifest_test.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/nyarly/testify/assert"
+	"github.com/nyarly/testify/require"
+	"github.com/opentable/sous/graph"
+	"github.com/opentable/sous/lib"
+	"github.com/samsalisbury/yaml"
+)
+
+func TestManifestGet(t *testing.T) {
+	out := &bytes.Buffer{}
+	smg := &SousManifestGet{
+		TargetManifestID: graph.TargetManifestID{
+			Source: sous.SourceLocation{
+				Repo: project1.Repo,
+			},
+		},
+		State:     makeTestState(),
+		OutWriter: graph.OutWriter(out),
+	}
+	res := smg.Execute([]string{})
+	assert.Equal(t, 0, res.ExitCode())
+
+	assert.Regexp(t, "github", out.String())
+}
+
+func TestManifestSet(t *testing.T) {
+	mid := sous.ManifestID{
+		Source: sous.SourceLocation{
+			Repo: project1.Repo,
+		},
+	}
+	baseState := makeTestState()
+	mani, present := baseState.Manifests.Get(mid)
+	require.True(t, present)
+	mani.Flavor = "vanilla"
+	yml, err := yaml.Marshal(mani)
+	require.NoError(t, err)
+	in := bytes.NewBuffer(yml)
+
+	state := makeTestState()
+
+	dummyWriter := sous.DummyStateManager{State: state}
+	writer := graph.LocalStateWriter{StateWriter: &dummyWriter}
+	sms := &SousManifestSet{
+		TargetManifestID: graph.TargetManifestID(mid),
+		State:            state,
+		InReader:         graph.InReader(in),
+		StateWriter:      writer,
+	}
+
+	assert.Equal(t, 0, dummyWriter.WriteCount)
+	res := sms.Execute([]string{})
+	assert.Equal(t, 0, res.ExitCode())
+	assert.Equal(t, 1, dummyWriter.WriteCount)
+
+	upManifest, present := state.Manifests.Get(mid)
+	require.True(t, present)
+	assert.Equal(t, upManifest.Flavor, "vanilla")
+
+}

--- a/cli/sous_metadata.go
+++ b/cli/sous_metadata.go
@@ -6,7 +6,7 @@ type SousMetadata struct{}
 
 var MetadataSubcommands = cmdr.Commands{}
 
-func init() { TopLevelCommands["query"] = &SousMetadata{} }
+func init() { TopLevelCommands["metadata"] = &SousMetadata{} }
 
 const sousMetadataHelp = `
 query and manipulate deployment metadata

--- a/cli/sous_update.go
+++ b/cli/sous_update.go
@@ -16,8 +16,7 @@ import (
 type SousUpdate struct {
 	config.DeployFilterFlags
 	config.OTPLFlags
-	Manifest graph.TargetManifest
-	*sous.SourceContext
+	Manifest    graph.TargetManifest
 	WD          graph.LocalWorkDirShell
 	GDM         graph.CurrentGDM
 	State       *sous.State

--- a/cli/tests/sous_test.go
+++ b/cli/tests/sous_test.go
@@ -13,10 +13,10 @@ func TestSous(t *testing.T) {
 
 	log.Print(term.Stderr)
 	term.Stdout.ShouldHaveNumLines(0)
-	term.Stderr.ShouldHaveNumLines(24)
+	term.Stderr.ShouldHaveNumLines(26)
 
 	term.Stderr.ShouldHaveExactLine("usage: sous <command>")
-	term.Stderr.ShouldHaveLineContaining("help     get help with sous")
+	term.Stderr.ShouldHaveLineContaining("help      get help with sous")
 }
 
 func TestSousVersion(t *testing.T) {

--- a/cli/tests/terminal.go
+++ b/cli/tests/terminal.go
@@ -37,11 +37,12 @@ func NewTerminal(t *testing.T, vstr string) *Terminal {
 	baseerr := TestOutput{"stderr", &bytes.Buffer{}, t}
 	combined := TestOutput{"combined output", &bytes.Buffer{}, t}
 
+	in := &bytes.Buffer{}
 	out := io.MultiWriter(baseout.Buffer, combined.Buffer)
 	err := io.MultiWriter(baseerr.Buffer, combined.Buffer)
 
 	s := &cli.Sous{Version: v}
-	c, er := cli.NewSousCLI(s, out, err)
+	c, er := cli.NewSousCLI(s, in, out, err)
 	if er != nil {
 		panic(er)
 	}

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -278,21 +278,18 @@ func newSourceContextDiscovery(g LocalGitRepo) *SourceContextDiscovery {
 }
 
 func newSourceContext(mid TargetManifestID, discovered *SourceContextDiscovery) (*sous.SourceContext, error) {
-	if err := discovered.GetError(mid); err != nil {
-		return nil, err
-	}
-	return discovered.SourceContext, nil
+	return discovered.Unwrap(mid)
 }
 
-func (scd *SourceContextDiscovery) GetError(mid TargetManifestID) error {
+func (scd *SourceContextDiscovery) Unwrap(mid TargetManifestID) (*sous.SourceContext, error) {
 	if scd.Error != nil {
-		return scd.Error
+		return nil, scd.Error
 	}
 	sl := sous.ManifestID(mid)
 	if sl.Source.Repo != scd.SourceLocation().Repo {
-		return errors.Errorf("source location %q is not the same as the remote %q", sl.Source.Repo, scd.SourceLocation().Repo)
+		return nil, errors.Errorf("source location %q is not the same as the remote %q", sl.Source.Repo, scd.SourceLocation().Repo)
 	}
-	return nil
+	return scd.SourceContext, nil
 }
 
 func (scd *SourceContextDiscovery) GetContext() *sous.SourceContext {

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -41,6 +41,8 @@ type (
 	OutWriter io.Writer
 	// ErrWriter is typically set to os.Stderr.
 	ErrWriter io.Writer
+	// InReader is typicially set to os.Stdin
+	InReader io.Reader
 	// Version represents a version of Sous.
 	Version struct{ semv.Version }
 	// LocalUser is the currently logged in user.
@@ -100,10 +102,11 @@ const (
 
 // BuildGraph builds the dependency injection graph, used to populate commands
 // invoked by the user.
-func BuildGraph(out, err io.Writer) *SousGraph {
+func BuildGraph(in io.Reader, out, err io.Writer) *SousGraph {
 	graph := &SousGraph{psyringe.New()}
 	// stdout, stderr
 	graph.Add(
+		func() InReader { return in },
 		func() OutWriter { return out },
 		func() ErrWriter { return err },
 	)

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -270,9 +270,9 @@ func newGitSourceContext(g LocalGitRepo) (GitSourceContext, error) {
 	return GitSourceContext{c}, initErr(err, "getting local git context")
 }
 
-func newSourceContext(f *config.DeployFilterFlags, g GitSourceContext) (*sous.SourceContext, error) {
-	c := g.SourceContext
-	if c == nil {
+func newSourceContext(f *config.DeployFilterFlags, g LocalGitRepo) (*sous.SourceContext, error) {
+	c, err := g.SourceContext()
+	if err != nil {
 		c = &sous.SourceContext{}
 	}
 	mid, err := newTargetManifestID(f, c)

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -270,14 +270,10 @@ func newGitSourceContext(g LocalGitRepo) (GitSourceContext, error) {
 	return GitSourceContext{c}, initErr(err, "getting local git context")
 }
 
-func newSourceContext(f *config.DeployFilterFlags, g LocalGitRepo) (*sous.SourceContext, error) {
+func newSourceContext(f *config.DeployFilterFlags, g LocalGitRepo, mid TargetManifestID) (*sous.SourceContext, error) {
 	c, err := g.SourceContext()
 	if err != nil {
 		c = &sous.SourceContext{}
-	}
-	mid, err := newTargetManifestID(f, c)
-	if err != nil {
-		return nil, errors.Wrapf(err, "getting source location")
 	}
 	sl := sous.ManifestID(mid)
 	if sl.Source.Repo != c.SourceLocation().Repo {

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"bytes"
 	"io/ioutil"
 	"log"
 	"testing"
@@ -15,7 +16,7 @@ import (
 
 func TestBuildGraph(t *testing.T) {
 	log.SetFlags(log.Flags() | log.Lshortfile)
-	g := BuildGraph(ioutil.Discard, ioutil.Discard)
+	g := BuildGraph(&bytes.Buffer{}, ioutil.Discard, ioutil.Discard)
 	g.Add(DryrunBoth)
 	g.Add(&config.Verbosity{})
 	g.Add(&config.DeployFilterFlags{})

--- a/graph/targetmanifest.go
+++ b/graph/targetmanifest.go
@@ -6,12 +6,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-func newTargetManifestID(f *config.DeployFilterFlags, g LocalGitRepo) (TargetManifestID, error) {
-	c, err := g.SourceContext()
-	if err != nil {
-		c = &sous.SourceContext{}
-	}
-	if f == nil {
+func newTargetManifestID(f *config.DeployFilterFlags, discovered *SourceContextDiscovery) (TargetManifestID, error) {
+	c := discovered.GetContext()
+	if f == nil { // XXX I think this needs to be supplied anyway by consumers...
 		f = &config.DeployFilterFlags{}
 	}
 	var repo, offset = c.PrimaryRemoteURL, c.OffsetDir
@@ -21,7 +18,7 @@ func newTargetManifestID(f *config.DeployFilterFlags, g LocalGitRepo) (TargetMan
 	}
 	if f.Offset != "" {
 		if f.Repo == "" {
-			return TargetManifestID{}, errors.Errorf("you specified -offset but not -repo")
+			return TargetManifestID{}, errors.Errorf("-offset doesn't make sense without a -repo or workspace remote")
 		}
 		offset = f.Offset
 	}

--- a/graph/targetmanifest.go
+++ b/graph/targetmanifest.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func newTargetManifestID(f *config.DeployFilterFlags, g GitSourceContext) (TargetManifestID, error) {
+func newTargetManifestID(f *config.DeployFilterFlags, g LocalGitRepo) (TargetManifestID, error) {
 	c, err := g.SourceContext()
 	if err != nil {
 		c = &sous.SourceContext{}
@@ -15,9 +15,6 @@ func newTargetManifestID(f *config.DeployFilterFlags, g GitSourceContext) (Targe
 		f = &config.DeployFilterFlags{}
 	}
 	var repo, offset = c.PrimaryRemoteURL, c.OffsetDir
-	if f.Repo != "" {
-		repo = f.Repo
-	}
 	if f.Repo != "" {
 		repo = f.Repo
 		offset = ""

--- a/graph/targetmanifest.go
+++ b/graph/targetmanifest.go
@@ -6,8 +6,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-func newTargetManifestID(f *config.DeployFilterFlags, c *sous.SourceContext) (TargetManifestID, error) {
-	if c == nil {
+func newTargetManifestID(f *config.DeployFilterFlags, g GitSourceContext) (TargetManifestID, error) {
+	c, err := g.SourceContext()
+	if err != nil {
 		c = &sous.SourceContext{}
 	}
 	if f == nil {

--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -83,6 +83,16 @@ func (rf *ResolveFilter) FilterDeployment(d *Deployment) bool {
 	return true
 }
 
+func (rf *ResolveFilter) FilterManifest(m *Manifest) bool {
+	if rf.Repo != "" && m.Source.Repo != rf.Repo {
+		return false
+	}
+	if rf.Offset != "" && m.Source.Dir != rf.Offset {
+		return false
+	}
+	return true
+}
+
 // NewResolver creates a new Resolver.
 func NewResolver(d Deployer, r Registry, rf *ResolveFilter) *Resolver {
 	return &Resolver{

--- a/lib/state_manager.go
+++ b/lib/state_manager.go
@@ -19,16 +19,19 @@ type (
 	// DummyStateManager is used for testing
 	DummyStateManager struct {
 		*State
+		ReadCount, WriteCount int
 	}
 )
 
 // ReadState implements StateManager
-func (sm DummyStateManager) ReadState() (*State, error) {
+func (sm *DummyStateManager) ReadState() (*State, error) {
+	sm.ReadCount++
 	return sm.State, nil
 }
 
 // WriteState implements StateManager
-func (sm DummyStateManager) WriteState(s *State) error {
+func (sm *DummyStateManager) WriteState(s *State) error {
+	sm.WriteCount++
 	*sm.State = *s
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 	//sous.Log.Debug.SetOutput(os.Stderr)
 	log.SetFlags(log.Flags() | log.Lshortfile)
 
-	c, err := cli.NewSousCLI(Sous, os.Stdout, os.Stderr)
+	c, err := cli.NewSousCLI(Sous, os.Stdin, os.Stdout, os.Stderr)
 	if err != nil {
 		die(err)
 	}

--- a/server/handle_manifest_test.go
+++ b/server/handle_manifest_test.go
@@ -122,7 +122,7 @@ func TestHandlesManifestPut(t *testing.T) {
 		Source: sous.SourceLocation{Repo: "gh"},
 		Kind:   sous.ManifestKindService,
 	})
-	writer := graph.LocalStateWriter{StateWriter: sous.DummyStateManager{State: state}}
+	writer := graph.LocalStateWriter{StateWriter: &sous.DummyStateManager{State: state}}
 
 	manifest := &sous.Manifest{
 		Source: sous.SourceLocation{Repo: "gh"},

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -14,7 +15,7 @@ import (
 
 func testInject(thing interface{}) error {
 	gf := func() Injector {
-		g := graph.BuildGraph(os.Stdout, os.Stdout)
+		g := graph.BuildGraph(&bytes.Buffer{}, os.Stdout, os.Stdout)
 		g.Add(&config.Verbosity{})
 		return g
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"net/http"
 	"os"
 
@@ -19,7 +20,7 @@ func New(laddr string, gf GraphFactory) *http.Server {
 // RunServer starts a server up.
 func RunServer(v *config.Verbosity, laddr string) error {
 	gf := func() Injector {
-		g := graph.BuildGraph(os.Stdout, os.Stdout)
+		g := graph.BuildGraph(&bytes.Buffer{}, os.Stdout, os.Stdout)
 		g.Add(v)
 		return g
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -86,7 +86,7 @@ func TestOverallRouter(t *testing.T) {
 	assert := assert.New(t)
 
 	gf := func() Injector {
-		g := graph.BuildGraph(os.Stdout, os.Stdout)
+		g := graph.BuildGraph(&bytes.Buffer{}, os.Stdout, os.Stdout)
 		g.Add(&config.Verbosity{})
 		return g
 	}

--- a/test/http_state_manager_test.go
+++ b/test/http_state_manager_test.go
@@ -72,8 +72,8 @@ func TestWriteState(t *testing.T) {
 		di.Add(sous.NewLogSet(os.Stderr, os.Stderr, ioutil.Discard))
 		graph.AddInternals(di)
 		di.Add(
-			func() graph.LocalStateReader { return graph.LocalStateReader{StateReader: sm} },
-			func() graph.LocalStateWriter { return graph.LocalStateWriter{StateWriter: sm} },
+			func() graph.LocalStateReader { return graph.LocalStateReader{StateReader: &sm} },
+			func() graph.LocalStateWriter { return graph.LocalStateWriter{StateWriter: &sm} },
 		)
 		di.Add(&config.Verbosity{})
 		return di


### PR DESCRIPTION
Git style workflow looks like

```
sous manifest get > tmpfile
$EDITOR tmpfile
sous manifest set < tmpfile
```

(possibly we could build a porcelain for that)

OTPL-style source repo as source of truth:
```
sous manifest set < repo/manifest.yaml
sous deploy
```

Also in this PR: teasing out the dependency cycle between SourceContext and
TargetManifestID in graph/. Solution was a graph-local `SourceContextDiscovery`
type, which can be unwrapped to `GetError()` or `GetContext()` to get the
discovered-or-default SourceContext.