### PR TITLE
Remove simple cmdr func aliases from cli package.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -16,14 +16,7 @@ import (
 
 // Func aliases, for convenience returning from commands.
 var (
-	SuccessData    = cmdr.SuccessData
-	Successf       = cmdr.Successf
-	Success        = cmdr.Success
-	UsageErrorf    = cmdr.UsageErrorf
-	OSErrorf       = cmdr.OSErrorf
-	IOErrorf       = cmdr.IOErrorf
-	InternalErrorf = cmdr.InternalErrorf
-	GeneralErrorf  = func(format string, a ...interface{}) cmdr.ErrorResult {
+	GeneralErrorf = func(format string, a ...interface{}) cmdr.ErrorResult {
 		return EnsureErrorResult(fmt.Errorf(format, a...))
 	}
 	EnsureErrorResult = func(err error) cmdr.ErrorResult {
@@ -38,7 +31,7 @@ func ProduceResult(err error) cmdr.Result {
 		return EnsureErrorResult(err)
 	}
 
-	return Success()
+	return cmdr.Success()
 }
 
 type (
@@ -63,9 +56,9 @@ type (
 func SuccessYAML(v interface{}) cmdr.Result {
 	b, err := yaml.Marshal(v)
 	if err != nil {
-		return InternalErrorf("unable to marshal YAML: %s", err)
+		return cmdr.InternalErrorf("unable to marshal YAML: %s", err)
 	}
-	return SuccessData(b)
+	return cmdr.SuccessData(b)
 }
 
 // Plumbing injects a command with the current psyringe,

--- a/cli/sous.go
+++ b/cli/sous.go
@@ -85,11 +85,11 @@ func (s *Sous) Execute(args []string) cmdr.Result {
 	if !ok {
 		return s.usage()
 	}
-	return UsageErrorf(whitespace.Trim(success.String()) + "\n")
+	return cmdr.UsageErrorf(whitespace.Trim(success.String()) + "\n")
 }
 
 func (s *Sous) usage() cmdr.ErrorResult {
-	err := UsageErrorf("usage: sous [options] command")
+	err := cmdr.UsageErrorf("usage: sous [options] command")
 	err.Tip = "try `sous help` for a list of commands"
 	return err
 }

--- a/cli/sous_build.go
+++ b/cli/sous_build.go
@@ -65,5 +65,5 @@ func (sb *SousBuild) Execute(args []string) cmdr.Result {
 	if err != nil {
 		return cmdr.EnsureErrorResult(err)
 	}
-	return Success(result)
+	return cmdr.Success(result)
 }

--- a/cli/sous_config.go
+++ b/cli/sous_config.go
@@ -30,21 +30,21 @@ func (sc *SousConfig) Execute(args []string) cmdr.Result {
 	c := graph.LocalSousConfig{Config: sc.Config.Config}
 	switch len(args) {
 	default:
-		return UsageErrorf("expected 0-2 arguments, received %d", len(args))
+		return cmdr.UsageErrorf("expected 0-2 arguments, received %d", len(args))
 	case 0:
-		return Successf(c.String())
+		return cmdr.Successf(c.String())
 	case 1:
 		name := args[0]
 		v, err := c.GetValue(name)
 		if err != nil {
-			return UsageErrorf("%s", err)
+			return cmdr.UsageErrorf("%s", err)
 		}
-		return Successf(v)
+		return cmdr.Successf(v)
 	case 2:
 		name, value := args[0], args[1]
 		if err := c.SetValue(sc.User.ConfigFile(), name, value); err != nil {
 			return EnsureErrorResult(err)
 		}
-		return Successf("set %s to %q", name, value)
+		return cmdr.Successf("set %s to %q", name, value)
 	}
 }

--- a/cli/sous_deploy.go
+++ b/cli/sous_deploy.go
@@ -63,7 +63,7 @@ func (sd *SousDeploy) Execute(args []string) cmdr.Result {
 	}
 
 	if sd.Config.Server != "" {
-		return Successf("Deployment instigated; handed off to server.")
+		return cmdr.Successf("Deployment instigated; handed off to server.")
 	}
 
 	// Running serverless, so run rectify.

--- a/cli/sous_help.go
+++ b/cli/sous_help.go
@@ -30,5 +30,5 @@ func (sh *SousHelp) Execute(args []string) cmdr.Result {
 	if err != nil {
 		return EnsureErrorResult(err)
 	}
-	return Successf(help)
+	return cmdr.Successf(help)
 }

--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -58,7 +58,7 @@ func (si *SousInit) Execute(args []string) cmdr.Result {
 	cluster := si.DeployFilterFlags.Cluster
 
 	if _, ok := si.State.Defs.Clusters[cluster]; !ok && cluster != "" {
-		return UsageErrorf("cluster %q not defined, pick one of: %s", cluster, si.State.Defs.Clusters)
+		return cmdr.UsageErrorf("cluster %q not defined, pick one of: %s", cluster, si.State.Defs.Clusters)
 	}
 
 	m := si.Target.Manifest
@@ -68,7 +68,7 @@ func (si *SousInit) Execute(args []string) cmdr.Result {
 	}
 
 	if ok := si.State.Manifests.Add(m); !ok {
-		return UsageErrorf("manifest %q already exists", m.ID())
+		return cmdr.UsageErrorf("manifest %q already exists", m.ID())
 	}
 	if err := si.StateWriter.WriteState(si.State); err != nil {
 		return EnsureErrorResult(err)

--- a/cli/sous_manifest.go
+++ b/cli/sous_manifest.go
@@ -17,7 +17,7 @@ func (SousManifest) Subcommands() cmdr.Commands {
 func (*SousManifest) Help() string { return sousManifestHelp }
 
 func (sm *SousManifest) Execute(args []string) cmdr.Result {
-	err := UsageErrorf("usage: sous manifest [options] <command>")
+	err := cmdr.UsageErrorf("usage: sous manifest [options] <command>")
 	err.Tip = "try `sous manifest help` for a list of commands"
 	return err
 }

--- a/cli/sous_manifest_get.go
+++ b/cli/sous_manifest_get.go
@@ -46,5 +46,5 @@ func (smg *SousManifestGet) Execute(args []string) cmdr.Result {
 		return EnsureErrorResult(err)
 	}
 	smg.OutWriter.Write(yml)
-	return Success()
+	return cmdr.Success()
 }

--- a/cli/sous_manifest_set.go
+++ b/cli/sous_manifest_set.go
@@ -62,5 +62,5 @@ func (smg *SousManifestSet) Execute(args []string) cmdr.Result {
 		return EnsureErrorResult(err)
 	}
 
-	return Success()
+	return cmdr.Success()
 }

--- a/cli/sous_metadata.go
+++ b/cli/sous_metadata.go
@@ -26,7 +26,7 @@ func (SousMetadata) Subcommands() cmdr.Commands {
 func (*SousMetadata) Help() string { return sousMetadataHelp }
 
 func (sm *SousMetadata) Execute(args []string) cmdr.Result {
-	err := UsageErrorf("usage: sous metadata [options] <command>")
+	err := cmdr.UsageErrorf("usage: sous metadata [options] <command>")
 	err.Tip = "try `sous help metadata` for a list of commands"
 	return err
 }

--- a/cli/sous_metadata_get.go
+++ b/cli/sous_metadata_get.go
@@ -51,7 +51,7 @@ func (smg *SousMetadataGet) Execute(args []string) cmdr.Result {
 		if err := outputMetadata(dep.Metadata, smg.ResolveFilter.Cluster, args, smg.OutWriter); err != nil {
 			return EnsureErrorResult(err)
 		}
-		return Success()
+		return cmdr.Success()
 	}
 
 	manis, err := filtered.Manifests(smg.State.Defs)
@@ -73,7 +73,7 @@ func (smg *SousMetadataGet) Execute(args []string) cmdr.Result {
 		}
 	}
 
-	return Success()
+	return cmdr.Success()
 }
 
 func outputMetadata(metadata sous.Metadata, clusterName string, args []string, out io.Writer) error {

--- a/cli/sous_metadata_set.go
+++ b/cli/sous_metadata_set.go
@@ -59,5 +59,5 @@ func (smg *SousMetadataSet) Execute(args []string) cmdr.Result {
 		return EnsureErrorResult(err)
 	}
 
-	return Success()
+	return cmdr.Success()
 }

--- a/cli/sous_query.go
+++ b/cli/sous_query.go
@@ -30,7 +30,7 @@ func (SousQuery) Subcommands() cmdr.Commands {
 }
 
 func (sb *SousQuery) Execute(args []string) cmdr.Result {
-	err := UsageErrorf("usage: sous query [options] command")
+	err := cmdr.UsageErrorf("usage: sous query [options] command")
 	err.Tip = "try `sous help query` for a list of commands"
 	return err
 }

--- a/cli/sous_query_ads.go
+++ b/cli/sous_query_ads.go
@@ -40,5 +40,5 @@ func (sb *SousQueryAds) Execute(args []string) cmdr.Result {
 		return EnsureErrorResult(err)
 	}
 	sous.DumpDeployments(os.Stdout, ads)
-	return Success()
+	return cmdr.Success()
 }

--- a/cli/sous_query_gdm.go
+++ b/cli/sous_query_gdm.go
@@ -36,5 +36,5 @@ func (*SousQueryGDM) RegisterOn(psy Addable) {
 func (sb *SousQueryGDM) Execute(args []string) cmdr.Result {
 	sous.Log.Vomit.Printf("%v", sb.GDM.Snapshot())
 	sous.DumpDeployments(os.Stdout, sb.GDM.Deployments)
-	return Success()
+	return cmdr.Success()
 }

--- a/cli/sous_rectify.go
+++ b/cli/sous_rectify.go
@@ -67,11 +67,11 @@ func (sr *SousRectify) RegisterOn(psy Addable) {
 // Execute fulfils the cmdr.Executor interface.
 func (sr *SousRectify) Execute(args []string) cmdr.Result {
 	if sr.Config.Server != "" {
-		return UsageErrorf("rectify is deprecated; the server at %s handles rectification.\n"+
+		return cmdr.UsageErrorf("rectify is deprecated; the server at %s handles rectification.\n"+
 			`If you really want to run rectification locally, unset config.server: 'sous config server ""'`, sr.Config.Server)
 	}
 	if !sr.SourceFlags.All && sr.Resolver.ResolveFilter.All() {
-		return UsageErrorf("Please specify what to rectify using the -repo tag.\n" +
+		return cmdr.UsageErrorf("Please specify what to rectify using the -repo tag.\n" +
 			"(Or -all if you really mean to rectify the whole world; see 'sous help rectify'.)")
 	}
 
@@ -79,5 +79,5 @@ func (sr *SousRectify) Execute(args []string) cmdr.Result {
 		return EnsureErrorResult(err)
 	}
 
-	return Success()
+	return cmdr.Success()
 }

--- a/cli/sous_update.go
+++ b/cli/sous_update.go
@@ -83,7 +83,7 @@ func (su *SousUpdate) Execute(args []string) cmdr.Result {
 	if err := su.StateWriter.WriteState(su.State); err != nil {
 		return EnsureErrorResult(err)
 	}
-	return Success()
+	return cmdr.Success()
 }
 
 func updateState(s *sous.State, gdm graph.CurrentGDM, sid sous.SourceID, did sous.DeployID) error {
@@ -110,14 +110,14 @@ func updateState(s *sous.State, gdm graph.CurrentGDM, sid sous.SourceID, did sou
 func getIDs(flags config.DeployFilterFlags, mid sous.ManifestID) (sous.SourceID, sous.DeployID, error) {
 	clusterName, tag, sid, did := flags.Cluster, flags.Tag, sous.SourceID{}, sous.DeployID{}
 	if clusterName == "" {
-		return sid, did, UsageErrorf("You must select a cluster using the -cluster flag.")
+		return sid, did, cmdr.UsageErrorf("You must select a cluster using the -cluster flag.")
 	}
 	if tag == "" {
-		return sid, did, UsageErrorf("You must provide the -tag flag.")
+		return sid, did, cmdr.UsageErrorf("You must provide the -tag flag.")
 	}
 	newVersion, err := semv.Parse(tag)
 	if err != nil {
-		return sid, did, UsageErrorf("Version %q not valid: %s", flags.Tag, err)
+		return sid, did, cmdr.UsageErrorf("Version %q not valid: %s", flags.Tag, err)
 	}
 	sid = mid.Source.SourceID(newVersion)
 	did = sous.DeployID{ManifestID: mid, Cluster: clusterName}

--- a/cli/sous_version.go
+++ b/cli/sous_version.go
@@ -22,5 +22,5 @@ func (*SousVersion) Help() string { return sousVersionHelp }
 func (sv *SousVersion) Execute(args []string) cmdr.Result {
 	out := `sous version %s (%s %s/%s)`
 	s := sv.Sous
-	return Successf(out, s.Version, s.GoVersion, s.OS, s.Arch)
+	return cmdr.Successf(out, s.Version, s.GoVersion, s.OS, s.Arch)
 }


### PR DESCRIPTION
Aliasing cmdr functions in the cli package have made it more confusing for me to reason about the boundaries between the two.

This PR removes the func aliases (some were going unused) and changes the appearances of cmdr functions within the cli package to be represented more explicitly.

This has been valuable for me just as an exercise. I think it will help things for me and others approaching this codebase in the future, but I am aware that this may be more style than substance. I'm happy to answer any questions, but this PR is the sum of my argument. If this change is problematic feel free to close the ticket.