### PR TITLE
Command Help Fixes

### DIFF
--- a/cli/sous.go
+++ b/cli/sous.go
@@ -39,8 +39,6 @@ type Sous struct {
 var TopLevelCommands = cmdr.Commands{}
 
 const sousHelp = `
-invoke sous
-
 sous is a tool to help speed up the build/test/deploy cycle at your organisation
 
 args: <command>

--- a/cli/sous.go
+++ b/cli/sous.go
@@ -41,7 +41,7 @@ var TopLevelCommands = cmdr.Commands{}
 const sousHelp = `
 sous is a tool to help speed up the build/test/deploy cycle at your organisation
 
-args: <command>
+usage: sous <command>
 
 sous helps by automating the boring bits of the build/test/deploy cycle. It
 provides commands in this CLI for performing all the actions the sous server is

--- a/cli/tests/sous_test.go
+++ b/cli/tests/sous_test.go
@@ -13,7 +13,7 @@ func TestSous(t *testing.T) {
 
 	log.Print(term.Stderr)
 	term.Stdout.ShouldHaveNumLines(0)
-	term.Stderr.ShouldHaveNumLines(26)
+	term.Stderr.ShouldHaveNumLines(41)
 
 	term.Stderr.ShouldHaveExactLine("usage: sous <command>")
 	term.Stderr.ShouldHaveLineContaining("help      get help with sous")

--- a/util/cmdr/command.go
+++ b/util/cmdr/command.go
@@ -12,6 +12,11 @@ type (
 	Command interface {
 		// Help is the help message for a command. To be a command, all you need
 		// is a help message.
+		// Help messages must follow this convention:
+		// The first line must be 50 characters or fewer, and describe
+		// succinctly what the command does.
+		// The second line must be blank.
+		// The remainder of the string is free-form text.
 		Help() string
 	}
 	// CanExecute means the command can itself be executed to do something.

--- a/util/cmdr/command.go
+++ b/util/cmdr/command.go
@@ -12,15 +12,6 @@ type (
 	Command interface {
 		// Help is the help message for a command. To be a command, all you need
 		// is a help message.
-		//
-		// Help messages must follow some conventions:
-		// The first line must be 50 characters or fewer, and describe
-		// succinctly what the command does.
-		// The second line must be blank.
-		// The third line should begin with "args: " followed by a list of named
-		// arguments (not flags or options)
-		// The remaining non-blank lines should contain a detailed description
-		// of how the command works, including usage examples.
 		Help() string
 	}
 	// CanExecute means the command can itself be executed to do something.

--- a/util/cmdr/help.go
+++ b/util/cmdr/help.go
@@ -4,44 +4,10 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"strings"
-
-	"github.com/opentable/sous/util/whitespace"
 )
 
 // Help contains help strings describing a command.
 type Help struct{ Short, Desc, Args, Long string }
-
-// ParseHelp parses a command's help string into its component parts.
-func ParseHelp(s string) *Help {
-	chunks := strings.SplitN(s, "\n\n", 4)
-	pieces := []string{}
-	for _, c := range chunks {
-		c = whitespace.Trim(c)
-		if len(s) != 0 {
-			pieces = append(pieces, c)
-		}
-	}
-	h := &Help{
-		"error: no short description defined",
-		"error: no description defined",
-		"",
-		"error: no help text defined",
-	}
-	if len(pieces) > 0 {
-		h.Short = pieces[0]
-	}
-	if len(pieces) > 1 {
-		h.Desc = pieces[1]
-	}
-	if len(pieces) > 2 {
-		h.Args = whitespace.Trim(strings.TrimPrefix(pieces[2], "args:"))
-	}
-	if len(pieces) == 3 {
-		h.Long = pieces[2]
-	}
-	return h
-}
 
 // Usage prints the usage message.
 func (h *Help) Usage(name string) string {
@@ -65,10 +31,8 @@ func (cli *CLI) Help(base Command, name string, args []string) (string, error) {
 
 func (cli *CLI) printHelp(out *Output, base Command, name string, args []string) error {
 	if len(args) == 0 {
-		help := ParseHelp(base.Help())
-		out.Println(help.Usage(name))
-		out.Println()
-		out.Println(help.Desc)
+		help := base.Help()
+		out.Println(help)
 		cli.printSubcommands(out, base, name)
 		cli.printOptions(out, base, name)
 		return nil
@@ -117,7 +81,6 @@ func commandTable(cs Commands) [][]string {
 	for i, name := range cs.SortedKeys() {
 		t[i] = make([]string, 2)
 		t[i][0] = name
-		t[i][1] = ParseHelp(cs[name].Help()).Short
 	}
 	return t
 }

--- a/util/cmdr/help.go
+++ b/util/cmdr/help.go
@@ -14,13 +14,6 @@ func (h *Help) Usage(name string) string {
 	return fmt.Sprintf("usage: %s %s", name, h.Args)
 }
 
-// PrintHelp recursively descends down the commands and subcommands named in its
-// arguments, and prints the help for the deepest member it meets, or returns an
-// error if no such command exists.
-func (cli *CLI) PrintHelp(base Command, name string, args []string) error {
-	return cli.printHelp(cli.Out, base, name, args)
-}
-
 // Help is similar to PrintHelp, except it returns the result as a string
 // instead of writing to the CLI's default Output.
 func (cli *CLI) Help(base Command, name string, args []string) (string, error) {

--- a/util/cmdr/help.go
+++ b/util/cmdr/help.go
@@ -6,12 +6,7 @@ import (
 	"strings"
 )
 
-// Usage prints the usage message.
-//func (h *Help) Usage(name string) string {
-//	return fmt.Sprintf("usage: %s %s", name, h.Args)
-//}
-
-// Help is similar to PrintHelp, except it returns the result as a string
+// Help is similar to printHelp, except it returns the result as a string
 // instead of writing to the CLI's default Output.
 func (cli *CLI) Help(base Command, name string, args []string) (string, error) {
 	b := &bytes.Buffer{}

--- a/util/cmdr/help.go
+++ b/util/cmdr/help.go
@@ -3,16 +3,12 @@ package cmdr
 import (
 	"bytes"
 	"flag"
-	"fmt"
 )
 
-// Help contains help strings describing a command.
-type Help struct{ Short, Desc, Args, Long string }
-
 // Usage prints the usage message.
-func (h *Help) Usage(name string) string {
-	return fmt.Sprintf("usage: %s %s", name, h.Args)
-}
+//func (h *Help) Usage(name string) string {
+//	return fmt.Sprintf("usage: %s %s", name, h.Args)
+//}
 
 // Help is similar to PrintHelp, except it returns the result as a string
 // instead of writing to the CLI's default Output.

--- a/util/cmdr/help.go
+++ b/util/cmdr/help.go
@@ -3,6 +3,7 @@ package cmdr
 import (
 	"bytes"
 	"flag"
+	"strings"
 )
 
 // Usage prints the usage message.
@@ -68,8 +69,10 @@ func (cli *CLI) printOptions(out *Output, command Command, name string) {
 func commandTable(cs Commands) [][]string {
 	t := make([][]string, len(cs))
 	for i, name := range cs.SortedKeys() {
+		shortHelp := strings.Split(cs[name].Help(), "\n")[1]
 		t[i] = make([]string, 2)
 		t[i][0] = name
+		t[i][1] = shortHelp
 	}
 	return t
 }


### PR DESCRIPTION
The help messages embedded in each of the command line utilities are now printing. I removed parseHelp() and the Help struct from cmdr. I removed the Usage() function that gave Help as its receiver. I removed the unused PrintHelp() function. The help string for the top-level sous command was modified to match what the tests expect. Subcommands have individual short descriptions when described in the help message of the parent command. Modified the tests to expect much longer help messages.