### PR TITLE
Changes to Git configuration lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ For contribution guidelines, see [here](./doc/contributions.md).
 
 [View documentation in the doc/ directory.](https://github.com/opentable/sous/tree/master/doc)
 
+
 # Using Sous
 
 If you're looking to get started using Sous

--- a/ext/storage/git_state_manager.go
+++ b/ext/storage/git_state_manager.go
@@ -36,7 +36,14 @@ func (gsm *GitStateManager) git(cmd ...string) error {
 	}
 	git := exec.Command(`git`, cmd...)
 	git.Dir = gsm.DiskStateManager.BaseDir
-	//git.Env = []string{"GIT_CONFIG_NOSYSTEM=true", "HOME=none", "XDG_CONFIG_HOME=none"}
+
+	// This had been commented out, with a comment to the effect that it was fixing a bug.
+	// However, it could lead to come confusion because the behavior of Sous
+	// server would change based on the configuration of git outside of the GDM
+	// repo.
+	// It's also definitely causing problems in testing for me (JL) because my
+	// local git configuration effects testing behaviors.
+	git.Env = []string{"GIT_CONFIG_NOSYSTEM=true", "HOME=none", "XDG_CONFIG_HOME=none"}
 	out, err := git.CombinedOutput()
 	if err == nil {
 		sous.Log.Debug.Printf("%+v: success", git.Args)

--- a/ext/storage/git_state_manager_test.go
+++ b/ext/storage/git_state_manager_test.go
@@ -95,6 +95,7 @@ func setupManagers(t *testing.T) (*GitStateManager, *DiskStateManager) {
 	git config --local receive.denyCurrentBranch ignore
 	git config user.email sous@opentable.com
 	git config user.name Sous
+	git config user.signingkey ""
 	git commit -m ""`, `testdata/origin`)
 	runScript(t, `git clone origin target`, `testdata`)
 	runScript(t, `git config user.email sous@opentable.com


### PR DESCRIPTION
Sketchy quickfix which should now be (properly) handled by our sous-server
wrapper conflicting with my git config in testing