### PR TITLE
Remove unparsed extended help text

### DIFF
--- a/cli/add_flags_test.go
+++ b/cli/add_flags_test.go
@@ -11,16 +11,16 @@ import (
 
 func TestAddFlagsForRectify(t *testing.T) {
 	expectedHelpText := `
-	-all
-				all deployments should be considered
-	-cluster string
-				target deployment cluster
-	-flavor string
-				flavor is a short string used to differentiate alternative deployments
-	-offset string
-				source code relative repository offset
-	-repo string
-				source code repository location
+  -all
+        all deployments should be considered
+  -cluster string
+        the deployment environment to consider
+  -flavor string
+        flavor is a short string used to differentiate alternative deployments
+  -offset string
+        source code relative repository offset
+  -repo string
+        source code repository location
 `
 
 	fs := flag.NewFlagSet("rectify", flag.ContinueOnError)
@@ -91,7 +91,7 @@ func TestAddFlags(t *testing.T) {
   -repo string
         source code repository location
   -revision string
-        source code revision ID
+        the ID of a revision in the repository to act upon
   -tag string
         source code revision tag
 `

--- a/cli/deploy_filter_flags.go
+++ b/cli/deploy_filter_flags.go
@@ -3,109 +3,35 @@ package cli
 const (
 	sourceFlagHelp = `
 	-source
-		source code location (alternative to -repo and -offset combination)
+		source code location (alternative to -repo and -offset combination)`
 
-		The source flag allows you to specify your source code location as a
-		single string, rather than passing -repo and -offet separately. It's
-		designed for humans using Sous, whereas -repo and -offset may be handy
-		for scripting contexts. If your source code is in the repository root,
-		all you need is to pass the repository name, e.g.:
-
-		    -source github.com/user/repo
-
-		If you need to specify an offset, just insert a comma between the repo
-		and the offset, e.g.:
-
-			-source github.com/user/repo,some/offset/dir
-
-		It is recommended to use -source when possible, in preference to -repo
-		and -offset, as -source also checks that Sous is able to handle the
-		passed source location from end to end.
-
-		Currently -source only supports GitHub repositories.
-
-	`
 	repoFlagHelp = `
 	-repo REPOSITORY_NAME
-		source code repository location
+		source code repository location`
 
-		The repository context is the name of a source code repository whose
-		code, configuration, artifacts, deployments, etc. will be acted upon.
-		If sous is run from inside a Git repository, and this flag is not
-		provided, repo will be constructed based on the git-configured fetch URL
-		of any remote named "upstream" or "origin", in that order.
-
-		Sous uses repository paths of the form <host>/<repo-path>. This enables
-		it to use whichever protocol is most appropriate. The host part of the
-		path is also used to support repository host specific features, like
-		querying an associated HTTP API to help with configuration etc.
-
-		Currently, Sous only has full support for GitHub repositories, e.g.
-
-		    "github.com/user/repo"
-
-		Support for other repository hosts may be added later as needed.
-
-		`
 	offsetFlagHelp = `
 	-offset RELATIVE_PATH
-		source code relative repository offset
+		source code relative repository offset`
 
-		Repository context offset is the relative path within a repository where
-		a piece of software is defined.
-
-		If you are working in a subdirectory of a repository, the default value
-		for offset will be the relative path of the current working directory
-		from the repository root.
-
-		Note: if you supply the -repo flag but not -offset, then -offset
-		defaults to "" (repo root), even if you are inside a subdirectory of the
-		named repo.
-
-		`
 	flavorFlagHelp = `
 	-flavor FLAVOR
-		flavor is a short string used to differentiate alternative deployments
+		flavor is a short string used to differentiate alternative deployments`
 
-		Sometimes it is necessary to have multiple, separately defined
-		deployments of a single piece of software in the same cluster, or set of
-		clusters. In these cases, you can specify multiple deployments by
-		configuring multiple manifests for your source location (repo/offset),
-		differentiated by a short "flavor" string.
-
-		Note that by default, Sous assumes a single manifest per source
-		location. Flavor is an advanced use case, and probably not necessary for
-		most applications.
-
-		`
 	tagFlagHelp = `
 	-tag TAG_NAME
-		source code revision tag
+		source code revision tag`
 
-		Repository tag is the name of a tag in the repository to act upon.
-
-		`
 	revisionFlagHelp = `
 	-revision REVISION_ID
-		source code revision ID
-
-		Revision ID is the ID of a revision in the repository to act upon.
-
-		`
+		the ID of a revision in the repository to act upon`
 
 	clusterFlagHelp = `
 	-cluster CLUSTER
-	  target deployment cluster
-
-		Cluster name is the the deployment environment to consider
-
-		`
+		the deployment environment to consider`
 
 	allFlagHelp = `
 	-all
-	  all deployments should be considered
-
-	  `
+	  all deployments should be considered`
 )
 
 var (

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -19,26 +19,11 @@ var deployFlags = `
 		set deployment context: cluster
 
 	-deployment.dry-run
-		do not make any changes deployments
-		
-		Instead of performing deployment actions on running clusters, just
-		display the actions that would be taken without this flag.
-`
+		do not make any changes deployments`
 
 var buildFlags = `
 	-build.strict
 		fail build if any advisories apply
 
-		Intended to produce production-grade build artifacts.
-
 	-build.force-clone
-		build from a fresh isolated clone
-
-		Force building from a new shallow clone of the source context.
-
-		Usually if building inside a repository using the default context, the
-		code inside the current working directory is built. If you specify a
-		context which does not match the default context, the source identified
-		the context is cloned into your local scratch directory, and built from
-		there.
-`
+		force building from a new shallow clone of the source context.`


### PR DESCRIPTION
This PR removes the unprinted extended help text from the deploy flags. I changed the short description of a couple of flags to use more concise text from the excised long help.