### PR TITLE
graph + config: Adds basic config validation.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -23,7 +23,10 @@ var (
 	OSErrorf          = cmdr.OSErrorf
 	IOErrorf          = cmdr.IOErrorf
 	InternalErrorf    = cmdr.InternalErrorf
-	EnsureErrorResult = cmdr.EnsureErrorResult
+	EnsureErrorResult = func(err error) cmdr.ErrorResult {
+		sous.Log.Debug.Println(err)
+		return cmdr.EnsureErrorResult(err)
+	}
 )
 
 // ProduceResult converts errors into Results

--- a/cli/sous_config.go
+++ b/cli/sous_config.go
@@ -8,7 +8,7 @@ import (
 // SousConfig is the sous config command.
 type SousConfig struct {
 	User   graph.LocalUser
-	Config graph.LocalSousConfig
+	Config graph.PossiblyInvalidConfig
 }
 
 func init() { TopLevelCommands["config"] = &SousConfig{} }
@@ -28,21 +28,22 @@ func (sc *SousConfig) Help() string { return sousConfigHelp }
 
 // Execute displays or sets config properties.
 func (sc *SousConfig) Execute(args []string) cmdr.Result {
+	c := graph.LocalSousConfig{Config: sc.Config.Config}
 	switch len(args) {
 	default:
 		return UsageErrorf("expected 0-2 arguments, received %d", len(args))
 	case 0:
-		return Successf(sc.Config.String())
+		return Successf(c.String())
 	case 1:
 		name := args[0]
-		v, err := sc.Config.GetValue(name)
+		v, err := c.GetValue(name)
 		if err != nil {
 			return UsageErrorf("%s", err)
 		}
 		return Successf(v)
 	case 2:
 		name, value := args[0], args[1]
-		if err := sc.Config.SetValue(sc.User.ConfigFile(), name, value); err != nil {
+		if err := c.SetValue(sc.User.ConfigFile(), name, value); err != nil {
 			return EnsureErrorResult(err)
 		}
 		return Successf("set %s to %q", name, value)

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"os/user"
 	"path"
@@ -28,6 +29,20 @@ type (
 		Docker docker.Config
 	}
 )
+
+// Validate returns an error if this config is invalid.
+func (c Config) Validate() error {
+	if c.Server != "" {
+		u, err := url.Parse(c.Server)
+		if err != nil {
+			return fmt.Errorf("Config.Server %q is not a valid URL: %s", c.Server, err)
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return fmt.Errorf("Config.Server %q must begin with http:// or https://", c.Server)
+		}
+	}
+	return nil
+}
 
 // DefaultConfig returns the default configuration.
 func DefaultConfig() Config {

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -403,6 +403,8 @@ func newDockerBuilder(cfg LocalSousConfig, cl LocalDockerClient, ctx *sous.Sourc
 		return nil, err
 	}
 	drh := cfg.Docker.RegistryHost
+	source.Sh = source.Sh.Clone().(*shell.Sh)
+	source.Sh.LongRunning = true
 	return docker.NewBuilder(nc, drh, source.Sh, scratch.Sh)
 }
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -159,7 +159,10 @@ func AddShells(graph adder) {
 
 // AddFilesystem adds filesystem to the graph
 func AddFilesystem(graph adder) {
+	c := config.DefaultConfig()
 	graph.Add(
+		newPossiblyInvalidLocalSousConfig,
+		DefaultConfig{&c},
 		newLocalSousConfig,
 		newLocalWorkDir,
 	)
@@ -346,9 +349,17 @@ func newLocalUser() (v LocalUser, err error) {
 	return v, initErr(err, "getting current user")
 }
 
-func newLocalSousConfig(u LocalUser) (v LocalSousConfig, err error) {
-	v.Config, err = newConfig(u.User.ConfigFile(), u.DefaultConfig())
+func newPossiblyInvalidLocalSousConfig(u LocalUser, defaultConfig DefaultConfig) (PossiblyInvalidConfig, error) {
+	v, err := newPossiblyInvalidConfig(u.ConfigFile(), defaultConfig)
 	return v, initErr(err, "getting configuration")
+}
+
+func newLocalSousConfig(pic PossiblyInvalidConfig) (v LocalSousConfig, err error) {
+	v.Config, err = pic.Config, pic.Validate()
+	if err != nil {
+		err = fmt.Errorf("%s\ntip: run 'sous config' to see and manipulate your configuration", err.Error())
+	}
+	return v, initErr(err, "validating configuration")
 }
 
 // TODO: This should register a cleanup task with the cli, to delete the temp

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -370,9 +370,10 @@ func newLocalWorkDir() (LocalWorkDir, error) {
 	return LocalWorkDir(s), initErr(err, "determining working directory")
 }
 
-func newLocalWorkDirShell(l LocalWorkDir) (v LocalWorkDirShell, err error) {
+func newLocalWorkDirShell(verbosity *config.Verbosity, l LocalWorkDir) (v LocalWorkDirShell, err error) {
 	v.Sh, err = shell.DefaultInDir(string(l))
 	v.TeeEcho = os.Stdout //XXX should use a writer
+	v.Sh.Debug = verbosity.Debug
 	//v.TeeOut = os.Stdout
 	//v.TeeErr = os.Stderr
 	return v, initErr(err, "getting current working directory")

--- a/graph/local_config_test.go
+++ b/graph/local_config_test.go
@@ -26,7 +26,7 @@ func TestNewConfig(t *testing.T) {
 		}
 	}()
 
-	written, err := newConfig(path, config.Config{})
+	written, err := newPossiblyInvalidConfig(path, DefaultConfig{&config.Config{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,12 +34,12 @@ func TestNewConfig(t *testing.T) {
 		t.Fatal("Config file not created:", path, ":", err)
 	}
 
-	read, err := newConfig(path, config.Config{})
+	read, err := newPossiblyInvalidConfig(path, DefaultConfig{&config.Config{}})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if *read != *written {
+	if *read.Config != *written.Config {
 		t.Log("READ:\n\n", read)
 		t.Log("WRITTEN:\n\n", written)
 		t.Error("Read and written configs were different.")

--- a/util/cmdr/errors.go
+++ b/util/cmdr/errors.go
@@ -2,7 +2,6 @@ package cmdr
 
 import (
 	"fmt"
-	"log"
 	"os"
 )
 
@@ -50,7 +49,6 @@ type (
 // intelligently, and eventially falls back to UnknownErr if no sensible
 // ErrorResult exists for that error.
 func EnsureErrorResult(err error) ErrorResult {
-	log.Print(err)
 	if result, ok := err.(ErrorResult); ok {
 		return result
 	}

--- a/util/configloader/configloader.go
+++ b/util/configloader/configloader.go
@@ -26,6 +26,9 @@ type (
 	DefaultFiller interface {
 		FillDefaults() error
 	}
+	Validator interface {
+		Validate() error
+	}
 )
 
 func (cl *ConfigLoader) SetLogFunc(f func(...interface{})) {
@@ -58,6 +61,13 @@ func (cl ConfigLoader) Load(target interface{}, filePath string) error {
 	}
 	if err := cl.overrideWithEnv(target); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (cl *ConfigLoader) Validate(target interface{}) error {
+	if validator, ok := target.(Validator); ok {
+		return validator.Validate()
 	}
 	return nil
 }

--- a/util/shell/command.go
+++ b/util/shell/command.go
@@ -35,6 +35,9 @@ type (
 		// TeeErr will be connected to stderr via a multireader, unless it is
 		// nil.
 		TeeErr io.Writer
+		// Debug indicates if this command is in debug mode. If true, every
+		// command and its combined output will be printed to screen.
+		Debug bool
 	}
 	// Result is the result of running a command to completion.
 	Result struct {
@@ -150,7 +153,6 @@ func (c *Command) ExitCode() (int, error) {
 // non-zero exit codes, use SucceedResult instead.
 func (c *Command) Result() (*Result, error) {
 	line := strings.Join([]string{c.Name, strings.Join(c.Args, " ")}, " ")
-	c.ConsoleEcho(line)
 	command := exec.Command(c.Name, c.Args...)
 	command.Dir = c.Dir
 	outbuf := &bytes.Buffer{}
@@ -181,6 +183,10 @@ func (c *Command) Result() (*Result, error) {
 				code = status.ExitStatus()
 			}
 		}
+		message := fmt.Sprintf("%s FAILED (exit code %d)", line, code)
+		c.ConsoleEcho(message)
+	} else if c.Debug {
+		c.ConsoleEcho(line + "\n> " + combinedbuf.String())
 	}
 	return &Result{
 		Command:  c,

--- a/util/shell/sh.go
+++ b/util/shell/sh.go
@@ -26,6 +26,9 @@ type (
 		// TeeErr is similar to TeeOut, except that it has stderr written to it
 		// instead of stdout.
 		TeeErr io.Writer
+		// Debug sets each command issued by this shell into debug mode, or not
+		// depending on this value.
+		Debug bool
 	}
 )
 
@@ -105,6 +108,7 @@ func (s *Sh) Cmd(name string, args ...interface{}) Cmd {
 		ConsoleEcho: s.ConsoleEcho,
 		TeeOut:      s.TeeOut,
 		TeeErr:      s.TeeErr,
+		Debug:       s.Debug,
 	}
 }
 

--- a/util/shell/sh.go
+++ b/util/shell/sh.go
@@ -29,6 +29,9 @@ type (
 		// Debug sets each command issued by this shell into debug mode, or not
 		// depending on this value.
 		Debug bool
+		// LongRunning sets each command issued by this shell to be a
+		// long-running command. See Command.LongRunning for details.
+		LongRunning bool
 	}
 )
 
@@ -109,6 +112,7 @@ func (s *Sh) Cmd(name string, args ...interface{}) Cmd {
 		TeeOut:      s.TeeOut,
 		TeeErr:      s.TeeErr,
 		Debug:       s.Debug,
+		LongRunning: s.LongRunning,
 	}
 }
 


### PR DESCRIPTION
Includes #223 

 - Previously config was not validated.
 - Now it is validated up-front for most use cases.
 - The exception is when running the 'sous config' command, since
   this is the command used to fix a broken config.

Specifically addresses https://github.com/opentable/sous/issues/215#issue-190866561