### PR TITLE
"sous help metadata" fixes

### DIFF
--- a/cli/sous_metadata.go
+++ b/cli/sous_metadata.go
@@ -8,8 +8,15 @@ var MetadataSubcommands = cmdr.Commands{}
 
 func init() { TopLevelCommands["metadata"] = &SousMetadata{} }
 
-const sousMetadataHelp = `
-query and manipulate deployment metadata
+const sousMetadataHelp = `query and manipulate deployment metadata
+
+The "sous metadata" command is an alternate means of configuring and
+viewing the subset of "metadata" values that can also be manipulated 
+by the "sous manifest" command.
+
+Metadata values do not change any behaviors in Sous. They exist to store 
+data needed for software that depends on the Sous server API, such as 
+build systems.
 `
 
 func (SousMetadata) Subcommands() cmdr.Commands {

--- a/cli/sous_metadata_get.go
+++ b/cli/sous_metadata_get.go
@@ -25,7 +25,7 @@ func init() { MetadataSubcommands["get"] = &SousMetadataGet{} }
 
 const sousMetadataGetHelp = `query deployment metadata`
 
-func (*SousMetadataGet) Help() string { return sousMetadataHelp }
+func (*SousMetadataGet) Help() string { return sousMetadataGetHelp }
 
 func (smg *SousMetadataGet) AddFlags(fs *flag.FlagSet) {
 	MustAddFlags(fs, &smg.DeployFilterFlags, MetadataFilterFlagsHelp)

--- a/cli/sous_metadata_set.go
+++ b/cli/sous_metadata_set.go
@@ -20,11 +20,9 @@ type SousMetadataSet struct {
 
 func init() { MetadataSubcommands["set"] = &SousMetadataSet{} }
 
-const sousMetadataSetHelp = `
-set deployment metadata
-`
+const sousMetadataSetHelp = `set deployment metadata`
 
-func (*SousMetadataSet) Help() string { return sousMetadataHelp }
+func (*SousMetadataSet) Help() string { return sousMetadataSetHelp }
 
 func (smg *SousMetadataSet) AddFlags(fs *flag.FlagSet) {
 	MustAddFlags(fs, &smg.DeployFilterFlags, MetadataFilterFlagsHelp)


### PR DESCRIPTION
Added more help text to the "sous metadata" command. Fixed the bugs that kept "sous help metadata get" and "sous help metadata set" help text from printing.