### PR TITLE
Future-proofing the /servers API

### DIFF
--- a/server/handle_servers.go
+++ b/server/handle_servers.go
@@ -3,14 +3,20 @@ package server
 import "github.com/opentable/sous/config"
 
 type (
+	// ServerListResource dispatches /servers
 	ServerListResource struct{}
 
+	// ServerListHandler handles GET for /servers
 	ServerListHandler struct {
 		Config *config.Config
 	}
 
+	server struct {
+		URL string
+	}
+
 	serverListData struct {
-		Servers []string
+		Servers []server
 	}
 )
 
@@ -19,7 +25,9 @@ func (slr *ServerListResource) Get() Exchanger { return &ServerListHandler{} }
 
 // Exchange implements Exchanger on ServerListHandler
 func (slh *ServerListHandler) Exchange() (interface{}, int) {
-	data := serverListData{Servers: make([]string, len(slh.Config.SiblingURLs))}
-	copy(data.Servers, slh.Config.SiblingURLs)
+	data := serverListData{Servers: []server{}}
+	for _, url := range slh.Config.SiblingURLs {
+		data.Servers = append(data.Servers, server{URL: url})
+	}
 	return data, 200
 }

--- a/server/handle_servers_test.go
+++ b/server/handle_servers_test.go
@@ -21,6 +21,6 @@ func TestHandleServerList_Get(t *testing.T) {
 
 	list, yup := rez.(serverListData)
 	assert.True(yup)
-	assert.Equal(list.Servers[0], "https://left.sous.com")
-	assert.Equal(list.Servers[1], "https://right.sous.com")
+	assert.Equal(list.Servers[0].URL, "https://left.sous.com")
+	assert.Equal(list.Servers[1].URL, "https://right.sous.com")
 }

--- a/server/server.go
+++ b/server/server.go
@@ -20,8 +20,9 @@ func New(laddr string, gf GraphFactory) *http.Server {
 
 // RunServer starts a server up.
 func RunServer(v *config.Verbosity, laddr string, ar *sous.AutoResolver) error {
+	mainGraph := graph.BuildGraph(&bytes.Buffer{}, os.Stdout, os.Stdout)
 	gf := func() Injector {
-		g := graph.BuildGraph(&bytes.Buffer{}, os.Stdout, os.Stdout)
+		g := mainGraph.Clone()
 		g.Add(v)
 		g.Add(ar)
 		return g


### PR DESCRIPTION
In the future, we'll likely want to give cluster names to the returned
servers. We can change the configs pretty easily, but the deployed
client base will be harder to change. Wrapping the URL string in a
struct (-> a JSON object) lets us add e.g. a Name field when that's
needed.