### PR TITLE
Status endpoint3

### DIFF
--- a/cli/sous_server.go
+++ b/cli/sous_server.go
@@ -69,7 +69,7 @@ func (ss *SousServer) Execute(args []string) cmdr.Result {
 	ss.Log.Info.Println("Starting scheduled GDM resolution.")
 	ss.AutoResolver.Kickoff()
 	ss.Log.Info.Printf("Sous Server v%s running at %s", ss.Sous.Version, ss.flags.laddr)
-	return EnsureErrorResult(server.RunServer(ss.Verbosity, ss.flags.laddr)) //always non-nil
+	return EnsureErrorResult(server.RunServer(ss.Verbosity, ss.flags.laddr, ss.AutoResolver)) //always non-nil
 }
 
 func ensureGDMExists(repo, localPath string, log func(string, ...interface{})) error {

--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -251,18 +251,20 @@ func TestDeletes(t *testing.T) {
 	}
 
 	dels := make(chan *sous.Deployable, 1)
-	errs := make(chan sous.DiffResolution, 10)
+	log := make(chan sous.DiffResolution, 10)
 
 	client := sous.NewDummyRectificationClient()
 	deployer := NewDeployer(client)
 
 	dels <- deleted
 	close(dels)
-	deployer.RectifyDeletes(dels, errs)
-	close(errs)
+	deployer.RectifyDeletes(dels, log)
+	close(log)
 
-	for e := range errs {
-		t.Error(e)
+	for e := range log {
+		if e.Error != nil {
+			t.Error(e)
+		}
 	}
 
 	assert.Len(client.Deployed, 0)

--- a/lib/auto_resolver.go
+++ b/lib/auto_resolver.go
@@ -1,6 +1,7 @@
 package sous
 
 import (
+	"sync"
 	"time"
 )
 
@@ -22,6 +23,8 @@ type (
 		*Resolver
 		*LogSet
 		listeners []autoResolveListener
+		sync.RWMutex
+		status *ResolveStatus
 	}
 )
 
@@ -86,6 +89,13 @@ func (ar *AutoResolver) Kickoff() TriggerChannel {
 	return done
 }
 
+// Status returns the current status of the resolution underway.
+func (ar *AutoResolver) Status() *ResolveStatus {
+	ar.RLock()
+	defer ar.RUnlock()
+	return ar.status
+}
+
 func loopTilDone(f func(), done TriggerChannel) {
 	for {
 		select {
@@ -95,6 +105,12 @@ func loopTilDone(f func(), done TriggerChannel) {
 			return
 		}
 	}
+}
+
+func (ar *AutoResolver) write(f func()) {
+	ar.Lock()
+	defer ar.Unlock()
+	f()
 }
 
 func (ar *AutoResolver) resolveLoop(tc, done TriggerChannel, ac announceChannel) {
@@ -121,7 +137,10 @@ func (ar *AutoResolver) resolveLoop(tc, done TriggerChannel, ac announceChannel)
 				break
 			}
 
-			ac <- ar.Resolver.Begin(gdm, state.Defs.Clusters).Wait()
+			ar.write(func() {
+				ar.status = ar.Resolver.Begin(gdm, state.Defs.Clusters)
+			})
+			ac <- ar.status.Wait()
 			ar.LogSet.Debug.Print("Completed resolve")
 		case <-done:
 			return

--- a/lib/deployer.go
+++ b/lib/deployer.go
@@ -5,9 +5,9 @@ type (
 	// read, update, and delete deployments.
 	Deployer interface {
 		RunningDeployments(reg Registry, from Clusters) (Deployments, error)
-		RectifyCreates(<-chan *Deployable, chan<- error)
-		RectifyDeletes(<-chan *Deployable, chan<- error)
-		RectifyModifies(<-chan *DeployablePair, chan<- error)
+		RectifyCreates(<-chan *Deployable, chan<- DiffResolution)
+		RectifyDeletes(<-chan *Deployable, chan<- DiffResolution)
+		RectifyModifies(<-chan *DeployablePair, chan<- DiffResolution)
 	}
 
 	// DummyDeployer is a noop deployer.
@@ -27,10 +27,10 @@ func (dd *DummyDeployer) RunningDeployments(reg Registry, from Clusters) (Deploy
 }
 
 // RectifyCreates implements Deployer
-func (dd *DummyDeployer) RectifyCreates(<-chan *Deployable, chan<- error) {}
+func (dd *DummyDeployer) RectifyCreates(<-chan *Deployable, chan<- DiffResolution) {}
 
 // RectifyDeletes implements Deployer
-func (dd *DummyDeployer) RectifyDeletes(<-chan *Deployable, chan<- error) {}
+func (dd *DummyDeployer) RectifyDeletes(<-chan *Deployable, chan<- DiffResolution) {}
 
 // RectifyModifies implements Deployer
-func (dd *DummyDeployer) RectifyModifies(<-chan *DeployablePair, chan<- error) {}
+func (dd *DummyDeployer) RectifyModifies(<-chan *DeployablePair, chan<- DiffResolution) {}

--- a/lib/name_resolver.go
+++ b/lib/name_resolver.go
@@ -11,6 +11,7 @@ type (
 	DeployableChans struct {
 		Start, Stop, Stable chan *Deployable
 		Update              chan *DeployablePair
+		sync.WaitGroup
 	}
 
 	// A DeployablePair is a pair of deployables, describing a "before and after"
@@ -78,14 +79,13 @@ func (dp *DeployablePair) ID() DeployID {
 
 // ResolveNames resolves diffs.
 func (dc *DeployableChans) ResolveNames(r Registry, diff *DiffChans, errs chan error) {
-	wg := sync.WaitGroup{}
-	wg.Add(4)
-	go resolveSingles(r, diff.Created, dc.Start, errs)
-	go unresolvedSingles(r, diff.Deleted, dc.Stop, errs)
-	go unresolvedSingles(r, diff.Retained, dc.Stable, errs)
-	go resolvePairs(r, diff.Modified, dc.Update, errs)
-	wg.Wait()
-	close(errs)
+	dc.WaitGroup = sync.WaitGroup{}
+	dc.Add(4)
+	go func() { resolveSingles(r, diff.Created, dc.Start, errs); dc.Done() }()
+	go func() { unresolvedSingles(r, diff.Deleted, dc.Stop, errs); dc.Done() }()
+	go func() { unresolvedSingles(r, diff.Retained, dc.Stable, errs); dc.Done() }()
+	go func() { resolvePairs(r, diff.Modified, dc.Update, errs); dc.Done() }()
+	go func() { dc.Wait(); close(errs) }()
 }
 
 func unresolvedSingles(r Registry, from chan *Deployment, to chan *Deployable, errs chan error) {

--- a/lib/resolvestatus.go
+++ b/lib/resolvestatus.go
@@ -21,6 +21,7 @@ type ResolveStatus struct {
 // DiffResolution is the result of applying a single diff.
 type DiffResolution struct {
 	DeployID DeployID
+	Desc     string
 	Error    error
 }
 
@@ -29,7 +30,6 @@ type DiffResolution struct {
 func NewResolveStatus(f func(*ResolveStatus)) *ResolveStatus {
 	rs := &ResolveStatus{
 		Log:      make(chan DiffResolution, 1e6),
-		Errors:   make(chan error, 1e6),
 		finished: make(chan struct{}),
 	}
 	go func() {

--- a/lib/resolvestatus_test.go
+++ b/lib/resolvestatus_test.go
@@ -81,8 +81,6 @@ func TestResolveStatus(t *testing.T) {
 				}
 			}
 
-			close(rs.Errors) // This is usually done by the rectify function.
-
 			<-block // Wait for signal from the test that this func may finish.
 		})
 
@@ -119,14 +117,6 @@ func TestResolveStatus(t *testing.T) {
 			if !strings.HasSuffix(actual, expected) {
 				t.Errorf("final phase == %q; want suffix %q", actual, expected)
 			}
-		}
-
-		if _, errorsOpen := <-rs.Errors; errorsOpen {
-			t.Errorf("Errors channel not closed")
-		}
-
-		if _, logOpen := <-rs.Log; logOpen {
-			t.Errorf("Log channel not closed")
 		}
 	}
 }

--- a/server/handle_status.go
+++ b/server/handle_status.go
@@ -1,17 +1,26 @@
 package server
 
+import (
+	"net/http"
+
+	"github.com/opentable/sous/lib"
+)
+
 type (
 	// StatusResource encapsulates a status response.
 	StatusResource struct{}
 
 	// StatusHandler handles requests for status.
-	StatusHandler struct{}
+	StatusHandler struct {
+		AutoResolver *sous.AutoResolver
+	}
 )
 
 // Get implements Getable on StatusResource.
-func (gr *StatusResource) Get() Exchanger { return &StatusHandler{} }
+func (*StatusResource) Get() Exchanger { return &StatusHandler{} }
 
-// Exchange implements the Handler interface
+// Exchange implements the Handler interface.
 func (h *StatusHandler) Exchange() (interface{}, int) {
-	return nil, 404
+	status := h.AutoResolver.Status()
+	return status, http.StatusOK
 }

--- a/server/server.go
+++ b/server/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/opentable/sous/config"
 	"github.com/opentable/sous/graph"
+	"github.com/opentable/sous/lib"
 )
 
 // New creates a Sous HTTP server.
@@ -18,10 +19,11 @@ func New(laddr string, gf GraphFactory) *http.Server {
 }
 
 // RunServer starts a server up.
-func RunServer(v *config.Verbosity, laddr string) error {
+func RunServer(v *config.Verbosity, laddr string, ar *sous.AutoResolver) error {
 	gf := func() Injector {
 		g := graph.BuildGraph(&bytes.Buffer{}, os.Stdout, os.Stdout)
 		g.Add(v)
+		g.Add(ar)
 		return g
 	}
 	s := New(laddr, gf)


### PR DESCRIPTION
Includes #269

Makes the result of `AutoResolver.Status()` available in the server at `/status`.

Next step is to make the list of actions taken so far in `ResolveStatus.Log` available to the `/status` endpoint.