### PR TITLE
Bugfix: allowed advisories empty strings.

### DIFF
--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -168,18 +168,19 @@ func GuardImages(r Registry, gdm Deployments) error {
 				if q.Name == "" {
 					continue
 				}
-				found := false
-				var advs []string
-				if d.Cluster != nil {
-					advs = d.Cluster.AllowedAdvisories
+				advisoryIsValid := false
+				var allowedAdvisories []string
+				if d.Cluster == nil {
+					return fmt.Errorf("nil cluster on deployment %q", d)
 				}
-				for _, aa := range advs {
+				allowedAdvisories = d.Cluster.AllowedAdvisories
+				for _, aa := range allowedAdvisories {
 					if aa == q.Name {
-						found = true
+						advisoryIsValid = true
 						break
 					}
 				}
-				if !found {
+				if !advisoryIsValid {
 					es = append(es, &UnacceptableAdvisory{q, &d.SourceID})
 				}
 			}

--- a/lib/state.go
+++ b/lib/state.go
@@ -119,7 +119,7 @@ func (cs Clusters) Clone() Clusters {
 // Clone returns a deep copy of this Cluster.
 func (c Cluster) Clone() *Cluster {
 	allowedAdvisories := make([]string, len(c.AllowedAdvisories))
-	copy(c.AllowedAdvisories, allowedAdvisories)
+	copy(allowedAdvisories, c.AllowedAdvisories)
 	c.AllowedAdvisories = allowedAdvisories
 	return &c
 }


### PR DESCRIPTION
- Resolves TECHOPS-1238

I've found a series of related probable bugs in the way we (rather I :P) have been using the `copy` builtin. I've been using it backwards. The correct usage is `copy(dest, source)`. Going to get more tests in around all the Clone methods soon.