### PR TITLE
Sous status (fixes compilation + test for #278)

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -404,3 +404,14 @@ func TestInvokeBuildWithRepoSelector(t *testing.T) {
 	assert.Equal(build.DeployFilterFlags.Repo, `github.com/opentable/sous`)
 
 }
+
+func TestInvokePlumbingStatus_noServer(t *testing.T) {
+	assert := assert.New(t)
+
+	_, exe, _, _ := prepareCommand(t, []string{`sous`, `plumbing`, `status`})
+	assert.Len(exe.Args, 0)
+
+	status := exe.Cmd.(*SousPlumbingStatus)
+
+	assert.Nil(status.StatusPoller)
+}

--- a/cli/sous_plumbing.go
+++ b/cli/sous_plumbing.go
@@ -1,0 +1,21 @@
+package cli
+
+import "github.com/opentable/sous/util/cmdr"
+
+// SousPlumbing is the `sous plumbing` subcommand
+type SousPlumbing struct{}
+
+// PlumbingSubcommands collects the subcommands of `sous plumbing` as they're added
+var PlumbingSubcommands = cmdr.Commands{}
+
+func init() { TopLevelCommands["plumbing"] = &SousPlumbing{} }
+
+const sousPlumbingHelp = `Plumbing subcommands of Sous - usually not needed by users`
+
+// Subcommands implements Submcommandor for SousPlumbing
+func (SousPlumbing) Subcommands() cmdr.Commands {
+	return PlumbingSubcommands
+}
+
+// Help implements Command for SousPlumbing
+func (*SousPlumbing) Help() string { return sousPlumbingHelp }

--- a/cli/sous_plumbing_status.go
+++ b/cli/sous_plumbing_status.go
@@ -33,6 +33,11 @@ func (sps *SousPlumbingStatus) RegisterOn(psy Addable) {
 
 // Execute implements cmdr.Executor on SousPlumbingStatus.
 func (sps *SousPlumbingStatus) Execute(args []string) cmdr.Result {
+
+	if sps.StatusPoller == nil {
+		return cmdr.UsageErrorf("Please configure a server using 'sous config Server <url>'")
+	}
+
 	sps.StatusPoller.Start()
 
 	return cmdr.Success()

--- a/cli/sous_plumbing_status.go
+++ b/cli/sous_plumbing_status.go
@@ -4,8 +4,7 @@ import (
 	"flag"
 
 	"github.com/opentable/sous/config"
-	"github.com/opentable/sous/graph"
-	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/cmdr"
 )
 

--- a/cli/sous_plumbing_status.go
+++ b/cli/sous_plumbing_status.go
@@ -10,8 +10,8 @@ import (
 
 // SousPlumbingStatus is the `sous plumbing status` object
 type SousPlumbingStatus struct {
-	config.DeployFilterFlags
-	*sous.StatusPoller
+	DeployFilterFlags config.DeployFilterFlags
+	StatusPoller      *sous.StatusPoller
 }
 
 func init() { PlumbingSubcommands["status"] = &SousPlumbingStatus{} }

--- a/cli/sous_plumbing_status.go
+++ b/cli/sous_plumbing_status.go
@@ -13,7 +13,6 @@ import (
 type SousPlumbingStatus struct {
 	config.DeployFilterFlags
 	*sous.StatusPoller
-	waitForStable bool
 }
 
 func init() { PlumbingSubcommands["status"] = &SousPlumbingStatus{} }
@@ -26,13 +25,11 @@ func (*SousPlumbingStatus) Help() string {
 // AddFlags implements cmdr.AddFlags on SousPlumbingStatus
 func (sps *SousPlumbingStatus) AddFlags(fs *flag.FlagSet) {
 	MustAddFlags(fs, &sps.DeployFilterFlags, ManifestFilterFlagsHelp)
-	MustAddFlags(fs, &sps.waitForStable, `wait until deployment is stable`)
 }
 
 // RegisterOn implements Registrant on SousPlumbingStatus
 func (sps *SousPlumbingStatus) RegisterOn(psy Addable) {
 	psy.Add(&sps.DeployFilterFlags)
-	psy.Add(graph.StatusWaitStable(sps.waitForStable))
 }
 
 // Execute implements cmdr.Executor on SousPlumbingStatus

--- a/cli/sous_plumbing_status.go
+++ b/cli/sous_plumbing_status.go
@@ -8,7 +8,7 @@ import (
 	"github.com/opentable/sous/util/cmdr"
 )
 
-// SousPlumbingStatus is the `sous plumbing status` object
+// SousPlumbingStatus is the `sous plumbing status` object.
 type SousPlumbingStatus struct {
 	DeployFilterFlags config.DeployFilterFlags
 	StatusPoller      *sous.StatusPoller
@@ -16,22 +16,22 @@ type SousPlumbingStatus struct {
 
 func init() { PlumbingSubcommands["status"] = &SousPlumbingStatus{} }
 
-// Help implements Command on SousPlumbingStatus
+// Help implements Command on SousPlumbingStatus.
 func (*SousPlumbingStatus) Help() string {
 	return `reports the status of a given deployment`
 }
 
-// AddFlags implements cmdr.AddFlags on SousPlumbingStatus
+// AddFlags implements cmdr.AddFlags on SousPlumbingStatus.
 func (sps *SousPlumbingStatus) AddFlags(fs *flag.FlagSet) {
 	MustAddFlags(fs, &sps.DeployFilterFlags, ManifestFilterFlagsHelp)
 }
 
-// RegisterOn implements Registrant on SousPlumbingStatus
+// RegisterOn implements Registrant on SousPlumbingStatus.
 func (sps *SousPlumbingStatus) RegisterOn(psy Addable) {
 	psy.Add(&sps.DeployFilterFlags)
 }
 
-// Execute implements cmdr.Executor on SousPlumbingStatus
+// Execute implements cmdr.Executor on SousPlumbingStatus.
 func (sps *SousPlumbingStatus) Execute(args []string) cmdr.Result {
 	sps.StatusPoller.Start()
 

--- a/cli/sous_plumbing_status.go
+++ b/cli/sous_plumbing_status.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"flag"
+
+	"github.com/opentable/sous/config"
+	"github.com/opentable/sous/graph"
+	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/cmdr"
+)
+
+// SousPlumbingStatus is the `sous plumbing status` object
+type SousPlumbingStatus struct {
+	config.DeployFilterFlags
+	*sous.StatusPoller
+	waitForStable bool
+}
+
+func init() { PlumbingSubcommands["status"] = &SousPlumbingStatus{} }
+
+// Help implements Command on SousPlumbingStatus
+func (*SousPlumbingStatus) Help() string {
+	return `reports the status of a given deployment`
+}
+
+// AddFlags implements cmdr.AddFlags on SousPlumbingStatus
+func (sps *SousPlumbingStatus) AddFlags(fs *flag.FlagSet) {
+	MustAddFlags(fs, &sps.DeployFilterFlags, ManifestFilterFlagsHelp)
+	MustAddFlags(fs, &sps.waitForStable, `wait until deployment is stable`)
+}
+
+// RegisterOn implements Registrant on SousPlumbingStatus
+func (sps *SousPlumbingStatus) RegisterOn(psy Addable) {
+	psy.Add(&sps.DeployFilterFlags)
+	psy.Add(graph.StatusWaitStable(sps.waitForStable))
+}
+
+// Execute implements cmdr.Executor on SousPlumbingStatus
+func (sps *SousPlumbingStatus) Execute(args []string) cmdr.Result {
+	sps.StatusPoller.Start()
+
+	return cmdr.Success()
+}

--- a/cli/sous_server.go
+++ b/cli/sous_server.go
@@ -69,7 +69,7 @@ func (ss *SousServer) Execute(args []string) cmdr.Result {
 	ss.Log.Info.Println("Starting scheduled GDM resolution.")
 	ss.AutoResolver.Kickoff()
 	ss.Log.Info.Printf("Sous Server v%s running at %s", ss.Sous.Version, ss.flags.laddr)
-	return EnsureErrorResult(server.RunServer(ss.Verbosity, ss.flags.laddr, ss.AutoResolver)) //always non-nil
+	return EnsureErrorResult(server.RunServer(ss.Verbosity, ss.flags.laddr)) //always non-nil
 }
 
 func ensureGDMExists(repo, localPath string, log func(string, ...interface{})) error {

--- a/cli/tests/sous_test.go
+++ b/cli/tests/sous_test.go
@@ -13,7 +13,7 @@ func TestSous(t *testing.T) {
 
 	log.Print(term.Stderr)
 	term.Stdout.ShouldHaveNumLines(0)
-	term.Stderr.ShouldHaveNumLines(41)
+	term.Stderr.ShouldHaveNumLines(42)
 
 	term.Stderr.ShouldHaveExactLine("usage: sous <command>")
 	term.Stderr.ShouldHaveLineContaining("help      get help with sous")

--- a/cli/tests/sous_test.go
+++ b/cli/tests/sous_test.go
@@ -13,7 +13,7 @@ func TestSous(t *testing.T) {
 
 	log.Print(term.Stderr)
 	term.Stdout.ShouldHaveNumLines(0)
-	term.Stderr.ShouldHaveNumLines(43)
+	term.Stderr.ShouldHaveNumLines(44)
 
 	term.Stderr.ShouldHaveExactLine("usage: sous <command>")
 	term.Stderr.ShouldHaveLineContaining("help      get help with sous")

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -143,21 +143,21 @@ type adder interface {
 	Add(...interface{})
 }
 
-// AddLogs adds a logset to the graph
+// AddLogs adds a logset to the graph.
 func AddLogs(graph adder) {
 	graph.Add(
 		newLogSet,
 	)
 }
 
-// AddUser adds the OS user to the graph
+// AddUser adds the OS user to the graph.
 func AddUser(graph adder) {
 	graph.Add(
 		newLocalUser,
 	)
 }
 
-// AddShells adds working shells to the graph
+// AddShells adds working shells to the graph.
 func AddShells(graph adder) {
 	graph.Add(
 		newLocalWorkDirShell,
@@ -165,14 +165,14 @@ func AddShells(graph adder) {
 	)
 }
 
-// AddFilesystem adds filesystem to the graph
+// AddFilesystem adds filesystem to the graph.
 func AddFilesystem(graph adder) {
 	graph.Add(
 		newConfigLoader,
 	)
 }
 
-// AddConfig adds filesystem to the graph
+// AddConfig adds filesystem to the graph.
 func AddConfig(graph adder) {
 	c := config.DefaultConfig()
 	graph.Add(
@@ -183,7 +183,7 @@ func AddConfig(graph adder) {
 	)
 }
 
-// AddNetwork adds features that require the network
+// AddNetwork adds features that require the network.
 func AddNetwork(graph adder) {
 	graph.Add(
 		newDockerClient,
@@ -192,7 +192,7 @@ func AddNetwork(graph adder) {
 	)
 }
 
-// AddDocker adds Docker to the graph
+// AddDocker adds Docker to the graph.
 func AddDocker(graph adder) {
 	graph.Add(
 		newDockerBuilder,
@@ -200,14 +200,14 @@ func AddDocker(graph adder) {
 	)
 }
 
-// AddSingularity adds Singularity clients to the graph
+// AddSingularity adds Singularity clients to the graph.
 func AddSingularity(graph adder) {
 	graph.Add(
 		newDeployer,
 	)
 }
 
-// AddState adds state reader and writers to the graph
+// AddState adds state reader and writers to the graph.
 func AddState(graph adder) {
 	graph.Add(
 		newStateManager,
@@ -216,7 +216,7 @@ func AddState(graph adder) {
 	)
 }
 
-// AddInternals adds the dependency contructors that are internal to Sous
+// AddInternals adds the dependency contructors that are internal to Sous.
 func AddInternals(graph adder) {
 	// internal to Sous
 	graph.Add(

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -13,7 +13,6 @@ import (
 	"github.com/opentable/sous/ext/git"
 	"github.com/opentable/sous/ext/github"
 	"github.com/opentable/sous/ext/singularity"
-	"github.com/opentable/sous/ext/storage"
 	"github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/cmdr"
 	"github.com/opentable/sous/util/docker_registry"
@@ -450,13 +449,14 @@ func newDockerClient() LocalDockerClient {
 	return LocalDockerClient{docker_registry.NewClient()}
 }
 
-func newHTTPClient(c LocalSousConfig) (*sous.HTTPClient, err) {
+func newHTTPClient(c LocalSousConfig) (*sous.HTTPClient, error) {
 	if c.Server == "" {
-		sous.Log.Warn.Println("No server set, Sous is running in server or workstation mode.")
-		sous.Log.Warn.Println("Configure a server like this: sous config server http://some.sous.server")
-		sous.Log.Warn.Printf("Using local state stored at %s", c.StateLocation)
-		dm := storage.NewDiskStateManager(c.StateLocation)
-		return &StateManager{StateManager: storage.NewGitStateManager(dm)}, nil
+		return nil, fmt.Errorf("cannot create client; no Server set in config")
+		//sous.Log.Warn.Println("No server set, Sous is running in server or workstation mode.")
+		//sous.Log.Warn.Println("Configure a server like this: sous config server http://some.sous.server")
+		//sous.Log.Warn.Printf("Using local state stored at %s", c.StateLocation)
+		//dm := storage.NewDiskStateManager(c.StateLocation)
+		//return &StateManager{StateManager: storage.NewGitStateManager(dm)}, nil
 	}
 	sous.Log.Debug.Printf("Using server at %s", c.Server)
 	return sous.NewClient(c.Server)

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -454,10 +454,11 @@ func newStateManager(c LocalSousConfig) (*StateManager, error) {
 		return &StateManager{StateManager: storage.NewGitStateManager(dm)}, nil
 	}
 	sous.Log.Debug.Printf("Using server at %s", c.Server)
-	hsm, err := sous.NewHTTPStateManager(c.Server)
+	cl, err := sous.NewClient(c.Server)
 	if err != nil {
 		return nil, err
 	}
+	hsm := sous.NewHTTPStateManager(cl)
 	return &StateManager{StateManager: hsm}, nil
 }
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -43,6 +43,9 @@ type (
 	ErrWriter io.Writer
 	// InReader is typicially set to os.Stdin
 	InReader io.Reader
+	// StatusWaitStable represents if `sous plumbing status` should continue to
+	// poll until the selected t
+	StatusWaitStable bool
 	// Version represents a version of Sous.
 	Version struct{ semv.Version }
 	// LocalUser is the currently logged in user.

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -476,6 +476,10 @@ func newStateManager(cl *sous.HTTPClient, c LocalSousConfig) *StateManager {
 }
 
 func newStatusPoller(cl *sous.HTTPClient, rf *sous.ResolveFilter) *sous.StatusPoller {
+	if cl == nil {
+		sous.Log.Warn.Println("Unable to poll for status.")
+		return nil
+	}
 	return sous.NewStatusPoller(cl, rf)
 }
 

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -32,6 +32,7 @@ func injectedStateManager(t *testing.T, cfg *config.Config) *StateManager {
 	g := psyringe.New()
 	g.Add(newStateManager)
 	g.Add(LocalSousConfig{Config: cfg})
+	g.Add(newHTTPClient)
 
 	smRcvr := struct {
 		Sm *StateManager

--- a/lib/auto_resolver_test.go
+++ b/lib/auto_resolver_test.go
@@ -70,7 +70,7 @@ func TestAfterDone(t *testing.T) {
 	ar.afterDone(tc, done, ac)
 	select {
 	case <-tc:
-	case <-time.After(time.Duration(8)):
+	case <-time.After(time.Duration(8 * time.Millisecond)):
 		t.Error("Trigger channel took too long")
 	default:
 		t.Error("Trigger channel not triggered")

--- a/lib/http_state_manager.go
+++ b/lib/http_state_manager.go
@@ -239,16 +239,16 @@ func (m *Manifest) VariancesFrom(c Comparable) (vs Variances) {
 
 func (hsm *HTTPStateManager) create(m *Manifest) error {
 	r, o, f := manifestDebugs(m)
-	return errors.Wrapf(hsm.Create("./manifests", manifestParams(m), m), "creating manifest %s %s %s", r, o, f)
+	return errors.Wrapf(hsm.Create("./manifest", manifestParams(m), m), "creating manifest %s %s %s", r, o, f)
 }
 
 func (hsm *HTTPStateManager) del(m *Manifest) error {
 	r, o, f := manifestDebugs(m)
-	return errors.Wrapf(hsm.Delete("./manifests", manifestParams(m), m), "deleting manifest %s %s %s", r, o, f)
+	return errors.Wrapf(hsm.Delete("./manifest", manifestParams(m), m), "deleting manifest %s %s %s", r, o, f)
 }
 
 func (hsm *HTTPStateManager) modify(mp *ManifestPair) error {
 	bf, af := mp.Prior, mp.Post
 	r, o, f := manifestDebugs(bf)
-	return errors.Wrapf(hsm.Update("./manifests", manifestParams(bf), bf, af), "updating manifest %s %s %s", r, o, f)
+	return errors.Wrapf(hsm.Update("./manifest", manifestParams(bf), bf, af), "updating manifest %s %s %s", r, o, f)
 }

--- a/lib/http_state_manager.go
+++ b/lib/http_state_manager.go
@@ -1,12 +1,7 @@
 package sous
 
 import (
-	"bytes"
-	"encoding/json"
-	"io"
-	"log"
-	"net/http"
-	"net/url"
+	"fmt"
 
 	"github.com/pkg/errors"
 )
@@ -15,55 +10,14 @@ type (
 	// An HTTPStateManager gets state from a Sous server and transmits updates
 	// back to that server.
 	HTTPStateManager struct {
-		serverURL *url.URL
-		cached    *State
-		http.Client
+		cached *State
+		*HTTPClient
 	}
 
 	gdmWrapper struct {
 		Deployments []*Deployment
 	}
-
-	// ReadDebugger wraps a ReadCloser and logs the data as it buffers past.
-	ReadDebugger struct {
-		wrapped io.ReadCloser
-		logged  bool
-		count   int
-		read    []byte
-		log     func([]byte, int, error)
-	}
 )
-
-// NewReadDebugger creates a new ReadDebugger that wraps a ReadCloser
-func NewReadDebugger(rc io.ReadCloser, log func([]byte, int, error)) *ReadDebugger {
-	return &ReadDebugger{
-		wrapped: rc,
-		read:    []byte{},
-		log:     log,
-	}
-}
-
-// Read implements Reader on ReadDebugger
-func (rd *ReadDebugger) Read(p []byte) (int, error) {
-	n, err := rd.wrapped.Read(p)
-	rd.read = append(rd.read, p...)
-	rd.count += n
-	if err != nil {
-		rd.log(rd.read, rd.count, err)
-		rd.logged = true
-	}
-	return n, err
-}
-
-// Close implements Closer on ReadDebugger
-func (rd *ReadDebugger) Close() error {
-	err := rd.wrapped.Close()
-	if !rd.logged {
-		rd.log(rd.read, rd.count, err)
-		rd.logged = true
-	}
-	return err
-}
 
 func (g *gdmWrapper) manifests(defs Defs) (Manifests, error) {
 	ds := NewDeployments()
@@ -73,27 +27,9 @@ func (g *gdmWrapper) manifests(defs Defs) (Manifests, error) {
 	return ds.Manifests(defs)
 }
 
-func (g *gdmWrapper) fromJSON(reader io.Reader) {
-	dec := json.NewDecoder(reader)
-	dec.Decode(g)
-}
-
 // NewHTTPStateManager creates a new HTTPStateManager.
-func NewHTTPStateManager(us string) (*HTTPStateManager, error) {
-	u, err := url.Parse(us)
-
-	hsm := &HTTPStateManager{
-		serverURL: u,
-	}
-
-	// XXX: This is in response to a mysterios issue surrounding automatic gzip and
-	// Etagging The client receives a gzipped response with "--gzip" appended to
-	// the original Etag The --gzip isn't stripped by whatever does it, although
-	// the body is decompressed on the server side.
-	// This is a hack to address that issue, which should be resolved properly
-	hsm.Client.Transport = &http.Transport{Proxy: http.ProxyFromEnvironment, DisableCompression: true}
-
-	return hsm, errors.Wrapf(err, "new state manager")
+func NewHTTPStateManager(client *HTTPClient) *HTTPStateManager {
+	return &HTTPStateManager{HTTPClient: client}
 }
 
 // ReadState implements StateReader for HTTPStateManager.
@@ -192,33 +128,6 @@ func (hsm *HTTPStateManager) process(dc DiffConcentrator) error {
 	}
 }
 
-func (hsm *HTTPStateManager) manifestURL(m *Manifest) (string, error) {
-	murl, err := url.Parse("./manifest")
-	if err != nil {
-		return "", err
-	}
-	mqry := url.Values{}
-	mqry.Set("repo", m.Source.Repo)
-	mqry.Set("offset", m.Source.Dir)
-	mqry.Set("flavor", m.Flavor)
-	murl.RawQuery = mqry.Encode()
-	return hsm.serverURL.ResolveReference(murl).String(), nil
-}
-
-func (hsm *HTTPStateManager) manifestJSON(m *Manifest) io.Reader {
-	buf := &bytes.Buffer{}
-	enc := json.NewEncoder(buf)
-	enc.Encode(m)
-	return buf
-}
-
-func (hsm *HTTPStateManager) jsonManifest(buf io.Reader) *Manifest {
-	m := &Manifest{}
-	dec := json.NewDecoder(buf)
-	dec.Decode(m)
-	return m
-}
-
 func (hsm *HTTPStateManager) retains(mc chan *Manifest, ec chan error, done chan struct{}) {
 	defer close(ec)
 	for {
@@ -285,179 +194,61 @@ func (hsm *HTTPStateManager) modifies(mc chan *ManifestPair, ec chan error, done
 	}
 }
 
+////
+
 func (hsm *HTTPStateManager) getDefs() (Defs, error) {
 	ds := Defs{}
-	url, err := hsm.serverURL.Parse("./defs")
-	if err != nil {
-		return ds, errors.Wrapf(err, "getting defs")
-	}
-
-	Log.Debug.Printf("Reading definitions from %s", url)
-
-	req, err := http.NewRequest("GET", url.String(), nil)
-	if err != nil {
-		return ds, errors.Wrapf(err, "getting defs")
-	}
-	rz, err := hsm.httpRequest(req)
-	if err != nil {
-		return ds, errors.Wrapf(err, "getting defs")
-	}
-	defer rz.Body.Close()
-
-	dec := json.NewDecoder(rz.Body)
-
-	return ds, errors.Wrapf(dec.Decode(&ds), "getting defs")
+	return ds, errors.Wrapf(hsm.Retrieve("./defs", nil, &ds), "getting defs")
 }
 
 func (hsm *HTTPStateManager) getManifests(defs Defs) (Manifests, error) {
-	url, err := hsm.serverURL.Parse("./gdm")
-	if err != nil {
+	gdm := gdmWrapper{}
+	if err := hsm.Retrieve("./gdm", nil, &gdm); err != nil {
 		return Manifests{}, errors.Wrapf(err, "getting manifests")
 	}
-
-	Log.Debug.Printf("Reading manifests from %s", url)
-
-	rq, err := http.NewRequest("GET", url.String(), nil)
-	if err != nil {
-		return Manifests{}, errors.Wrapf(err, "getting manifests")
-	}
-	gdmRz, err := hsm.httpRequest(rq)
-	if err != nil {
-		return Manifests{}, errors.Wrapf(err, "getting manifests")
-	}
-	defer gdmRz.Body.Close()
-	gdm := &gdmWrapper{}
-	gdm.fromJSON(gdmRz.Body)
 	return gdm.manifests(defs)
 }
 
-func (hsm *HTTPStateManager) httpRequest(req *http.Request) (*http.Response, error) {
-	if req.Body == nil {
-		Log.Vomit.Printf("-> %s %q", req.Method, req.URL)
-	} else {
-		req.Body = NewReadDebugger(req.Body, func(b []byte, n int, err error) {
-			Log.Vomit.Printf("-> %s %q:\n%sSent %d bytes, result: %v", req.Method, req.URL, string(b), n, err)
-		})
+func manifestParams(m *Manifest) map[string]string {
+	return map[string]string{
+		"repo":   m.Source.Repo,
+		"offset": m.Source.Dir,
+		"flavor": m.Flavor,
 	}
-	rz, err := hsm.Client.Do(req)
-	log.Print(err)
-	if rz == nil {
-		return rz, err
+}
+
+func manifestDebugs(m *Manifest) (r, o, f string) {
+	return m.Source.Repo, m.Source.Dir, m.Flavor
+}
+
+// EmptyReceiver implements Comparable on Manifest
+func (m *Manifest) EmptyReceiver() Comparable {
+	return &Manifest{}
+}
+
+// VariancesFrom implements Comparable on Manifest
+func (m *Manifest) VariancesFrom(c Comparable) (vs Variances) {
+	o, ok := c.(*Manifest)
+	if !ok {
+		return Variances{fmt.Sprintf("Not a *Manifest: %T", c)}
 	}
-	if rz.Body == nil {
-		Log.Vomit.Printf("<- %s %q %d", req.Method, req.URL, rz.StatusCode)
-	} else {
-		rz.Body = NewReadDebugger(rz.Body, func(b []byte, n int, err error) {
-			Log.Vomit.Printf("<- %s %q %d:\n%sRead %d bytes, result: %v", req.Method, req.URL, rz.StatusCode, string(b), n, err)
-		})
-	}
-	return rz, err
+
+	_, diffs := m.Diff(o)
+	return Variances(diffs)
 }
 
 func (hsm *HTTPStateManager) create(m *Manifest) error {
-	murl, err := hsm.manifestURL(m)
-	if err != nil {
-		return err
-	}
-	json := hsm.manifestJSON(m)
-	Log.Debug.Printf("Creating manifest: PUT %q", murl)
-	Log.Debug.Printf("Creating manifest: %s", json)
-	rq, err := http.NewRequest("PUT", murl, json)
-	if err != nil {
-		return errors.Wrapf(err, "create manifest request")
-	}
-	rq.Header.Add("If-None-Match", "*")
-	rz, err := hsm.httpRequest(rq)
-	if err != nil {
-		return err //XXX network problems? retry?
-	}
-	defer rz.Body.Close()
-	if rz.StatusCode != 200 {
-		return errors.Errorf("%s: %#v", rz.Status, m)
-	}
-	return nil
+	r, o, f := manifestDebugs(m)
+	return errors.Wrapf(hsm.Create("./manifests", manifestParams(m), m), "creating manifest %s %s %s", r, o, f)
 }
 
 func (hsm *HTTPStateManager) del(m *Manifest) error {
-	u, etag, err := hsm.getManifestEtag(m)
-	if err != nil {
-		return errors.Wrapf(err, "delete manifest request")
-	}
-
-	drq, err := http.NewRequest("DELETE", u, nil)
-	if err != nil {
-		return errors.Wrapf(err, "delete manifest request")
-	}
-	drq.Header.Add("If-Match", etag)
-	drz, err := hsm.httpRequest(drq)
-	if err != nil {
-		return errors.Wrapf(err, "delete manifest request")
-	}
-	defer drz.Body.Close()
-	if !(drz.StatusCode >= 200 && drz.StatusCode < 300) {
-		return errors.Errorf("Delete %s failed: %s", u, drz.Status)
-	}
-	return nil
+	r, o, f := manifestDebugs(m)
+	return errors.Wrapf(hsm.Delete("./manifests", manifestParams(m), m), "deleting manifest %s %s %s", r, o, f)
 }
 
 func (hsm *HTTPStateManager) modify(mp *ManifestPair) error {
-	bf := mp.Prior
-	af := mp.Post
-	u, etag, err := hsm.getManifestEtag(bf)
-	if err != nil {
-		return errors.Wrapf(err, "modify request")
-	}
-
-	// XXX I don't think the URL should be *able* to be different here.
-	u, err = hsm.manifestURL(af)
-	if err != nil {
-		return err
-	}
-
-	json := hsm.manifestJSON(af)
-	Log.Debug.Printf("Updating manifest at %q", u)
-	Log.Debug.Printf("Updating manifest to %s", json)
-
-	prq, err := http.NewRequest("PUT", u, json)
-	if err != nil {
-		return errors.Wrapf(err, "modify request")
-	}
-	prq.Header.Add("If-Match", etag)
-	prz, err := hsm.httpRequest(prq)
-	if err != nil {
-		return errors.Wrapf(err, "modify request")
-	}
-	defer prz.Body.Close()
-	if !(prz.StatusCode >= 200 && prz.StatusCode < 300) {
-		return errors.Errorf("Update failed: %s / %#v", prz.Status, af)
-	}
-	return nil
-}
-
-func (hsm *HTTPStateManager) getManifestEtag(m *Manifest) (string, string, error) {
-	u, err := hsm.manifestURL(m)
-	if err != nil {
-		return "", "", err
-	}
-
-	Log.Debug.Printf("Getting manifest from %s", u)
-
-	grq, err := http.NewRequest("GET", u, nil)
-	if err != nil {
-		return "", "", err
-	}
-	grz, err := hsm.httpRequest(grq)
-	if err != nil {
-		return "", "", err
-	}
-	defer grz.Body.Close()
-	if !(grz.StatusCode >= 200 && grz.StatusCode < 300) {
-		return "", "", errors.Errorf("GET %s, %s: %#v", u, grz.Status, m)
-	}
-	rm := hsm.jsonManifest(grz.Body)
-	different, differences := rm.Diff(m)
-	if different {
-		return "", "", errors.Errorf("Remote and local versions of manifest don't match: %#v", differences)
-	}
-	return u, grz.Header.Get("Etag"), nil
+	bf, af := mp.Prior, mp.Post
+	r, o, f := manifestDebugs(bf)
+	return errors.Wrapf(hsm.Update("./manifests", manifestParams(bf), bf, af), "updating manifest %s %s %s", r, o, f)
 }

--- a/lib/http_state_manager_test.go
+++ b/lib/http_state_manager_test.go
@@ -30,10 +30,11 @@ func TestHTTPStateManager_Create(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(h))
 
-	hsm, err := NewHTTPStateManager(srv.URL)
+	cl, err := NewClient(srv.URL)
 	if err != nil {
 		t.Error(err)
 	}
+	hsm := NewHTTPStateManager(cl)
 	hsm.create(&Manifest{})
 	if !reqd {
 		t.Errorf("No request issued")
@@ -77,10 +78,11 @@ func TestHTTPStateManager_Delete(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(h))
 
-	hsm, err := NewHTTPStateManager(srv.URL)
+	cl, err := NewClient(srv.URL)
 	if err != nil {
 		t.Error(err)
 	}
+	hsm := NewHTTPStateManager(cl)
 	hsm.del(&Manifest{})
 	if !reqd {
 		t.Errorf("No request issued")
@@ -124,10 +126,11 @@ func TestHTTPStateManager_Modify(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(h))
 
-	hsm, err := NewHTTPStateManager(srv.URL)
+	cl, err := NewClient(srv.URL)
 	if err != nil {
 		t.Error(err)
 	}
+	hsm := NewHTTPStateManager(cl)
 	hsm.modify(&ManifestPair{
 		Prior: &Manifest{},
 		Post:  &Manifest{},

--- a/lib/httpclient.go
+++ b/lib/httpclient.go
@@ -163,10 +163,9 @@ func (client *HTTPClient) getBodyEtag(url string, body Comparable, ierr error) (
 	return rz.Header.Get("Etag"), nil
 }
 
-func (client *HTTPClient) buildRequest(method, url string, headers map[string]string, rqBody interface{}, ierr error) (rq *http.Request, err error) {
+func (client *HTTPClient) buildRequest(method, url string, headers map[string]string, rqBody interface{}, ierr error) (*http.Request, error) {
 	if ierr != nil {
-		err = ierr
-		return
+		return nil, ierr
 	}
 
 	Log.Debug.Printf("Sending %s %q", method, url)
@@ -181,7 +180,7 @@ func (client *HTTPClient) buildRequest(method, url string, headers map[string]st
 		JSON = buf
 	}
 
-	rq, err = http.NewRequest(method, url, JSON)
+	rq, err := http.NewRequest(method, url, JSON)
 
 	if headers != nil {
 		for k, v := range headers {
@@ -192,18 +191,17 @@ func (client *HTTPClient) buildRequest(method, url string, headers map[string]st
 	return rq, err
 }
 
-func (client *HTTPClient) sendRequest(rq *http.Request, ierr error) (rz *http.Response, err error) {
+func (client *HTTPClient) sendRequest(rq *http.Request, ierr error) (*http.Response, error) {
 	if ierr != nil {
-		err = ierr
-		return
+		return nil, ierr
 	}
-	rz, err = client.httpRequest(rq)
+	rz, err := client.httpRequest(rq)
 	if err != nil {
 		Log.Debug.Printf("Received %v", err)
-		return
+		return rz, err
 	}
 	Log.Debug.Printf("Received \"%s %s\" -> %d", rq.Method, rq.URL, rz.StatusCode)
-	return
+	return rz, err
 }
 
 func (client *HTTPClient) getBody(rz *http.Response, rzBody interface{}, err error) error {

--- a/lib/httpclient.go
+++ b/lib/httpclient.go
@@ -12,15 +12,15 @@ import (
 )
 
 type (
-	// HTTPClient interacts with a Sous http server
-	//   It's designed to handle basic CRUD operations in a safe and restful way
+	// HTTPClient interacts with a Sous http server.
+	//   It's designed to handle basic CRUD operations in a safe and restful way.
 	HTTPClient struct {
 		serverURL *url.URL
 		http.Client
 	}
 
 	// Comparable is a required interface for Update and Delete, which provides
-	// the mechanism for comparing the remote resource to the local data
+	// the mechanism for comparing the remote resource to the local data.
 	Comparable interface {
 		// EmptyReceiver should return a pointer to an "zero value" for the recieving type.
 		// For example:
@@ -29,15 +29,15 @@ type (
 
 		// VariancesFrom returns a list of differences from another Comparable.
 		// If the two structs are equivalent, it should return an empty list.
-		// Usually, the first check will be for identical type, and return "types differ"
+		// Usually, the first check will be for identical type, and return "types differ."
 		VariancesFrom(Comparable) Variances
 	}
 
-	// Variances is a list of differences between two structs
+	// Variances is a list of differences between two structs.
 	Variances []string
 )
 
-// NewClient returns a new HTTPClient for a particular serverURL
+// NewClient returns a new HTTPClient for a particular serverURL.
 func NewClient(serverURL string) (*HTTPClient, error) {
 	u, err := url.Parse(serverURL)
 
@@ -49,7 +49,7 @@ func NewClient(serverURL string) (*HTTPClient, error) {
 	// and Etagging The client receives a gzipped response with "--gzip" appended
 	// to the original Etag The --gzip isn't stripped by whatever does it,
 	// although the body is decompressed on the server side.  This is a hack to
-	// address that issue, which should be resolved properly
+	// address that issue, which should be resolved properly.
 	client.Client.Transport = &http.Transport{Proxy: http.ProxyFromEnvironment, DisableCompression: true}
 
 	return client, errors.Wrapf(err, "new Sous REST client")
@@ -71,7 +71,7 @@ func (client *HTTPClient) Retrieve(urlPath string, qParms map[string]string, rzB
 }
 
 // Create uses the contents of qBody to create a new resource at the server at urlPath/qParms
-// It issues a PUT with "If-No-Match: *", so if a resource already exists, it'll return an error
+// It issues a PUT with "If-No-Match: *", so if a resource already exists, it'll return an error.
 func (client *HTTPClient) Create(urlPath string, qParms map[string]string, qBody interface{}) error {
 	return errors.Wrapf(func() error {
 		url, err := client.buildURL(urlPath, qParms)
@@ -97,7 +97,7 @@ func (client *HTTPClient) Update(urlPath string, qParms map[string]string, from,
 }
 
 // Delete removes a resource from the server, granted that we know the resource that we're removing.
-// It functions similarly to Update, but issues DELETE requests
+// It functions similarly to Update, but issues DELETE requests.
 func (client *HTTPClient) Delete(urlPath string, qParms map[string]string, from Comparable) error {
 	return errors.Wrapf(func() error {
 		url, err := client.buildURL(urlPath, qParms)
@@ -243,12 +243,13 @@ func (client *HTTPClient) httpRequest(req *http.Request) (*http.Response, error)
 	}
 	if rz.Body == nil {
 		Log.Vomit.Printf("Client <- %s %q %d <empty response body>", req.Method, req.URL, rz.StatusCode)
-	} else {
-		rz.Body = NewReadDebugger(rz.Body, func(b []byte, n int, err error) {
-			Log.Vomit.Printf("Client <- %s %q: %d", req.Method, req.URL, rz.StatusCode)
-			Log.Vomit.Print(string(b))
-			Log.Vomit.Printf("Read %d bytes, result: %v", n, err)
-		})
+		return rz, err
 	}
+
+	rz.Body = NewReadDebugger(rz.Body, func(b []byte, n int, err error) {
+		Log.Vomit.Printf("Client <- %s %q: %d", req.Method, req.URL, rz.StatusCode)
+		Log.Vomit.Print(string(b))
+		Log.Vomit.Printf("Read %d bytes, result: %v", n, err)
+	})
 	return rz, err
 }

--- a/lib/httpclient.go
+++ b/lib/httpclient.go
@@ -1,0 +1,238 @@
+package sous
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+type (
+	// HTTPClient interacts with a Sous http server
+	//   It's designed to handle basic CRUD operations in a safe and restful way
+	HTTPClient struct {
+		serverURL *url.URL
+		http.Client
+	}
+
+	// Comparable is a required interface for Update and Delete, which provides
+	// the mechanism for comparing the remote resource to the local data
+	Comparable interface {
+		// EmptyReceiver should return a pointer to an "zero value" for the recieving type.
+		// For example:
+		//   func (x *X) EmptyReceiver() { return &X{} }
+		EmptyReceiver() Comparable
+
+		// VariancesFrom returns a list of differences from another Comparable.
+		// If the two structs are equivalent, it should return an empty list.
+		// Usually, the first check will be for identical type, and return "types differ"
+		VariancesFrom(Comparable) Variances
+	}
+
+	// Variances is a list of differences between two structs
+	Variances []string
+)
+
+// NewClient returns a new HTTPClient for a particular serverURL
+func NewClient(serverURL string) (*HTTPClient, error) {
+	u, err := url.Parse(serverURL)
+
+	client := &HTTPClient{
+		serverURL: u,
+	}
+
+	// XXX: This is in response to a mysterious issue surrounding automatic gzip
+	// and Etagging The client receives a gzipped response with "--gzip" appended
+	// to the original Etag The --gzip isn't stripped by whatever does it,
+	// although the body is decompressed on the server side.  This is a hack to
+	// address that issue, which should be resolved properly
+	client.Client.Transport = &http.Transport{Proxy: http.ProxyFromEnvironment, DisableCompression: true}
+
+	return client, errors.Wrapf(err, "new Sous REST client")
+}
+
+// ****
+
+// Retrieve makes a GET request on urlPath, after transforming qParms into ?&=
+// style query params. It deserializes the returned JSON into rzBody. Errors
+// are returned if anything goes wrong, including a non-Success HTTP result
+// (but note that there may be a response anyway.
+func (client *HTTPClient) Retrieve(urlPath string, qParms map[string]string, rzBody interface{}) error {
+	return errors.Wrapf(func() error {
+		url, err := client.buildURL(urlPath, qParms)
+		rq, err := client.buildRequest("GET", url, nil, nil, err)
+		rz, err := client.sendRequest(rq, err)
+		return client.getBody(rz, rzBody, err)
+	}(), "Retrieve %s", urlPath)
+}
+
+// Create uses the contents of qBody to create a new resource at the server at urlPath/qParms
+// It issues a PUT with "If-No-Match: *", so if a resource already exists, it'll return an error
+func (client *HTTPClient) Create(urlPath string, qParms map[string]string, qBody interface{}) error {
+	return errors.Wrapf(func() error {
+		url, err := client.buildURL(urlPath, qParms)
+		rq, err := client.buildRequest("PUT", url, noMatchStar(), qBody, err)
+		rz, err := client.sendRequest(rq, err)
+		return client.getBody(rz, nil, err)
+	}(), "Create %s", urlPath)
+}
+
+// Update changes the representation of a given resource.
+// It compares the known value to from, and rejects if they're different (on
+// the grounds that the client is going to clobber a value it doesn't know
+// about.) Then it issues a PUT with "If-Match: <etag of from>" so that the
+// server can check that we're changing from a known value.
+func (client *HTTPClient) Update(urlPath string, qParms map[string]string, from, qBody Comparable) error {
+	return errors.Wrapf(func() error {
+		url, err := client.buildURL(urlPath, qParms)
+		etag, err := client.getBodyEtag(url, from, err)
+		rq, err := client.buildRequest("PUT", url, ifMatch(etag), qBody, err)
+		rz, err := client.sendRequest(rq, err)
+		return client.getBody(rz, nil, err)
+	}(), "Update %s", urlPath)
+}
+
+// Delete removes a resource from the server, granted that we know the resource that we're removing.
+// It functions similarly to Update, but issues DELETE requests
+func (client *HTTPClient) Delete(urlPath string, qParms map[string]string, from Comparable) error {
+	return errors.Wrapf(func() error {
+		url, err := client.buildURL(urlPath, qParms)
+		etag, err := client.getBodyEtag(url, from, err)
+		rq, err := client.buildRequest("DELETE", url, ifMatch(etag), nil, err)
+		rz, err := client.sendRequest(rq, err)
+		return client.getBody(rz, nil, err)
+	}(), "Delete %s", urlPath)
+}
+
+// ***
+
+func noMatchStar() map[string]string {
+	return map[string]string{"If-None-Match": "*"}
+}
+
+func ifMatch(etag string) map[string]string {
+	return map[string]string{"If-Match": etag}
+}
+
+// ****
+
+func (client *HTTPClient) buildURL(urlPath string, qParms map[string]string) (urlS string, err error) {
+	URL, err := client.serverURL.Parse(urlPath)
+	if err != nil {
+		return
+	}
+	if qParms == nil {
+		return URL.String(), nil
+	}
+	qry := url.Values{}
+	for k, v := range qParms {
+		qry.Set(k, v)
+	}
+	URL.RawQuery = qry.Encode()
+	return client.serverURL.ResolveReference(URL).String(), nil
+}
+
+func (client *HTTPClient) getBodyEtag(url string, body Comparable, ierr error) (etag string, err error) {
+	if ierr != nil {
+		err = ierr
+		return
+	}
+	Log.Debug.Printf("Getting existing resource from %s", url)
+
+	rzBody := body.EmptyReceiver()
+
+	rq, err := client.buildRequest("GET", url, nil, nil, nil)
+	rz, err := client.sendRequest(rq, err)
+	err = client.getBody(rz, rzBody, err)
+	if err != nil {
+		return
+	}
+
+	differences := rzBody.VariancesFrom(body)
+	if len(differences) > 0 {
+		return "", errors.Errorf("Remote and local versions of %s resource don't match: %#v", url, differences)
+	}
+	return rz.Header.Get("Etag"), nil
+}
+
+func (client *HTTPClient) buildRequest(method, url string, headers map[string]string, rqBody interface{}, ierr error) (rq *http.Request, err error) {
+	if ierr != nil {
+		err = ierr
+		return
+	}
+
+	Log.Debug.Printf("Sending %s %q", method, url)
+
+	var JSON io.Reader
+
+	if rqBody != nil {
+		JSON := &bytes.Buffer{}
+		enc := json.NewEncoder(JSON)
+		enc.Encode(rqBody)
+		Log.Debug.Printf("%s", JSON)
+	}
+
+	rq, err = http.NewRequest(method, url, JSON)
+
+	if headers != nil {
+		for k, v := range headers {
+			rq.Header.Add(k, v)
+		}
+	}
+
+	return rq, err
+}
+
+func (client *HTTPClient) sendRequest(rq *http.Request, ierr error) (rz *http.Response, err error) {
+	if ierr != nil {
+		err = ierr
+		return
+	}
+	rz, err = client.httpRequest(rq)
+	Log.Debug.Printf("Received \"%s %s\" -> %d", rq.Method, rq.URL, rz.StatusCode)
+	return
+}
+
+func (client *HTTPClient) getBody(rz *http.Response, rzBody interface{}, err error) error {
+	if err != nil {
+		return err
+	}
+	defer rz.Body.Close()
+
+	if rzBody != nil {
+		dec := json.NewDecoder(rz.Body)
+		err = dec.Decode(rzBody)
+	}
+
+	if rz.StatusCode != 200 {
+		return errors.Errorf("%s: %#v", rz.Status, rzBody)
+	}
+	return err
+}
+
+func (client *HTTPClient) httpRequest(req *http.Request) (*http.Response, error) {
+	if req.Body == nil {
+		Log.Vomit.Printf("-> %s %q", req.Method, req.URL)
+	} else {
+		req.Body = NewReadDebugger(req.Body, func(b []byte, n int, err error) {
+			Log.Vomit.Printf("-> %s %q:\n%sSent %d bytes, result: %v", req.Method, req.URL, string(b), n, err)
+		})
+	}
+	rz, err := client.Client.Do(req)
+	log.Print(err)
+	if rz == nil {
+		return rz, err
+	}
+	if rz.Body == nil {
+		Log.Vomit.Printf("<- %s %q %d", req.Method, req.URL, rz.StatusCode)
+	} else {
+		rz.Body = NewReadDebugger(rz.Body, func(b []byte, n int, err error) {
+			Log.Vomit.Printf("<- %s %q %d:\n%sRead %d bytes, result: %v", req.Method, req.URL, rz.StatusCode, string(b), n, err)
+		})
+	}
+	return rz, err
+}

--- a/lib/httpclient.go
+++ b/lib/httpclient.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 
@@ -152,7 +151,7 @@ func (client *HTTPClient) getBodyEtag(url string, body Comparable, ierr error) (
 		rq, err = client.buildRequest("GET", url, nil, nil, nil)
 		rz, err = client.sendRequest(rq, err)
 		return client.getBody(rz, rzBody, err)
-	}(), "Getting Etag for %s", url)
+	}(), "etag for %s", url)
 	if err != nil {
 		return
 	}
@@ -183,7 +182,6 @@ func (client *HTTPClient) buildRequest(method, url string, headers map[string]st
 	}
 
 	rq, err = http.NewRequest(method, url, JSON)
-	log.Printf("%#v", rq)
 
 	if headers != nil {
 		for k, v := range headers {
@@ -226,7 +224,7 @@ func (client *HTTPClient) getBody(rz *http.Response, rzBody interface{}, err err
 		}
 		return errors.Errorf("%s: %#v", rz.Status, string(b))
 	}
-	return err
+	return errors.Wrapf(err, "processing response body")
 }
 
 func (client *HTTPClient) httpRequest(req *http.Request) (*http.Response, error) {
@@ -240,7 +238,6 @@ func (client *HTTPClient) httpRequest(req *http.Request) (*http.Response, error)
 		})
 	}
 	rz, err := client.Client.Do(req)
-	log.Print(err)
 	if rz == nil {
 		return rz, err
 	}

--- a/lib/readdebugger.go
+++ b/lib/readdebugger.go
@@ -13,7 +13,7 @@ type (
 	}
 )
 
-// NewReadDebugger creates a new ReadDebugger that wraps a ReadCloser
+// NewReadDebugger creates a new ReadDebugger that wraps a ReadCloser.
 func NewReadDebugger(rc io.ReadCloser, log func([]byte, int, error)) *ReadDebugger {
 	return &ReadDebugger{
 		wrapped: rc,
@@ -22,7 +22,7 @@ func NewReadDebugger(rc io.ReadCloser, log func([]byte, int, error)) *ReadDebugg
 	}
 }
 
-// Read implements Reader on ReadDebugger
+// Read implements Reader on ReadDebugger.
 func (rd *ReadDebugger) Read(p []byte) (int, error) {
 	n, err := rd.wrapped.Read(p)
 	rd.read = append(rd.read, p...)
@@ -34,7 +34,7 @@ func (rd *ReadDebugger) Read(p []byte) (int, error) {
 	return n, err
 }
 
-// Close implements Closer on ReadDebugger
+// Close implements Closer on ReadDebugger.
 func (rd *ReadDebugger) Close() error {
 	err := rd.wrapped.Close()
 	if !rd.logged {

--- a/lib/readdebugger.go
+++ b/lib/readdebugger.go
@@ -1,0 +1,45 @@
+package sous
+
+import "io"
+
+type (
+	// ReadDebugger wraps a ReadCloser and logs the data as it buffers past.
+	ReadDebugger struct {
+		wrapped io.ReadCloser
+		logged  bool
+		count   int
+		read    []byte
+		log     func([]byte, int, error)
+	}
+)
+
+// NewReadDebugger creates a new ReadDebugger that wraps a ReadCloser
+func NewReadDebugger(rc io.ReadCloser, log func([]byte, int, error)) *ReadDebugger {
+	return &ReadDebugger{
+		wrapped: rc,
+		read:    []byte{},
+		log:     log,
+	}
+}
+
+// Read implements Reader on ReadDebugger
+func (rd *ReadDebugger) Read(p []byte) (int, error) {
+	n, err := rd.wrapped.Read(p)
+	rd.read = append(rd.read, p...)
+	rd.count += n
+	if err != nil {
+		rd.log(rd.read, rd.count, err)
+		rd.logged = true
+	}
+	return n, err
+}
+
+// Close implements Closer on ReadDebugger
+func (rd *ReadDebugger) Close() error {
+	err := rd.wrapped.Close()
+	if !rd.logged {
+		rd.log(rd.read, rd.count, err)
+		rd.logged = true
+	}
+	return err
+}

--- a/lib/resolvefilter.go
+++ b/lib/resolvefilter.go
@@ -1,0 +1,99 @@
+package sous
+
+import "fmt"
+
+type (
+	// A ResolveFilter filters Deployments and Clusters for the purpose of
+	// Resolve.resolve().
+	ResolveFilter struct {
+		Repo     string
+		Offset   string
+		Tag      string
+		Revision string
+		Flavor   string
+		Cluster  string
+	}
+)
+
+// All returns true if the ResolveFilter would allow all deployments.
+func (rf *ResolveFilter) All() bool {
+	return rf.Repo == "" &&
+		rf.Offset == "" &&
+		rf.Tag == "" &&
+		rf.Revision == "" &&
+		rf.Flavor == "" &&
+		rf.Cluster == ""
+}
+
+func (rf *ResolveFilter) String() string {
+	cl, fl, rp, of, tg, rv := rf.Cluster, rf.Flavor, rf.Repo, rf.Offset, rf.Tag, rf.Revision
+	if cl == "" {
+		cl = `*`
+	}
+	if fl == "" {
+		fl = `*`
+	}
+	if rp == "" {
+		rp = `*`
+	}
+	if of == "" {
+		of = `*`
+	}
+	if tg == "" {
+		tg = `*`
+	}
+	if rv == "" {
+		rv = `*`
+	}
+	return fmt.Sprintf("<cluster:%s repo:%s offset:%s flavor:%s tag:%s revision:%s>",
+		cl, rp, of, fl, tg, rv)
+}
+
+// FilteredClusters returns a new Clusters relevant to the Deployments that this
+// ResolveFilter would permit.
+func (rf *ResolveFilter) FilteredClusters(c Clusters) Clusters {
+	newC := make(Clusters)
+	for n, c := range c {
+		if rf.Cluster != "" && n != rf.Cluster {
+			continue
+		}
+		newC[n] = c // c is a *Cluster, so be aware they need to not be changed
+	}
+	return newC
+}
+
+// FilterDeployment behaves as a DeploymentPredicate, filtering Deployments if
+// they match its criteria.
+func (rf *ResolveFilter) FilterDeployment(d *Deployment) bool {
+	if rf.Repo != "" && d.SourceID.Location.Repo != rf.Repo {
+		return false
+	}
+	if rf.Offset != "" && d.SourceID.Location.Dir != rf.Offset {
+		return false
+	}
+	if rf.Tag != "" && d.SourceID.Version.String() != rf.Tag {
+		return false
+	}
+	if rf.Revision != "" && d.SourceID.RevID() != rf.Revision {
+		return false
+	}
+	if rf.Flavor != "" && d.Flavor != rf.Flavor {
+		return false
+	}
+	if rf.Cluster != "" && d.ClusterName != rf.Cluster {
+		return false
+	}
+	return true
+}
+
+// FilterManifest returns true if ???
+// TODO: @nyarly can you provide a description of what this function does?
+func (rf *ResolveFilter) FilterManifest(m *Manifest) bool {
+	if rf.Repo != "" && m.Source.Repo != rf.Repo {
+		return false
+	}
+	if rf.Offset != "" && m.Source.Dir != rf.Offset {
+		return false
+	}
+	return true
+}

--- a/lib/resolvefilter.go
+++ b/lib/resolvefilter.go
@@ -86,13 +86,20 @@ func (rf *ResolveFilter) FilterDeployment(d *Deployment) bool {
 	return true
 }
 
-// FilterManifest returns true if ???
-// TODO: @nyarly can you provide a description of what this function does?
+// FilterManifest returns true if the Manifest is matched by this ResolveFilter.
 func (rf *ResolveFilter) FilterManifest(m *Manifest) bool {
+	return rf.FilterManifestID(m.ID())
+}
+
+// FilterManifestID returns true if the ManifestID is matched by this ResolveFilter.
+func (rf *ResolveFilter) FilterManifestID(m ManifestID) bool {
 	if rf.Repo != "" && m.Source.Repo != rf.Repo {
 		return false
 	}
 	if rf.Offset != "" && m.Source.Dir != rf.Offset {
+		return false
+	}
+	if rf.Flavor != "" && m.Flavor != rf.Flavor {
 		return false
 	}
 	return true

--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -1,9 +1,6 @@
 package sous
 
-import (
-	"fmt"
-	"sync"
-)
+import "sync"
 
 type (
 	// Resolver is responsible for resolving intended and actual deployment
@@ -14,105 +11,11 @@ type (
 		*ResolveFilter
 	}
 
-	// A ResolveFilter filters Deployments and Clusters for the purpose of
-	// Resolve.resolve().
-	ResolveFilter struct {
-		Repo     string
-		Offset   string
-		Tag      string
-		Revision string
-		Flavor   string
-		Cluster  string
-	}
-
 	// DeploymentPredicate takes a *Deployment and returns true if the
 	// deployment matches the predicate. Used by Filter to select a subset of a
 	// Deployments.
 	DeploymentPredicate func(*Deployment) bool
 )
-
-// All returns true if the ResolveFilter would allow all deployments.
-func (rf *ResolveFilter) All() bool {
-	return rf.Repo == "" &&
-		rf.Offset == "" &&
-		rf.Tag == "" &&
-		rf.Revision == "" &&
-		rf.Flavor == "" &&
-		rf.Cluster == ""
-}
-
-func (rf *ResolveFilter) String() string {
-	cl, fl, rp, of, tg, rv := rf.Cluster, rf.Flavor, rf.Repo, rf.Offset, rf.Tag, rf.Revision
-	if cl == "" {
-		cl = `*`
-	}
-	if fl == "" {
-		fl = `*`
-	}
-	if rp == "" {
-		rp = `*`
-	}
-	if of == "" {
-		of = `*`
-	}
-	if tg == "" {
-		tg = `*`
-	}
-	if rv == "" {
-		rv = `*`
-	}
-	return fmt.Sprintf("<cluster:%s repo:%s offset:%s flavor:%s tag:%s revision:%s>",
-		cl, rp, of, fl, tg, rv)
-}
-
-// FilteredClusters returns a new Clusters relevant to the Deployments that this
-// ResolveFilter would permit.
-func (rf *ResolveFilter) FilteredClusters(c Clusters) Clusters {
-	newC := make(Clusters)
-	for n, c := range c {
-		if rf.Cluster != "" && n != rf.Cluster {
-			continue
-		}
-		newC[n] = c // c is a *Cluster, so be aware they need to not be changed
-	}
-	return newC
-}
-
-// FilterDeployment behaves as a DeploymentPredicate, filtering Deployments if
-// they match its criteria.
-func (rf *ResolveFilter) FilterDeployment(d *Deployment) bool {
-	if rf.Repo != "" && d.SourceID.Location.Repo != rf.Repo {
-		return false
-	}
-	if rf.Offset != "" && d.SourceID.Location.Dir != rf.Offset {
-		return false
-	}
-	if rf.Tag != "" && d.SourceID.Version.String() != rf.Tag {
-		return false
-	}
-	if rf.Revision != "" && d.SourceID.RevID() != rf.Revision {
-		return false
-	}
-	if rf.Flavor != "" && d.Flavor != rf.Flavor {
-		return false
-	}
-	if rf.Cluster != "" && d.ClusterName != rf.Cluster {
-		return false
-	}
-	return true
-}
-
-// FilterManifest returns true if ???
-// TODO: @nyarly can you provide a description of what this function does?
-func (rf *ResolveFilter) FilterManifest(m *Manifest) bool {
-	if rf.Repo != "" && m.Source.Repo != rf.Repo {
-		return false
-	}
-	if rf.Offset != "" && m.Source.Dir != rf.Offset {
-		return false
-	}
-	return true
-}
 
 // NewResolver creates a new Resolver.
 func NewResolver(d Deployer, r Registry, rf *ResolveFilter) *Resolver {

--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -43,7 +43,10 @@ func (r *Resolver) reportStable(stable chan *Deployable, results chan DiffResolu
 	for dep := range stable {
 		results <- DiffResolution{
 			DeployID: dep.ID(),
-			Desc:     "unchanged",
+			// XXX This value is 'magic' - the `sous status` command uses it to
+			// recognize a complete resolution. Don't change it here without changing
+			// it everywhere.
+			Desc: "unchanged",
 		}
 	}
 }

--- a/lib/status_poller.go
+++ b/lib/status_poller.go
@@ -92,6 +92,13 @@ func (rs ResolveState) String() string {
 	}
 }
 
+func NewStatusPoller(cl *HTTPClient, rf *ResolveFilter) *StatusPoller {
+	return &StatusPoller{
+		HTTPClient:    cl,
+		ResolveFilter: rf,
+	}
+}
+
 func newSubPoller(serverURL string, baseFilter *ResolveFilter) (*subPoller, error) {
 	cl, err := NewClient(serverURL)
 	if err != nil {

--- a/lib/status_poller.go
+++ b/lib/status_poller.go
@@ -1,0 +1,11 @@
+package sous
+
+type (
+	// StatusPoller polls servers for status
+	StatusPoller struct {
+	}
+)
+
+func (sp *StatusPoller) Start() {
+
+}

--- a/lib/status_poller.go
+++ b/lib/status_poller.go
@@ -1,11 +1,194 @@
 package sous
 
+import "time"
+
 type (
-	// StatusPoller polls servers for status
+	// StatusPoller polls servers for status.
 	StatusPoller struct {
+		*HTTPClient
+		*ResolveFilter
+	}
+
+	subPoller struct {
+		*HTTPClient
+		locationFilter, idFilter *ResolveFilter
+	}
+
+	// copied from server - avoiding coupling to server implemention
+	server struct {
+		URL string
+	}
+
+	// copied from server - avoiding coupling to server implemention
+	serverListData struct {
+		Servers []server
+	}
+
+	// copied from server - avoiding coupling to server implemention
+	statusData struct {
+		Deployments           []*Deployment
+		Completed, InProgress *ResolveStatus
+	}
+
+	// A ResolveState reflects the state of the Sous clusters in regard to
+	// resolving a particular SourceID.
+	ResolveState int
+
+	statPair struct {
+		url  string
+		stat resolveState
 	}
 )
 
-func (sp *StatusPoller) Start() {
+const (
+	// ResolveNotPolled is the entry state. It means we haven't received data
+	// from a server yet.
+	ResolveNotPolled resolveState = iota
+	// ResolveNotStarted conveys the condition that the server is not yet working
+	// to resolve the SourceLocation in question. Granted that a manifest update
+	// has succeeded, expect that once the current auto-resolve cycle concludes,
+	// the resolve-subject GDM will be updated, and we'll move past this state.
+	ResolveNotStarted
+	// ResolvedNotVersion conveys that the server knows the SourceLocation
+	// already, but is resolving a different version. Again, expect that on the
+	// next auto-resolve cycle we'll move past this state.
+	ResolveNotVersion
+	// ResolveInProgress conveys a resolve action has been taken by the server,
+	// which implies that the server's intended version (which we've confirmed is
+	// the same as our intended version) is different from the
+	// Mesos/Singularity's version.
+	ResolveInProgress
+	// ResolveErred conveys that the resolution returned an error. This might be transient.
+	ResolveErred
+	// ResolveComplete is the success state: the server knows about our intended
+	// deployment, and that deployment has returned as having been stable.
+	ResolveComplete
+)
 
+func newSubPoller(serverURL string, baseFilter *ResolveFilter) (*subPoller, error) {
+	cl, err := NewClient(serverURL)
+	if err != nil {
+		return nil, err
+	}
+
+	loc := *baseFilter
+	loc.Cluster = ""
+	loc.Tag = ""
+	loc.Revision = ""
+
+	id := *baseFilter
+	id.Cluster = ""
+
+	return &subPoller{
+		HTTPClient:     cl,
+		locationFilter: &loc,
+		idFilter:       &id,
+	}, nil
+}
+
+// Start begins the process of polling for cluster statuses.
+func (sp *StatusPoller) Start() error {
+	clusters := &serverListData{}
+	if err := sp.Retrieve("./servers", nil, clusters); err != nil {
+		return err
+	}
+
+	subs := []*subPoller{}
+
+	for _, s := range cluster {
+		sub, err := newSubPoller(s.URL)
+		if err != nil {
+			return err
+		}
+		subs = append(subs, sub)
+	}
+
+	return sp.poll(subs)
+}
+
+func (sp *StatusPoller) poll(subs []*subPoller) ResolveState {
+	collect := make(chan statPair)
+	done := make(chan struct{})
+	totalStatus := ResolveNotPolled
+	go func() {
+		pollChans := map[string]resolveState{}
+		for {
+			update := <-collect
+			pollChans[update.url] = update.stat
+			max := ResolveComplete
+			for u, s := range pollChans {
+				if s <= max {
+					max = s
+				}
+			}
+			totalStatus = max
+			if totalStatus >= ResolveComplete {
+				close(done)
+				return
+			}
+		}
+	}()
+
+	for _, s := range subs {
+		go sub.start(collect, done)
+	}
+
+	<-done
+	return totalStatus
+}
+
+func (sub *subPoller) start(rs chan statPair, done chan struct{}) {
+	rs <- statPair{url: sub.HTTPClient.serverURL, stat: ResolveNotPolled}
+	rs <- pollOnce()
+	for {
+		select {
+		case <-time.Tick(time.Second / 2):
+			stat := pollOnce()
+			rs <- statPair{url: sub.HTTPClient.serverURL, stat: stat}
+			if stat >= ResolveComplete {
+				return
+			}
+		case <-done:
+			return
+		}
+	}
+}
+
+func (sub *subPoller) pollOnce() resolveState {
+	data := &statusData{}
+	sub.Retrieve("./status", nil, data)
+
+	return sub.computeState(
+		data.intentionFor(sub.locationFilter),
+		data.stableFor(sub.locationFilter),
+		data.currentFor(sub.locationFilter),
+	)
+}
+
+func (sub *subPoller) computeState(srvIntent *Deployment, stable, current *DiffResolution) ResolveState {
+	Log.Debug.Printf("%s reports intent to resolve %v", sub.HTTPClient.serverURL, srvIntent)
+	Log.Debug.Printf("%s reports stable rez: %v", sub.HTTPClient.serverURL, stable)
+	Log.Debug.Printf("%s reports in-progress rez: %v", sub.HTTPClient.serverURL, current)
+
+	if srvIntent == nil {
+		return ResolveNotStarted
+	}
+
+	if !sub.idFilter.FilterDeployment(srvIntent) {
+		return ResolveNotVersion
+	}
+
+	if current == nil {
+		current = stable
+	}
+
+	if current.Error != nil {
+		return ResolveErred
+	}
+
+	if current.Desc == "unchanged" {
+		return ResolveComplete
+	}
+
+	return ResolveInProgress
 }

--- a/lib/status_poller_test.go
+++ b/lib/status_poller_test.go
@@ -1,0 +1,63 @@
+package sous
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/samsalisbury/semv"
+)
+
+func TestSubPoller_ComputeState(t *testing.T) {
+	testRepo := "github.com/opentable/example"
+	testDir := "test"
+	rezErr := fmt.Errorf("something bad")
+
+	versionDep := func(version string) *Deployment {
+		return &Deployment{
+			Cluster: &Cluster{},
+			SourceID: SourceID{
+				Location: SourceLocation{
+					Repo: testRepo,
+					Dir:  testDir,
+				},
+				Version: semv.MustParse(version),
+			},
+		}
+	}
+
+	diffRez := func(desc string, err error) *DiffResolution {
+		return &DiffResolution{
+			Desc:  desc,
+			Error: err,
+		}
+	}
+
+	testCompute := func(version string, intent *Deployment, stable, current *DiffResolution, expected ResolveState) {
+		sub := subPoller{
+			idFilter: &ResolveFilter{
+				Tag: version,
+			},
+		}
+		if actual := sub.computeState(intent, stable, current); expected != actual {
+			t.Errorf("sub.computeState(%v, %v, %v) -> %v != %v", intent, stable, current, actual, expected)
+		}
+	}
+
+	testCompute("1.0", nil, nil, nil, ResolveNotStarted)
+	testCompute("1.0", versionDep("0.9"), nil, nil, ResolveNotVersion)
+	testCompute("1.0", versionDep("1.0"), nil, nil, ResolvePendingRequest)
+
+	testCompute("1.0", versionDep("1.0"), diffRez("update", nil), nil, ResolveInProgress) //known update , no outcome yet
+	testCompute("1.0", versionDep("1.0"), nil, diffRez("update", nil), ResolveInProgress) //new update   , now in progress
+	testCompute("1.0", versionDep("1.0"), diffRez("unchanged", nil), diffRez("update", nil), ResolveInProgress)
+	testCompute("1.0", versionDep("1.0"), diffRez("create", rezErr), diffRez("update", nil), ResolveInProgress)
+
+	testCompute("1.0", versionDep("1.0"), diffRez("unchanged", rezErr), nil, ResolveErred)
+	testCompute("1.0", versionDep("1.0"), nil, diffRez("unchanged", rezErr), ResolveErred)
+	testCompute("1.0", versionDep("1.0"), diffRez("unchanged", nil), diffRez("unchanged", rezErr), ResolveErred)
+	testCompute("1.0", versionDep("1.0"), diffRez("create", rezErr), diffRez("unchanged", rezErr), ResolveErred)
+
+	testCompute("1.0", versionDep("1.0"), diffRez("unchanged", nil), nil, ResolveComplete)
+	testCompute("1.0", versionDep("1.0"), nil, diffRez("unchanged", nil), ResolveComplete)
+	testCompute("1.0", versionDep("1.0"), diffRez("create", rezErr), diffRez("unchanged", nil), ResolveComplete)
+}

--- a/server/handle_manifest.go
+++ b/server/handle_manifest.go
@@ -22,6 +22,7 @@ type (
 	// PUTManifestHandler handles PUT exchanges for manifests
 	PUTManifestHandler struct {
 		*sous.State
+		*sous.LogSet
 		*http.Request
 		*QueryValues
 		StateWriter graph.StateWriter
@@ -84,7 +85,8 @@ func (pmh *PUTManifestHandler) Exchange() (interface{}, int) {
 	dec.Decode(m)
 	flaws := m.Validate()
 	if len(flaws) > 0 {
-		return "", http.StatusBadRequest
+		pmh.Vomit.Printf("%#v", flaws)
+		return "Invalid manifest", http.StatusBadRequest
 	}
 	pmh.State.Manifests.Set(mid, m)
 	if err := pmh.StateWriter.WriteState(pmh.State); err != nil {

--- a/server/handle_status.go
+++ b/server/handle_status.go
@@ -16,6 +16,7 @@ type (
 	StatusHandler struct {
 		GDM          graph.CurrentGDM
 		AutoResolver *sous.AutoResolver
+		*sous.ResolveFilter
 	}
 
 	statusData struct {
@@ -30,7 +31,7 @@ func (*StatusResource) Get() Exchanger { return &StatusHandler{} }
 // Exchange implements the Handler interface.
 func (h *StatusHandler) Exchange() (interface{}, int) {
 	status := statusData{Deployments: []*sous.Deployment{}}
-	for _, d := range h.GDM.Snapshot() {
+	for _, d := range h.GDM.Filter(h.ResolveFilter.FilterDeployment).Snapshot() {
 		status.Deployments = append(status.Deployments, d)
 	}
 	status.Completed, status.InProgress = h.AutoResolver.Statuses()

--- a/server/router.go
+++ b/server/router.go
@@ -17,20 +17,20 @@ import (
 )
 
 type (
-	// The MetaHandler collects common behavior for route handlers
+	// The MetaHandler collects common behavior for route handlers.
 	MetaHandler struct {
 		router        *httprouter.Router
 		graphFac      GraphFactory //XXX This is a workaround for a bug in psyringe.Clone()
 		statusHandler *StatusMiddleware
 	}
 
-	// ResponseWriter wraps the the http.ResponseWriter interface
+	// ResponseWriter wraps the the http.ResponseWriter interface.
 	// XXX This is a workaround for Psyringe
 	ResponseWriter struct {
 		http.ResponseWriter
 	}
 
-	// ExchangeLogger and logs the exchange
+	// ExchangeLogger wraps and logs the exchange.
 	ExchangeLogger struct {
 		Exchanger Exchanger
 		*sous.LogSet
@@ -38,16 +38,16 @@ type (
 		httprouter.Params
 	}
 
-	// Injector is an interface for DI systems
+	// Injector is an interface for DI systems.
 	Injector interface {
 		Inject(...interface{}) error
 		Add(...interface{})
 	}
-	// A GraphFactory builds a SousGraph
+	// A GraphFactory builds a SousGraph.
 	GraphFactory func() Injector
 )
 
-// Exchange implements Exchanger on ExchangeLogger
+// Exchange implements Exchanger on ExchangeLogger.
 func (xlog *ExchangeLogger) Exchange() (data interface{}, status int) {
 	xlog.Vomit.Printf("Server: <- %s %s params: %v", xlog.Method, xlog.URL.String(), xlog.Params)
 	data, status = xlog.Exchanger.Exchange()
@@ -55,11 +55,7 @@ func (xlog *ExchangeLogger) Exchange() (data interface{}, status int) {
 	return
 }
 
-// Seriously considering "BodyInBodyOut" "BodyInEmptyOut" "EmptyInBodyOut" "EmptyInEmptyOut"
-// because that covers pretty much every case for the requests themselves, and
-// the exchanger is really the crucial part of the transform
-
-// GetHandling handles Get requests
+// GetHandling handles Get requests.
 func (mh *MetaHandler) GetHandling(factory ExchangeFactory) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		h := mh.injectedHandler(factory, w, r, p)
@@ -68,7 +64,7 @@ func (mh *MetaHandler) GetHandling(factory ExchangeFactory) httprouter.Handle {
 	}
 }
 
-// DeleteHandling handles Delete requests
+// DeleteHandling handles Delete requests.
 func (mh *MetaHandler) DeleteHandling(factory ExchangeFactory) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		h := mh.injectedHandler(factory, w, r, p)
@@ -77,7 +73,7 @@ func (mh *MetaHandler) DeleteHandling(factory ExchangeFactory) httprouter.Handle
 	}
 }
 
-// HeadHandling handles Head requests
+// HeadHandling handles Head requests.
 func (mh *MetaHandler) HeadHandling(factory ExchangeFactory) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		h := mh.injectedHandler(factory, w, r, p)
@@ -86,7 +82,7 @@ func (mh *MetaHandler) HeadHandling(factory ExchangeFactory) httprouter.Handle {
 	}
 }
 
-// PutHandling handles PUT requests
+// PutHandling handles PUT requests.
 func (mh *MetaHandler) PutHandling(factory ExchangeFactory) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		if r.Header.Get("If-Match") == "" && r.Header.Get("If-None-Match") == "" {
@@ -119,7 +115,7 @@ func (mh *MetaHandler) PutHandling(factory ExchangeFactory) httprouter.Handle {
 	}
 }
 
-// InstallPanicHandler installs an panic handler into the router
+// InstallPanicHandler installs an panic handler into the router.
 func (mh *MetaHandler) InstallPanicHandler() {
 	g := mh.graphFac()
 	g.Inject(mh.statusHandler)

--- a/server/server.go
+++ b/server/server.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/opentable/sous/config"
 	"github.com/opentable/sous/graph"
-	"github.com/opentable/sous/lib"
 )
 
 // New creates a Sous HTTP server.
@@ -19,12 +18,11 @@ func New(laddr string, gf GraphFactory) *http.Server {
 }
 
 // RunServer starts a server up.
-func RunServer(v *config.Verbosity, laddr string, ar *sous.AutoResolver) error {
+func RunServer(v *config.Verbosity, laddr string) error {
 	mainGraph := graph.BuildGraph(&bytes.Buffer{}, os.Stdout, os.Stdout)
 	gf := func() Injector {
 		g := mainGraph.Clone()
 		g.Add(v)
-		g.Add(ar)
 		return g
 	}
 	s := New(laddr, gf)

--- a/test/http_state_manager_test.go
+++ b/test/http_state_manager_test.go
@@ -79,10 +79,11 @@ func TestWriteState(t *testing.T) {
 	testServer := httptest.NewServer(server.SousRouteMap.BuildRouter(gf))
 	defer testServer.Close()
 
-	hsm, err := sous.NewHTTPStateManager(testServer.URL)
+	cl, err := sous.NewClient(testServer.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
+	hsm := sous.NewHTTPStateManager(cl)
 
 	originalState, err := hsm.ReadState()
 	if err != nil {


### PR DESCRIPTION
Includes #278; fixes compilation and tests.

- Note: newHTTPClient can now return (nil, nil), meaning no error and a nil
  HTTP client) which is unusual in our graph that tends to return an error
  when it cannot construct a requested value.
- This is not a problem currently, and it's documented, but we need to take
  care when we want to assume the presence of an HTTP client.

**UPDATED** now also fixes invocation of `sous plumbing status` when `config.Server == ""` and adds regression test.