### PR TITLE
Fixes a DI oversight in `sous query artifacts`

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -153,6 +153,13 @@ func TestInvokeQuery(t *testing.T) {
 	assert.NotNil(exe)
 }
 
+func TestInvokeQueryArtifacts(t *testing.T) {
+	assert := assert.New(t)
+
+	exe := justCommand(t, []string{`sous`, `query`, `artifacts`})
+	assert.NotNil(exe)
+}
+
 func TestInvokeMetadataGet(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -281,21 +288,8 @@ options:
     	source code relative repository offset
   -repo string
     	source code repository location
-
-func TestInvokeQueryArtifacts(t *testing.T) {
-	assert := assert.New(t)
-
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-
-	c, err := NewSousCLI(semv.MustParse(`1.2.3`), stdout, stderr)
-	assert.NoError(err)
-
-	exe, err := c.Prepare([]string{`sous`, `query`, `artifacts`})
-	assert.NoError(err)
-	assert.NotNil(exe)
-}
 */
+
 func TestInvokeWithUnknownFlags(t *testing.T) {
 	log.SetFlags(log.Flags() | log.Lshortfile)
 	assert := assert.New(t)

--- a/cli/sous_query_artifacts.go
+++ b/cli/sous_query_artifacts.go
@@ -20,6 +20,10 @@ Note that Sous may discover more images after attempting a rectify
 
 `
 
+func (*SousQueryArtifacts) RegisterOn(psy Addable) {
+	psy.Add(graph.DryrunNeither)
+}
+
 // Help prints the help
 func (*SousQueryArtifacts) Help() string { return sousQueryArtifactsHelp }
 

--- a/cli/sous_server_test.go
+++ b/cli/sous_server_test.go
@@ -43,25 +43,22 @@ func TestEnsureGDMExists(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create the empty source repo.
-	c := exec.Command("git", "init")
-	c.Dir = gdmSourceRepo
-	if err := c.Run(); err != nil {
-		t.Fatal(err)
+	git := func(args ...string) {
+		c := exec.Command("git", args...)
+		c.Dir = gdmSourceRepo
+		if err := c.Run(); err != nil {
+			t.Fatal(err)
+		}
 	}
+
+	// Create the empty source repo.
+	git("init")
+	git("config", "commit.gpgSign", "false")
 	if err := ioutil.WriteFile(path.Join(gdmSourceRepo, "a-file"), []byte("hi"), 0777); err != nil {
 		t.Fatal(err)
 	}
-	c = exec.Command("git", "add", "-A")
-	c.Dir = gdmSourceRepo
-	if err := c.Run(); err != nil {
-		t.Fatal(err)
-	}
-	c = exec.Command("git", "commit", "-m", "a message")
-	c.Dir = gdmSourceRepo
-	if err := c.Run(); err != nil {
-		t.Fatal(err)
-	}
+	git("add", "-A")
+	git("commit", "-m", "a message")
 
 	// SourceLocation dir does not exist; repo does.
 	if err := ensureGDMExists(gdmSourceRepo, nonexistentSourceLocation, t.Logf); err != nil {


### PR DESCRIPTION
When the DryRunOption was added, `sous query artifacts` got missed. I found a
test that had been commented out from before that time, which is probably why
we had this issue.

DryRunOption became an input to the (docker) Registry injection - in certain
circumstances, a dummy registry gets injected. Because `s q a` doesn't update
the registry, I'm simply injecting a fixed "DryRunNeither" so that a live
registry client becomes available.

Along with this change, I ran across a couple of other places where local git
configuration impacted testing. Tried a different approach to addressing that.
Not sure which I like better.