### PR TITLE
Allows for ENV set options to be empty

### DIFF
--- a/util/configloader/configloader.go
+++ b/util/configloader/configloader.go
@@ -1,5 +1,5 @@
-// The config package provides JSON-based configuration files, with automatic
-// environment variable overriding.
+// The configloader package provides YAML-based configuration files, with
+// automatic environment variable overriding.
 package configloader
 
 import (

--- a/util/configloader/configloader.go
+++ b/util/configloader/configloader.go
@@ -51,13 +51,13 @@ func (cl ConfigLoader) Load(target interface{}, filePath string) error {
 			return err
 		}
 	}
-	if err := cl.overrideWithEnv(target); err != nil {
-		return err
-	}
 	if fd, ok := target.(DefaultFiller); ok {
 		if err := fd.FillDefaults(); err != nil {
 			return err
 		}
+	}
+	if err := cl.overrideWithEnv(target); err != nil {
+		return err
 	}
 	return nil
 }
@@ -129,8 +129,8 @@ func (cl ConfigLoader) overrideField(sf reflect.StructField, originalVal reflect
 	if envName == "" {
 		return nil
 	}
-	envVal := os.Getenv(envName)
-	if envVal == "" {
+	envVal, present := os.LookupEnv(envName)
+	if !present {
 		return nil
 	}
 	var finalVal reflect.Value

--- a/util/configloader/configloader_test.go
+++ b/util/configloader/configloader_test.go
@@ -59,3 +59,23 @@ func TestLoad_Env(t *testing.T) {
 		t.Errorf("got SomeVar=%q; want %q", c.SomeVar, expected)
 	}
 }
+
+func TestLoad_EmptyEnv(t *testing.T) {
+	cl := New()
+	c := TestConfig{}
+
+	expected := ""
+	os.Setenv("TEST_SOME_VAR", expected)
+
+	if e := os.Getenv("TEST_SOME_VAR"); e != expected {
+		t.Fatalf("setenv failed")
+	}
+
+	if err := cl.Load(&c, "test_config.yaml"); err != nil {
+		t.Fatal(err)
+	}
+
+	if c.SomeVar != expected {
+		t.Errorf("got SomeVar=%q; want %q", c.SomeVar, expected)
+	}
+}


### PR DESCRIPTION
The use case was to be able to set SOUS_SERVER="" to do local rectifies
occasionally, but have a default server in the config.yaml for most
things.