### PR TITLE
Adding /status endpoint

### DIFF
--- a/lib/auto_resolver.go
+++ b/lib/auto_resolver.go
@@ -24,7 +24,7 @@ type (
 		*LogSet
 		listeners []autoResolveListener
 		sync.RWMutex
-		status *ResolveStatus
+		status *ResolveRecorder
 	}
 )
 
@@ -90,7 +90,7 @@ func (ar *AutoResolver) Kickoff() TriggerChannel {
 }
 
 // Status returns the current status of the resolution underway.
-func (ar *AutoResolver) Status() ResolveStatus {
+func (ar *AutoResolver) Status() ResolveRecorder {
 	ar.RLock()
 	defer ar.RUnlock()
 	return *ar.status

--- a/lib/auto_resolver.go
+++ b/lib/auto_resolver.go
@@ -90,10 +90,10 @@ func (ar *AutoResolver) Kickoff() TriggerChannel {
 }
 
 // Status returns the current status of the resolution underway.
-func (ar *AutoResolver) Status() *ResolveStatus {
+func (ar *AutoResolver) Status() ResolveStatus {
 	ar.RLock()
 	defer ar.RUnlock()
-	return ar.status
+	return *ar.status
 }
 
 func loopTilDone(f func(), done TriggerChannel) {

--- a/lib/auto_resolver_test.go
+++ b/lib/auto_resolver_test.go
@@ -39,6 +39,25 @@ func TestDone(t *testing.T) {
 	assert.True(received, "Should have received announcement")
 }
 
+func TestAutoResolver_CurrentStatus(t *testing.T) {
+	assert := assert.New(t)
+	ar := setupAR()
+
+	tc := make(TriggerChannel, 10)
+	ac := make(announceChannel, 1)
+	done := make(TriggerChannel)
+	tc.trigger()
+
+	stable, live := ar.Statuses()
+	assert.Nil(stable)
+	assert.Nil(live)
+
+	ar.resolveLoop(tc, done, ac)
+	stable, live = ar.Statuses()
+	assert.NotNil(stable)
+	assert.NotNil(live)
+}
+
 func TestAfterDone(t *testing.T) {
 	ar := setupAR()
 	ar.UpdateTime = time.Duration(1)

--- a/lib/resolvestatus.go
+++ b/lib/resolvestatus.go
@@ -95,6 +95,7 @@ func (rr *ResolveRecorder) foldErrors(log chan DiffResolution) error {
 	if len(re.Causes) > 0 {
 		return re
 	}
+
 	return nil
 }
 

--- a/lib/resolvestatus.go
+++ b/lib/resolvestatus.go
@@ -7,9 +7,12 @@ import (
 type (
 	// ResolveStatus captures the status of a Resolve
 	ResolveStatus struct {
+		// Phase reports the current phase of resolution
 		Phase string
-		Log   []DiffResolution
-		Errs  ResolveErrors
+		// Log collects the resolution steps that have been performed
+		Log []DiffResolution
+		// Errs collects errors during resolution
+		Errs ResolveErrors
 	}
 
 	// ResolveRecorder represents the status of a resolve run.
@@ -27,9 +30,12 @@ type (
 
 	// DiffResolution is the result of applying a single diff.
 	DiffResolution struct {
-		DeployID DeployID
-		Desc     string
-		Error    error
+		// DeployID is the ID of the deployment being resolved
+		DeployID
+		// Desc describes the difference and its resolution
+		Desc string
+		// Error captures the error (if any) encountered during diff resolution
+		Error error
 	}
 )
 

--- a/lib/resolvestatus_test.go
+++ b/lib/resolvestatus_test.go
@@ -58,17 +58,17 @@ var resolveStatusTests = []struct {
 	},
 }
 
-func TestResolveStatus(t *testing.T) {
+func TestResolveRecorder(t *testing.T) {
 
 	for testNum, test := range resolveStatusTests {
 
-		// block is used to block the func passed to NewResolveStatus from
+		// block is used to block the func passed to NewResolveRecorder from
 		// completing so we can run assertions that need to happen prior to
 		// completion.
 		block := make(chan struct{})
 
 		// Run all the phases in the test in order.
-		rs := NewResolveStatus(func(rs *ResolveStatus) {
+		rs := NewResolveRecorder(func(rs *ResolveRecorder) {
 			for phaseNum, phase := range test.Phases {
 				// Note 1: 1-indexed phase naming.
 				phaseName := fmt.Sprintf("test %d; phase %d", testNum+1, phaseNum+1)

--- a/server/handle_status.go
+++ b/server/handle_status.go
@@ -10,14 +10,17 @@ import (
 type (
 	// StatusResource encapsulates a status response.
 	StatusResource struct {
-		Deployments           []*sous.Deployment
-		Completed, InProgress *sous.ResolveStatus
 	}
 
 	// StatusHandler handles requests for status.
 	StatusHandler struct {
 		GDM          graph.CurrentGDM
 		AutoResolver *sous.AutoResolver
+	}
+
+	statusData struct {
+		Deployments           []*sous.Deployment
+		Completed, InProgress *sous.ResolveStatus
 	}
 )
 
@@ -26,7 +29,7 @@ func (*StatusResource) Get() Exchanger { return &StatusHandler{} }
 
 // Exchange implements the Handler interface.
 func (h *StatusHandler) Exchange() (interface{}, int) {
-	status := StatusResource{Deployments: []*sous.Deployment{}}
+	status := statusData{Deployments: []*sous.Deployment{}}
 	for _, d := range h.GDM.Snapshot() {
 		status.Deployments = append(status.Deployments, d)
 	}

--- a/server/handle_status.go
+++ b/server/handle_status.go
@@ -3,15 +3,20 @@ package server
 import (
 	"net/http"
 
+	"github.com/opentable/sous/graph"
 	"github.com/opentable/sous/lib"
 )
 
 type (
 	// StatusResource encapsulates a status response.
-	StatusResource struct{}
+	StatusResource struct {
+		Deployments           []*sous.Deployment
+		Completed, InProgress *sous.ResolveStatus
+	}
 
 	// StatusHandler handles requests for status.
 	StatusHandler struct {
+		GDM          graph.CurrentGDM
 		AutoResolver *sous.AutoResolver
 	}
 )
@@ -21,6 +26,10 @@ func (*StatusResource) Get() Exchanger { return &StatusHandler{} }
 
 // Exchange implements the Handler interface.
 func (h *StatusHandler) Exchange() (interface{}, int) {
-	status := h.AutoResolver.Status()
+	status := StatusResource{Deployments: []*sous.Deployment{}}
+	for _, d := range h.GDM.Snapshot() {
+		status.Deployments = append(status.Deployments, d)
+	}
+	status.Completed, status.InProgress = h.AutoResolver.Statuses()
 	return status, http.StatusOK
 }

--- a/server/handle_status_test.go
+++ b/server/handle_status_test.go
@@ -19,5 +19,5 @@ func TestHandlesStatusGet(t *testing.T) {
 	}
 	data, status := th.Exchange()
 	assert.Equal(status, 200)
-	assert.Len(data.(StatusResource).Deployments, 0)
+	assert.Len(data.(statusData).Deployments, 0)
 }

--- a/server/handle_status_test.go
+++ b/server/handle_status_test.go
@@ -8,13 +8,16 @@ import (
 	"github.com/opentable/sous/lib"
 )
 
-func TestHandlesGDMGet(t *testing.T) {
+func TestHandlesStatusGet(t *testing.T) {
 	assert := assert.New(t)
 
-	th := &GDMHandler{graph.CurrentGDM{
-		Deployments: sous.NewDeployments(),
-	}}
+	th := &StatusHandler{
+		GDM: graph.CurrentGDM{
+			Deployments: sous.NewDeployments(),
+		},
+		AutoResolver: &sous.AutoResolver{},
+	}
 	data, status := th.Exchange()
 	assert.Equal(status, 200)
-	assert.Len(data.(gdmWrapper).Deployments, 0)
+	assert.Len(data.(StatusResource).Deployments, 0)
 }


### PR DESCRIPTION
This adds 'GET /status' that can be queried to get: the current GDM, the last stable resolve status (i.e. at the end of a resolve cycle) and the current (in progress) resolve status.

This should be enough data that clients can poll it for updates. If load is unacceptable, we can add a variation that omits the live status and rely on etagging for caching.

