### PR TITLE
Adds request debug logging for all HSM HTTP traffic

### DIFF
--- a/lib/auto_resolver_test.go
+++ b/lib/auto_resolver_test.go
@@ -51,7 +51,7 @@ func TestAfterDone(t *testing.T) {
 	ar.afterDone(tc, done, ac)
 	select {
 	case <-tc:
-	case <-time.After(time.Duration(4)):
+	case <-time.After(time.Duration(8)):
 		t.Error("Trigger channel took too long")
 	default:
 		t.Error("Trigger channel not triggered")

--- a/lib/http_state_manager_test.go
+++ b/lib/http_state_manager_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 )
@@ -89,7 +88,7 @@ func TestHTTPStateManager_Delete(t *testing.T) {
 }
 
 func TestHTTPStateManager_Modify(t *testing.T) {
-	Log.Vomit.SetOutput(os.Stderr)
+	//Log.Vomit.SetOutput(os.Stderr)
 	reqd := false
 	etag := "w/sauce"
 	h := func(rw http.ResponseWriter, r *http.Request) {

--- a/lib/http_state_manager_test.go
+++ b/lib/http_state_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -88,6 +89,7 @@ func TestHTTPStateManager_Delete(t *testing.T) {
 }
 
 func TestHTTPStateManager_Modify(t *testing.T) {
+	Log.Vomit.SetOutput(os.Stderr)
 	reqd := false
 	etag := "w/sauce"
 	h := func(rw http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This was done to try to address TECHOPS-1316, but once it was completed, could not reproduce an issue.
Nevertheless, the extra output is worthwhile, so I'm issuing this PR for it.