### PR TITLE
Small code improvements

### DIFF
--- a/lib/status_poller.go
+++ b/lib/status_poller.go
@@ -186,6 +186,7 @@ func (sub *subPoller) start(rs chan statPair, done chan struct{}) {
 		return
 	}
 	ticker := time.NewTicker(time.Second / 2)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
@@ -195,7 +196,6 @@ func (sub *subPoller) start(rs chan statPair, done chan struct{}) {
 				return
 			}
 		case <-done:
-			ticker.Stop()
 			return
 		}
 	}

--- a/server/handle_servers_test.go
+++ b/server/handle_servers_test.go
@@ -22,6 +22,10 @@ func TestHandleServerList_Get(t *testing.T) {
 	list, yup := rez.(serverListData)
 	assert.True(yup)
 
+	if list.Servers[0].ClusterName == "right" {
+		list.Servers = []server{list.Servers[1], list.Servers[0]}
+	}
+
 	// test predates config []string -> map[string]string
 	assert.Equal(list.Servers[0].URL, "https://left.sous.com")
 	assert.Equal(list.Servers[1].URL, "https://right.sous.com")


### PR DESCRIPTION
This is a followup to suggestions made in #282.

The logging of request and response bodies in the HTTP client has been
extracted to a method, and it now logs problems compacting JSON (which can
occur, if nothing else, if a large JSON body comes in in multiple chunks.)

The Ticker leak is now covered with a defer - n.b. that the original NewTicker
was introduced to cover a leak that time.Tick() introduces.