### PR TITLE
sous init help fix

### DIFF
--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -29,7 +29,10 @@ usage: sous init
 Sous init uses contextual information from your current source code tree and
 repository to generate a basic configuration for that project. You will need to
 flesh out some additional details.
-`
+
+init must be invoked in the root of a git repository with configured remotes.
+
+init will register the project on every known server.`
 
 // Help returns the help string for this command
 func (si *SousInit) Help() string { return sousInitHelp }

--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -30,7 +30,8 @@ Sous init uses contextual information from your current source code tree and
 repository to generate a basic configuration for that project. You will need to
 flesh out some additional details.
 
-init must be invoked in the root of a git repository with configured remotes.
+init must be invoked in a git repository that has either an 'upstream' or 
+'origin' remote configured.
 
 init will register the project on every known server.`
 

--- a/graph/sourcecontext_test.go
+++ b/graph/sourcecontext_test.go
@@ -14,8 +14,8 @@ type resolveSourceLocationInput struct {
 }
 
 func TestResolveSourceLocation_failure(t *testing.T) {
-	assertSourceContextError(t, &sous.ResolveFilter{}, &SourceContextDiscovery{}, "no repo specified, please use -repo or run sous inside a git repo")
-	assertSourceContextError(t, nil, &SourceContextDiscovery{}, "no repo specified, please use -repo or run sous inside a git repo")
+	assertSourceContextError(t, &sous.ResolveFilter{}, &SourceContextDiscovery{}, "no repo specified, please use -repo or run sous inside a git repo with a configured remote")
+	assertSourceContextError(t, nil, &SourceContextDiscovery{}, "no repo specified, please use -repo or run sous inside a git repo with a configured remote")
 	assertSourceContextError(t,
 		&sous.ResolveFilter{Offset: "some/offset"},
 		&SourceContextDiscovery{},

--- a/graph/targetmanifest.go
+++ b/graph/targetmanifest.go
@@ -23,7 +23,7 @@ func newTargetManifestID(f *sous.ResolveFilter, discovered *SourceContextDiscove
 		offset = f.Offset
 	}
 	if repo == "" {
-		return TargetManifestID{}, errors.Errorf("no repo specified, please use -repo or run sous inside a git repo")
+		return TargetManifestID{}, errors.Errorf("no repo specified, please use -repo or run sous inside a git repo with a configured remote")
 	}
 	return TargetManifestID{
 		Source: sous.SourceLocation{


### PR DESCRIPTION
This more completely explains the requirements to run sous init. Previously it was not explained that the current working directory must not only contain a git repository, but a git repository with configured remotes.