### PR TITLE
Removed unused AddGlobalFlagSetFunc() from cmdr

### DIFF
--- a/util/cmdr/cli.go
+++ b/util/cmdr/cli.go
@@ -78,12 +78,6 @@ func (c *CLI) init() {
 	c.Err.SetIndentStyle(indentString)
 }
 
-// AddGlobalFlagSetFunc adds a new function for adding flags to the global flag
-// set.
-func (c *CLI) AddGlobalFlagSetFunc(f func(*flag.FlagSet)) {
-	c.GlobalFlagSetFuncs = append(c.GlobalFlagSetFuncs, f)
-}
-
 // Invoke begins invoking the CLI starting with the base command, and handles
 // all command output. It then returns the result for further processing.
 func (c *CLI) Invoke(args []string) Result {


### PR DESCRIPTION
I didn't see this being used anywhere, and my local cmdr tests pass without it. This should be an easy merge so long as Travis has no complaints.