### PR TITLE
Adds "repo guessing" to the docker name cache

### DIFF
--- a/ext/docker/names.go
+++ b/ext/docker/names.go
@@ -56,12 +56,12 @@ func Labels(sid sous.SourceID) map[string]string {
 	return labels
 }
 
-func imageNameBase(sid sous.SourceID) string {
-	name := sid.Location.Repo
+func imageRepoName(sl sous.SourceLocation) string {
+	name := sl.Repo
 
 	name = stripRE.ReplaceAllString(name, "")
-	if sid.Location.Dir != "" {
-		name = strings.Join([]string{name, sid.Location.Dir}, "/")
+	if sl.Dir != "" {
+		name = strings.Join([]string{name, sl.Dir}, "/")
 	}
 	return name
 }
@@ -71,9 +71,9 @@ func tagName(v semv.Version) string {
 }
 
 func versionName(sid sous.SourceID) string {
-	return strings.Join([]string{imageNameBase(sid), tagName(sid.Version)}, ":")
+	return strings.Join([]string{imageRepoName(sid.Location), tagName(sid.Version)}, ":")
 }
 
 func revisionName(sid sous.SourceID) string {
-	return strings.Join([]string{imageNameBase(sid), sid.RevID()}, ":")
+	return strings.Join([]string{imageRepoName(sid.Location), sid.RevID()}, ":")
 }

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -499,7 +499,8 @@ func makeDockerRegistry(cfg LocalSousConfig, cl LocalDockerClient) (*docker.Name
 	if err != nil {
 		return nil, errors.Wrap(err, "building name cache DB")
 	}
-	return docker.NewNameCache(cl.Client, db), nil
+	drh := cfg.Docker.RegistryHost
+	return docker.NewNameCache(drh, cl.Client, db), nil
 }
 
 func newInserter(cfg LocalSousConfig, cl LocalDockerClient) (sous.Inserter, error) {

--- a/integration/deployment_builder_test.go
+++ b/integration/deployment_builder_test.go
@@ -48,7 +48,7 @@ func TestBuildDeployments(t *testing.T) {
 	clusterNick := "tcluster"
 	reqID := appLocation + clusterNick
 
-	nc := docker.NewNameCache(drc, db)
+	nc := docker.NewNameCache("", drc, db)
 
 	singCl := sing.NewClient(SingularityURL)
 	//singCl.Debug = true

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -57,7 +57,7 @@ func TestGetRunningDeploymentSet(t *testing.T) {
 	registerLabelledContainers()
 	drc := docker_registry.NewClient()
 	drc.BecomeFoolishlyTrusting()
-	nc := docker.NewNameCache(drc, newInMemoryDB("grds"))
+	nc := docker.NewNameCache("", drc, newInMemoryDB("grds"))
 	client := singularity.NewRectiAgent(nc)
 	d := singularity.NewDeployer(nc, client)
 
@@ -93,7 +93,7 @@ func TestMissingImage(t *testing.T) {
 	drc := docker_registry.NewClient()
 	drc.BecomeFoolishlyTrusting()
 	// easiest way to make sure that the manifest doesn't actually get registered
-	dummyNc := docker.NewNameCache(drc, newInMemoryDB("bitbucket"))
+	dummyNc := docker.NewNameCache("", drc, newInMemoryDB("bitbucket"))
 
 	stateOne := sous.State{
 		Defs: clusterDefs,
@@ -103,7 +103,7 @@ func TestMissingImage(t *testing.T) {
 	}
 
 	// ****
-	nc := docker.NewNameCache(drc, newInMemoryDB("missingimage"))
+	nc := docker.NewNameCache("", drc, newInMemoryDB("missingimage"))
 
 	client := singularity.NewRectiAgent(nc)
 	deployer := singularity.NewDeployer(nc, client)
@@ -151,7 +151,7 @@ func TestResolve(t *testing.T) {
 
 	db := newInMemoryDB("testresolve")
 
-	nc := docker.NewNameCache(drc, db)
+	nc := docker.NewNameCache("", drc, db)
 
 	stateOneTwo := sous.State{
 		Defs: clusterDefs,

--- a/integration/name_cache_test.go
+++ b/integration/name_cache_test.go
@@ -29,7 +29,7 @@ func TestNameCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	nc := docker.NewNameCache(drc, db)
+	nc := docker.NewNameCache("", drc, db)
 
 	repoOne := "https://github.com/opentable/one.git"
 	manifest(nc, "opentable/one", "test-one", repoOne, "1.1.1")


### PR DESCRIPTION
When the name cache is checked for the image name for a source ID
and there's no image name known,
it gets all tags from an appropriate repo.
If it doesn't know of an appropriate repo,
it now guesses, based on the algorithm that
the docker builder uses to generate a repo.

TECHOPS-1314