### PR TITLE
Cache fixes

### DIFF
--- a/ext/docker/config.go
+++ b/ext/docker/config.go
@@ -15,7 +15,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		RegistryHost:       "docker.otenv.com",
-		DatabaseDriver:     "sqlite3",
+		DatabaseDriver:     "sqlite3_sous",
 		DatabaseConnection: InMemory,
 	}
 }

--- a/ext/docker/image_mapping.go
+++ b/ext/docker/image_mapping.go
@@ -603,7 +603,7 @@ func (nc *NameCache) dbInsert(sid sous.SourceID, in, etag string, quals []sous.Q
 		return errors.Wrapf(err, "inserting (%d, %d) into repo_through_location", nid, id)
 	}
 
-	versionString := sid.Version.Format(semv.MMPPre)
+	versionString := sid.Version.Format(semv.Complete)
 	Log.Vomit.Printf("Inserting metadata id:%v etag:%v name:%v version:%v", id, etag, in, versionString)
 
 	id, err = nc.ensureInDB(

--- a/ext/docker/image_mapping_test.go
+++ b/ext/docker/image_mapping_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func inMemoryDB(name string) *sql.DB {
-	db, err := GetDatabase(&DBConfig{"sqlite3", InMemoryConnection(name)})
+	db, err := GetDatabase(&DBConfig{"sqlite3_sous", InMemoryConnection(name)})
 	if err != nil {
 		panic(err)
 	}
@@ -40,7 +40,7 @@ func BenchmarkRecreateDB(b *testing.B) {
 	}()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := GetDatabase(&DBConfig{"sqlite3", "testdata/test.db"})
+		_, err := GetDatabase(&DBConfig{"sqlite3_sous", "testdata/test.db"})
 		if err != nil {
 			b.Log(err)
 		}
@@ -57,7 +57,7 @@ func BenchmarkCreateDB(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		dbName := fmt.Sprintf("testdata/test%d.db", i)
-		_, err := GetDatabase(&DBConfig{"sqlite3", dbName})
+		_, err := GetDatabase(&DBConfig{"sqlite3_sous", dbName})
 		if err != nil {
 			b.Log(err)
 		}
@@ -68,7 +68,7 @@ func BenchmarkCreateInMemoryDB(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		dbName := fmt.Sprintf("inmemory%d.db", i)
-		_, err := GetDatabase(&DBConfig{"sqlite3", InMemoryConnection(dbName)})
+		_, err := GetDatabase(&DBConfig{"sqlite3_sous", InMemoryConnection(dbName)})
 		if err != nil {
 			b.Log(err)
 		}

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -67,7 +67,7 @@ func testBuildInserter(t *testing.T, serverStr string) sous.Inserter {
 	ins, err := newInserter(LocalSousConfig{Config: &config.Config{
 		Server: serverStr,
 		Docker: docker.Config{
-			DatabaseDriver:     "sqlite3",
+			DatabaseDriver:     "sqlite3_sous",
 			DatabaseConnection: docker.InMemory,
 		},
 	}}, LocalDockerClient{})

--- a/integration/deployment_builder_test.go
+++ b/integration/deployment_builder_test.go
@@ -37,7 +37,7 @@ func TestBuildDeployments(t *testing.T) {
 	drc.BecomeFoolishlyTrusting()
 
 	db, err := docker.GetDatabase(&docker.DBConfig{
-		Driver:     "sqlite3",
+		Driver:     "sqlite3_sous",
 		Connection: docker.InMemoryConnection("testresolve"),
 	})
 	if err != nil {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -70,7 +70,7 @@ func TestGetRunningDeploymentSet_all(t *testing.T) {
 		assert.Regexp("^100\\.", grafana.Resources["memory"]) // XXX strings and floats...
 		assert.Equal("1", grafana.Resources["ports"])         // XXX strings and floats...
 		assert.Equal(17, grafana.SourceID.Version.Patch)
-		assert.Equal("91495f1b1630084e301241100ecf2e775f6b672c", grafana.SourceID.Version.Meta)
+		//assert.Equal("91495f1b1630084e301241100ecf2e775f6b672c", grafana.SourceID.Version.Meta)
 		assert.Equal(1, grafana.NumInstances)
 		assert.Equal(sous.ManifestKindService, grafana.Kind)
 	}
@@ -103,7 +103,7 @@ func TestGetRunningDeploymentSet_all2(t *testing.T) {
 		assert.Regexp("^100\\.", grafana.Resources["memory"]) // XXX strings and floats...
 		assert.Equal("1", grafana.Resources["ports"])         // XXX strings and floats...
 		assert.Equal(17, grafana.SourceID.Version.Patch)
-		assert.Equal("91495f1b1630084e301241100ecf2e775f6b672c", grafana.SourceID.Version.Meta)
+		//assert.Equal("91495f1b1630084e301241100ecf2e775f6b672c", grafana.SourceID.Version.Meta)
 		assert.Equal(1, grafana.NumInstances)
 		assert.Equal(sous.ManifestKindService, grafana.Kind)
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -45,7 +45,7 @@ func newInMemoryDB(name string) *sql.DB {
 	return db
 }
 
-func TestGetRunningDeploymentSet(t *testing.T) {
+func TestGetRunningDeploymentSet_all(t *testing.T) {
 	//sous.Log.Vomit.SetFlags(sous.Log.Vomit.Flags() | log.Ltime)
 	//sous.Log.Vomit.SetOutput(os.Stderr)
 	//sous.Log.Vomit.Print("Starting stderr output")

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -70,7 +70,7 @@ func TestGetRunningDeploymentSet_all(t *testing.T) {
 		assert.Regexp("^100\\.", grafana.Resources["memory"]) // XXX strings and floats...
 		assert.Equal("1", grafana.Resources["ports"])         // XXX strings and floats...
 		assert.Equal(17, grafana.SourceID.Version.Patch)
-		//assert.Equal("91495f1b1630084e301241100ecf2e775f6b672c", grafana.SourceID.Version.Meta)
+		assert.Equal("91495f1b1630084e301241100ecf2e775f6b672c", grafana.SourceID.Version.Meta)
 		assert.Equal(1, grafana.NumInstances)
 		assert.Equal(sous.ManifestKindService, grafana.Kind)
 	}
@@ -103,7 +103,7 @@ func TestGetRunningDeploymentSet_all2(t *testing.T) {
 		assert.Regexp("^100\\.", grafana.Resources["memory"]) // XXX strings and floats...
 		assert.Equal("1", grafana.Resources["ports"])         // XXX strings and floats...
 		assert.Equal(17, grafana.SourceID.Version.Patch)
-		//assert.Equal("91495f1b1630084e301241100ecf2e775f6b672c", grafana.SourceID.Version.Meta)
+		assert.Equal("91495f1b1630084e301241100ecf2e775f6b672c", grafana.SourceID.Version.Meta)
 		assert.Equal(1, grafana.NumInstances)
 		assert.Equal(sous.ManifestKindService, grafana.Kind)
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -78,6 +78,7 @@ func TestGetRunningDeploymentSet_all(t *testing.T) {
 	ResetSingularity()
 }
 
+// TODO: do the double-run in a single test rather than rely on deficiencies in our testing infra
 func TestGetRunningDeploymentSet_all2(t *testing.T) {
 	//sous.Log.Vomit.SetFlags(sous.Log.Vomit.Flags() | log.Ltime)
 	//sous.Log.Vomit.SetOutput(os.Stderr)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -36,7 +36,7 @@ func TestGetLabels(t *testing.T) {
 
 func newInMemoryDB(name string) *sql.DB {
 	db, err := docker.GetDatabase(&docker.DBConfig{
-		Driver:     "sqlite3",
+		Driver:     "sqlite3_sous",
 		Connection: docker.InMemoryConnection(name),
 	})
 	if err != nil {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -78,6 +78,39 @@ func TestGetRunningDeploymentSet_all(t *testing.T) {
 	ResetSingularity()
 }
 
+func TestGetRunningDeploymentSet_all2(t *testing.T) {
+	//sous.Log.Vomit.SetFlags(sous.Log.Vomit.Flags() | log.Ltime)
+	//sous.Log.Vomit.SetOutput(os.Stderr)
+	//sous.Log.Vomit.Print("Starting stderr output")
+	sous.Log.Debug.SetFlags(sous.Log.Debug.Flags() | log.Ltime)
+	sous.Log.Debug.SetOutput(os.Stderr)
+	sous.Log.Debug.Print("Starting stderr output")
+	assert := assert.New(t)
+
+	registerLabelledContainers()
+	drc := docker_registry.NewClient()
+	drc.BecomeFoolishlyTrusting()
+	nc := docker.NewNameCache("", drc, newInMemoryDB("grds"))
+	client := singularity.NewRectiAgent()
+	d := singularity.NewDeployer(client)
+
+	ds, which := deploymentWithRepo(nc, assert, d, "github.com/opentable/docker-grafana")
+	deps := ds.Snapshot()
+	if assert.Equal(3, len(deps)) {
+		grafana := deps[which]
+		assert.Equal(SingularityURL, grafana.Cluster.BaseURL)
+		assert.Regexp("^0\\.1", grafana.Resources["cpus"])    // XXX strings and floats...
+		assert.Regexp("^100\\.", grafana.Resources["memory"]) // XXX strings and floats...
+		assert.Equal("1", grafana.Resources["ports"])         // XXX strings and floats...
+		assert.Equal(17, grafana.SourceID.Version.Patch)
+		assert.Equal("91495f1b1630084e301241100ecf2e775f6b672c", grafana.SourceID.Version.Meta)
+		assert.Equal(1, grafana.NumInstances)
+		assert.Equal(sous.ManifestKindService, grafana.Kind)
+	}
+
+	ResetSingularity()
+}
+
 func TestMissingImage(t *testing.T) {
 	assert := assert.New(t)
 

--- a/integration/name_cache_test.go
+++ b/integration/name_cache_test.go
@@ -23,7 +23,7 @@ func TestNameCache(t *testing.T) {
 	drc.BecomeFoolishlyTrusting()
 
 	db, err := docker.GetDatabase(&docker.DBConfig{
-		Driver:     "sqlite3",
+		Driver:     "sqlite3_sous",
 		Connection: docker.InMemoryConnection("testnamecache"),
 	})
 	if err != nil {


### PR DESCRIPTION
This PR first adds a duplicate (failing) test to demonstrate that we get different results depending on if we get docker image metadata from the cache or not (e5db6c2). Then it demonstrates that one of the assertions in the tests is not satisfiable by commenting it out, making the tests pass (86169bc). Next we change the way semantic versions are compared in cache database queries to align that with the semver spec (fc3cde9). Then we add revision data to the cache via alteration of the text format used (6b279bd). Finally, the broken assertions are reinstated, and the tests pass (3f183be).