### PR TITLE
shell: Long-running commands print when starting.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -23,7 +23,10 @@ var (
 	OSErrorf          = cmdr.OSErrorf
 	IOErrorf          = cmdr.IOErrorf
 	InternalErrorf    = cmdr.InternalErrorf
-	EnsureErrorResult = cmdr.EnsureErrorResult
+	EnsureErrorResult = func(err error) cmdr.ErrorResult {
+		sous.Log.Debug.Println(err)
+		return cmdr.EnsureErrorResult(err)
+	}
 )
 
 // ProduceResult converts errors into Results

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -403,6 +403,8 @@ func newDockerBuilder(cfg LocalSousConfig, cl LocalDockerClient, ctx *sous.Sourc
 		return nil, err
 	}
 	drh := cfg.Docker.RegistryHost
+	source.Sh = source.Sh.Clone().(*shell.Sh)
+	source.Sh.LongRunning = true
 	return docker.NewBuilder(nc, drh, source.Sh, scratch.Sh)
 }
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -370,9 +370,10 @@ func newLocalWorkDir() (LocalWorkDir, error) {
 	return LocalWorkDir(s), initErr(err, "determining working directory")
 }
 
-func newLocalWorkDirShell(l LocalWorkDir) (v LocalWorkDirShell, err error) {
+func newLocalWorkDirShell(verbosity *config.Verbosity, l LocalWorkDir) (v LocalWorkDirShell, err error) {
 	v.Sh, err = shell.DefaultInDir(string(l))
 	v.TeeEcho = os.Stdout //XXX should use a writer
+	v.Sh.Debug = verbosity.Debug
 	//v.TeeOut = os.Stdout
 	//v.TeeErr = os.Stderr
 	return v, initErr(err, "getting current working directory")

--- a/util/cmdr/errors.go
+++ b/util/cmdr/errors.go
@@ -2,7 +2,6 @@ package cmdr
 
 import (
 	"fmt"
-	"log"
 	"os"
 )
 
@@ -50,7 +49,6 @@ type (
 // intelligently, and eventially falls back to UnknownErr if no sensible
 // ErrorResult exists for that error.
 func EnsureErrorResult(err error) ErrorResult {
-	log.Print(err)
 	if result, ok := err.(ErrorResult); ok {
 		return result
 	}

--- a/util/shell/command.go
+++ b/util/shell/command.go
@@ -35,6 +35,9 @@ type (
 		// TeeErr will be connected to stderr via a multireader, unless it is
 		// nil.
 		TeeErr io.Writer
+		// Debug indicates if this command is in debug mode. If true, every
+		// command and its combined output will be printed to screen.
+		Debug bool
 	}
 	// Result is the result of running a command to completion.
 	Result struct {
@@ -150,7 +153,6 @@ func (c *Command) ExitCode() (int, error) {
 // non-zero exit codes, use SucceedResult instead.
 func (c *Command) Result() (*Result, error) {
 	line := strings.Join([]string{c.Name, strings.Join(c.Args, " ")}, " ")
-	c.ConsoleEcho(line)
 	command := exec.Command(c.Name, c.Args...)
 	command.Dir = c.Dir
 	outbuf := &bytes.Buffer{}
@@ -181,6 +183,10 @@ func (c *Command) Result() (*Result, error) {
 				code = status.ExitStatus()
 			}
 		}
+		message := fmt.Sprintf("%s FAILED (exit code %d)", line, code)
+		c.ConsoleEcho(message)
+	} else if c.Debug {
+		c.ConsoleEcho(line + "\n> " + combinedbuf.String())
 	}
 	return &Result{
 		Command:  c,

--- a/util/shell/sh.go
+++ b/util/shell/sh.go
@@ -26,6 +26,9 @@ type (
 		// TeeErr is similar to TeeOut, except that it has stderr written to it
 		// instead of stdout.
 		TeeErr io.Writer
+		// Debug sets each command issued by this shell into debug mode, or not
+		// depending on this value.
+		Debug bool
 	}
 )
 
@@ -105,6 +108,7 @@ func (s *Sh) Cmd(name string, args ...interface{}) Cmd {
 		ConsoleEcho: s.ConsoleEcho,
 		TeeOut:      s.TeeOut,
 		TeeErr:      s.TeeErr,
+		Debug:       s.Debug,
 	}
 }
 

--- a/util/shell/sh.go
+++ b/util/shell/sh.go
@@ -29,6 +29,9 @@ type (
 		// Debug sets each command issued by this shell into debug mode, or not
 		// depending on this value.
 		Debug bool
+		// LongRunning sets each command issued by this shell to be a
+		// long-running command. See Command.LongRunning for details.
+		LongRunning bool
 	}
 )
 
@@ -109,6 +112,7 @@ func (s *Sh) Cmd(name string, args ...interface{}) Cmd {
 		TeeOut:      s.TeeOut,
 		TeeErr:      s.TeeErr,
 		Debug:       s.Debug,
+		LongRunning: s.LongRunning,
 	}
 }
 


### PR DESCRIPTION
Includes #222 

- Previously long-running commands produced no output, leading
  to an apparent hang.
- Now at the beginning of a long-running command, the command
  line is printed, so the user at least knows what is being
  attempted.
- This primarily impacts the docker commands for now.