### PR TITLE
cli: Detailed errors only if -d flag.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -23,7 +23,10 @@ var (
 	OSErrorf          = cmdr.OSErrorf
 	IOErrorf          = cmdr.IOErrorf
 	InternalErrorf    = cmdr.InternalErrorf
-	EnsureErrorResult = cmdr.EnsureErrorResult
+	EnsureErrorResult = func(err error) cmdr.ErrorResult {
+		sous.Log.Debug.Println(err)
+		return cmdr.EnsureErrorResult(err)
+	}
 )
 
 // ProduceResult converts errors into Results

--- a/util/cmdr/errors.go
+++ b/util/cmdr/errors.go
@@ -2,7 +2,6 @@ package cmdr
 
 import (
 	"fmt"
-	"log"
 	"os"
 )
 
@@ -50,7 +49,6 @@ type (
 // intelligently, and eventially falls back to UnknownErr if no sensible
 // ErrorResult exists for that error.
 func EnsureErrorResult(err error) ErrorResult {
-	log.Print(err)
 	if result, ok := err.(ErrorResult); ok {
 		return result
 	}


### PR DESCRIPTION
- Previously every CLI error was logged raw to stdout.
- Now only the top-level error is printed unless the -d flag is set.
- In particular this makes errors happening during injection much
  less verbose and more useful to users.

"Top-level" here means the actual error, rather than all the wrapped context added by `errors.Wrap` which isn't useful to end users.