### PR TITLE
Bugfix otpl field mapping

### DIFF
--- a/ext/otpl/otpl.go
+++ b/ext/otpl/otpl.go
@@ -45,6 +45,12 @@ type (
 func (sr SingularityResources) SousResources() sous.Resources {
 	r := make(sous.Resources, len(sr))
 	for k, v := range sr {
+		if k == "numPorts" {
+			k = "ports"
+		}
+		if k == "memoryMb" {
+			k = "memory"
+		}
 		r[k] = strconv.FormatFloat(v, 'g', -1, 64)
 	}
 	return r

--- a/ext/otpl/otpl_test.go
+++ b/ext/otpl/otpl_test.go
@@ -1,0 +1,51 @@
+package otpl
+
+import (
+	"testing"
+
+	sous "github.com/opentable/sous/lib"
+)
+
+func TestSingularityResources_SousResources(t *testing.T) {
+	tests := []struct {
+		Singularity SingularityResources
+		Sous        sous.Resources
+	}{
+		{ // This won't really happen.
+			SingularityResources{
+				"cpu":    1,
+				"ports":  1,
+				"memory": 1,
+			},
+			sous.Resources{
+				"cpu":    "1",
+				"ports":  "1",
+				"memory": "1",
+			},
+		},
+		{ // Mapping singularity resource names to Sous ones.
+			SingularityResources{
+				"cpu":      1,
+				"numPorts": 1,
+				"memoryMb": 1,
+			},
+			sous.Resources{
+				"cpu":    "1",
+				"ports":  "1",
+				"memory": "1",
+			},
+		},
+	}
+
+	for i, test := range tests {
+		input := test.Singularity
+		expected := test.Sous
+
+		actual := input.SousResources()
+		if !actual.Equal(expected) {
+			t.Errorf("got resources %# v; want %# v; for input %d %# v",
+				actual, expected, i, input)
+		}
+	}
+
+}


### PR DESCRIPTION
This maps Singularity resource names, as found in OTPL deploy configuration into Sous resource names. The sous resource names are probably less clear than the singularity names [1], however updating those would be a bit more disruptive than just mapping this correctly for now.


[1] From comment I made on private issue tracker:
>Actually, in Sous proper, we should probably have used "numPorts" instead of "ports", as that is used in the Mesos ecosystem to mean a list of specific ports rather than a request for a number of ports assigned by the platform. However, I will refrain from making that change as it would be pretty disruptive.

> Likewise, "memoryMb" is an easier ask than simply "memory", because it has a unit all we need is a float to represent it. "memory" on the other hand has no unit, and so we can either presume bytes (which aren't nice for hand-editing manifests) or make it a string with a unit. Not doing this now, but I favour the simple "memoryMb" option with no unit in the value. This field already represents MB, so that means the only change needed is to update the name of the string. All this is for the future, for now, doing the quick thing. cc Judson Lester Lars Lehtonen