### PR TITLE
Fixes a missed stitch in injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ For contribution guidelines, see [here](./doc/contributions.md).
 
 [View documentation in the doc/ directory.](https://github.com/opentable/sous/tree/master/doc)
 
-
 # Using Sous
 
 If you're looking to get started using Sous

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -179,6 +179,7 @@ func AddConfig(graph adder) {
 		newPossiblyInvalidLocalSousConfig,
 		DefaultConfig{&c},
 		newLocalSousConfig,
+		newSousConfig,
 		newLocalWorkDir,
 	)
 }

--- a/graph/local_config.go
+++ b/graph/local_config.go
@@ -27,6 +27,10 @@ type (
 	ConfigLoader struct{ configloader.ConfigLoader }
 )
 
+func newSousConfig(lsc LocalSousConfig) *config.Config {
+	return lsc.Config
+}
+
 func newPossiblyInvalidLocalSousConfig(u LocalUser, defaultConfig DefaultConfig, gcl *ConfigLoader) (PossiblyInvalidConfig, error) {
 	v, err := newPossiblyInvalidConfig(u.ConfigFile(), defaultConfig, gcl)
 	return v, initErr(err, "getting configuration")

--- a/server/handle_servers.go
+++ b/server/handle_servers.go
@@ -1,6 +1,10 @@
 package server
 
-import "github.com/opentable/sous/config"
+import (
+	"log"
+
+	"github.com/opentable/sous/config"
+)
 
 type (
 	// ServerListResource dispatches /servers
@@ -27,6 +31,8 @@ func (slr *ServerListResource) Get() Exchanger { return &ServerListHandler{} }
 // Exchange implements Exchanger on ServerListHandler
 func (slh *ServerListHandler) Exchange() (interface{}, int) {
 	data := serverListData{Servers: []server{}}
+	log.Printf("%#v", slh)
+	log.Printf("%#v", slh.Config)
 	for name, url := range slh.Config.SiblingURLs {
 		data.Servers = append(data.Servers, server{ClusterName: name, URL: url})
 	}

--- a/server/routemap.go
+++ b/server/routemap.go
@@ -60,9 +60,7 @@ type (
 	*/
 )
 
-// BuildRouter builds a returns an http.Handler based on some constant configuration
-func (rm *RouteMap) BuildRouter(grf func() Injector) http.Handler {
-	r := httprouter.New()
+func (rm *RouteMap) buildMetaHandler(r *httprouter.Router, grf func() Injector) *MetaHandler {
 	ph := &StatusMiddleware{}
 	mh := &MetaHandler{
 		graphFac:      grf,
@@ -70,6 +68,14 @@ func (rm *RouteMap) BuildRouter(grf func() Injector) http.Handler {
 		statusHandler: ph,
 	}
 	mh.InstallPanicHandler()
+
+	return mh
+}
+
+// BuildRouter builds a returns an http.Handler based on some constant configuration
+func (rm *RouteMap) BuildRouter(grf func() Injector) http.Handler {
+	r := httprouter.New()
+	mh := rm.buildMetaHandler(r, grf)
 
 	for _, e := range *rm {
 		get, canGet := e.Resource.(Getable)

--- a/server/server_injection_test.go
+++ b/server/server_injection_test.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/nyarly/testify/assert"
+	"github.com/nyarly/testify/require"
+	"github.com/opentable/sous/config"
+	"github.com/opentable/sous/graph"
+)
+
+func basicInjectedHandler(factory ExchangeFactory, t *testing.T) Exchanger {
+	require := require.New(t)
+
+	gf := func() Injector {
+		g := graph.TestGraphWithConfig(&bytes.Buffer{}, os.Stdout, os.Stdout, "StateLocation: '../ext/storage/testdata/in'\n")
+		g.Add(&config.Verbosity{})
+		return g
+	}
+
+	r := httprouter.New()
+	mh := SousRouteMap.buildMetaHandler(r, gf)
+
+	w := httptest.NewRecorder()
+	rq := httptest.NewRequest("GET", "/", nil)
+
+	serverListGetLogger := mh.injectedHandler(factory, w, rq, httprouter.Params{})
+
+	logger, ok := serverListGetLogger.(*ExchangeLogger)
+	require.True(ok)
+
+	return logger.Exchanger
+}
+
+func TestServerListHandlerInjection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	slr := &ServerListResource{}
+	slh := basicInjectedHandler(slr.Get, t)
+
+	serverListGet, ok := slh.(*ServerListHandler)
+	require.True(ok)
+
+	assert.NotNil(serverListGet.Config)
+}


### PR DESCRIPTION
The ServerListHandler needs a *config.Config injected, but the graph
didn't have one added (there was a *graph.LocalSousConfig that needed
unwrapping.)

Also adds the start of tests for this kind of case.