### PR TITLE
Bugfix manifest set

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -155,26 +155,43 @@ func TestInvokeQuery(t *testing.T) {
 
 func TestInvokeMetadataGet(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
+
 	exe := justCommand(t, []string{`sous`, `metadata`, `get`, `-repo`, `github.com/opentable/sous`})
 	assert.NotNil(exe)
+	metaGet, good := exe.Cmd.(*SousMetadataGet)
+	require.True(good)
+	assert.NotNil(metaGet.State)
 }
 
 func TestInvokeMetadataSet(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 	exe := justCommand(t, []string{`sous`, `metadata`, `set`, `-repo`, `github.com/opentable/sous`, `BuildBranch`, `master`})
 	assert.NotNil(exe)
+	metaSet, good := exe.Cmd.(*SousMetadataSet)
+	require.True(good)
+	assert.NotNil(metaSet.State)
 }
 
 func TestInvokeManifestGet(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 	exe := justCommand(t, []string{`sous`, `manifest`, `get`, `-repo`, `github.com/opentable/sous`})
 	assert.NotNil(exe)
+	maniGet, good := exe.Cmd.(*SousManifestGet)
+	require.True(good)
+	assert.NotNil(maniGet.State)
 }
 
 func TestInvokeManifestSet(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 	exe := justCommand(t, []string{`sous`, `manifest`, `set`, `-repo`, `github.com/opentable/sous`})
 	assert.NotNil(exe)
+	maniSet, good := exe.Cmd.(*SousManifestSet)
+	require.True(good)
+	assert.NotNil(maniSet.StateWriter)
 }
 
 func TestInvokeServer(t *testing.T) {

--- a/cli/sous_manifest_get.go
+++ b/cli/sous_manifest_get.go
@@ -16,6 +16,7 @@ type SousManifestGet struct {
 	graph.TargetManifestID
 	*sous.State
 	graph.OutWriter
+	*sous.ResolveFilter
 }
 
 func init() { ManifestSubcommands["get"] = &SousManifestGet{} }
@@ -37,7 +38,7 @@ func (smg *SousManifestGet) Execute(args []string) cmdr.Result {
 
 	mani, present := smg.State.Manifests.Get(mid)
 	if !present {
-		return EnsureErrorResult(errors.Errorf("No manifest for %v yet. See `sous init`", smg.DeployFilterFlags))
+		return EnsureErrorResult(errors.Errorf("No manifest matched by %v yet. See `sous init`", smg.ResolveFilter))
 	}
 
 	yml, err := yaml.Marshal(mani)

--- a/cli/sous_manifest_set.go
+++ b/cli/sous_manifest_set.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"flag"
 	"io/ioutil"
-	"log"
 
 	"github.com/opentable/sous/config"
 	"github.com/opentable/sous/graph"
@@ -19,6 +18,7 @@ type SousManifestSet struct {
 	*sous.State
 	graph.StateWriter
 	graph.InReader
+	*sous.ResolveFilter
 }
 
 func init() { ManifestSubcommands["set"] = &SousManifestSet{} }
@@ -44,7 +44,7 @@ func (smg *SousManifestSet) Execute(args []string) cmdr.Result {
 
 	_, present := smg.State.Manifests.Get(mid)
 	if !present {
-		return EnsureErrorResult(errors.Errorf("No manifest for %v yet. See `sous init`", smg.DeployFilterFlags))
+		return EnsureErrorResult(errors.Errorf("No manifest matched by %v yet. See `sous init`", smg.ResolveFilter))
 	}
 
 	yml := sous.Manifest{}

--- a/cli/sous_manifest_set.go
+++ b/cli/sous_manifest_set.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"flag"
 	"io/ioutil"
+	"log"
 
 	"github.com/opentable/sous/config"
 	"github.com/opentable/sous/graph"
@@ -16,7 +17,7 @@ type SousManifestSet struct {
 	config.DeployFilterFlags
 	graph.TargetManifestID
 	*sous.State
-	sous.StateWriter
+	graph.StateWriter
 	graph.InReader
 }
 

--- a/cli/sous_metadata_get.go
+++ b/cli/sous_metadata_get.go
@@ -46,7 +46,7 @@ func (smg *SousMetadataGet) Execute(args []string) cmdr.Result {
 			return EnsureErrorResult(err)
 		}
 		if dep == nil {
-			return EnsureErrorResult(errors.Errorf("No manifest deploy for %v", smg.DeployFilterFlags))
+			return EnsureErrorResult(errors.Errorf("No manifest matched by %v", smg.ResolveFilter))
 		}
 		if err := outputMetadata(dep.Metadata, smg.ResolveFilter.Cluster, args, smg.OutWriter); err != nil {
 			return EnsureErrorResult(err)
@@ -63,7 +63,7 @@ func (smg *SousMetadataGet) Execute(args []string) cmdr.Result {
 		return EnsureErrorResult(err)
 	}
 	if mani == nil {
-		return EnsureErrorResult(errors.Errorf("No manifest for %v", smg.DeployFilterFlags))
+		return EnsureErrorResult(errors.Errorf("No manifest matched by %v", smg.ResolveFilter))
 	}
 
 	for clusterName, deploySpec := range mani.Deployments {

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -228,12 +228,10 @@ func AddInternals(graph adder) {
 }
 
 func newResolveFilter(sf *config.DeployFilterFlags, shc sous.SourceHostChooser) (*sous.ResolveFilter, error) {
-	log.Printf("%#v", sf)
 	return sf.BuildFilter(shc.ParseSourceLocation)
 }
 
 func newResolver(filter *sous.ResolveFilter, d sous.Deployer, r sous.Registry) *sous.Resolver {
-	log.Printf("%#v", filter)
 	return sous.NewResolver(d, r, filter)
 }
 

--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -43,8 +43,27 @@ func (rf *ResolveFilter) All() bool {
 }
 
 func (rf *ResolveFilter) String() string {
-	return fmt.Sprintf("cluster: %q flavor: %q repo: %q offset: %q tag: %q revision %q",
-		rf.Cluster, rf.Flavor, rf.Repo, rf.Offset, rf.Tag, rf.Revision)
+	cl, fl, rp, of, tg, rv := rf.Cluster, rf.Flavor, rf.Repo, rf.Offset, rf.Tag, rf.Revision
+	if cl == "" {
+		cl = `*`
+	}
+	if fl == "" {
+		fl = `*`
+	}
+	if rp == "" {
+		rp = `*`
+	}
+	if of == "" {
+		of = `*`
+	}
+	if tg == "" {
+		tg = `*`
+	}
+	if rv == "" {
+		rv = `*`
+	}
+	return fmt.Sprintf("<cluster:%s repo:%s offset:%s flavor:%s tag:%s revision:%s>",
+		cl, rp, of, fl, tg, rv)
 }
 
 // FilteredClusters returns a new Clusters relevant to the Deployments that this ResolveFilter would permit


### PR DESCRIPTION
Specifically, StateWriter is an interface, which means it needs a wrapper
struct, and the command itself took the bare interface rather than the `graph`
package wrapper. Regression test added to `cli_test.go` and fix made.

Additionally, I realized while testing this that the output for `sous
{manifest,metadata} {set,get}` was incredibly obtuse. This improves on that as
well.

