### PR TITLE
Fix sous query help tip.

### DIFF
--- a/cli/sous_query.go
+++ b/cli/sous_query.go
@@ -33,6 +33,6 @@ func (SousQuery) Subcommands() cmdr.Commands {
 
 func (sb *SousQuery) Execute(args []string) cmdr.Result {
 	err := UsageErrorf("usage: sous query [options] command")
-	err.Tip = "try `sous query help` for a list of commands"
+	err.Tip = "try `sous help query` for a list of commands"
 	return err
 }


### PR DESCRIPTION
There are bigger problems that need to be addressed with CLI help messages that aren't being printed, but this solves the portion of issue 216 where the sous query help tip gives incorrect information.