### PR TITLE
Fix for null fields in /status

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -132,6 +132,11 @@ func NewSousCLI(s *Sous, in io.Reader, out, errout io.Writer) (*CLI, error) {
 			}
 		}
 
+		// This is tricky: we need to inject the completely added graph to the
+		// graph itself so that sous_server can pass a complete graph to
+		// server.RunServer
+		g.Add(g)
+
 		for _, c := range chain {
 			if err := g.Inject(c); err != nil {
 				return err

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -210,6 +210,9 @@ func TestInvokeServer(t *testing.T) {
 
 	exe = justCommand(t, []string{`sous`, `server`, `-cluster`, `test`})
 	assert.NotNil(t, exe)
+	server, good := exe.Cmd.(*SousServer)
+	require.True(t, good)
+	assert.NotNil(t, server.SousGraph)
 }
 
 /*

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	"log" //ok
 	"os"
 	"os/user"
 
@@ -233,8 +233,8 @@ func AddInternals(graph adder) {
 		newLocalGitClient,
 		newLocalGitRepo,
 		newSourceHostChooser,
-		newCurrentState,
-		newCurrentGDM,
+		NewCurrentState,
+		NewCurrentGDM,
 		newTargetManifest,
 		newDetectedOTPLConfig,
 		newUserSelectedOTPLDeploySpecs,
@@ -492,7 +492,7 @@ func newLocalStateWriter(sm *StateManager) StateWriter {
 	return StateWriter{sm}
 }
 
-func newCurrentState(sr StateReader) (*sous.State, error) {
+func NewCurrentState(sr StateReader) (*sous.State, error) {
 	state, err := sr.ReadState()
 	if os.IsNotExist(errors.Cause(err)) {
 		log.Println("error reading state:", err)
@@ -502,7 +502,7 @@ func newCurrentState(sr StateReader) (*sous.State, error) {
 	return state, initErr(err, "reading sous state")
 }
 
-func newCurrentGDM(state *sous.State) (CurrentGDM, error) {
+func NewCurrentGDM(state *sous.State) (CurrentGDM, error) {
 	deployments, err := state.Deployments()
 	if err != nil {
 		return CurrentGDM{}, initErr(err, "expanding state")

--- a/server/graph.go
+++ b/server/graph.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"github.com/opentable/sous/graph"
+	sous "github.com/opentable/sous/lib"
+)
+
+type (
+	// A LiveGDM wraps a sous.Deployments and gets refreshed per server request
+	LiveGDM struct {
+		sous.Deployments
+	}
+)
+
+// AddsPerRequest registers items into a SousGraph that need to be fresh per request
+func AddsPerRequest(g Injector) {
+	g.Add(liveGDM)
+}
+
+func liveGDM(sr graph.StateReader) (*LiveGDM, error) {
+	state, err := graph.NewCurrentState(sr)
+	if err != nil {
+		return nil, err
+	}
+	gdm, err := graph.NewCurrentGDM(state)
+	if err != nil {
+		return nil, err
+	}
+	return &LiveGDM{gdm.Deployments}, nil
+}

--- a/server/handle_gdm.go
+++ b/server/handle_gdm.go
@@ -1,9 +1,6 @@
 package server
 
-import (
-	"github.com/opentable/sous/graph"
-	"github.com/opentable/sous/lib"
-)
+import "github.com/opentable/sous/lib"
 
 type (
 	// GDMResource is the resource for the GDM
@@ -11,7 +8,7 @@ type (
 
 	// GDMHandler is an injectable request handler
 	GDMHandler struct {
-		GDM graph.CurrentGDM
+		GDM *LiveGDM
 	}
 
 	gdmWrapper struct {

--- a/server/handle_gdm_test.go
+++ b/server/handle_gdm_test.go
@@ -4,14 +4,13 @@ import (
 	"testing"
 
 	"github.com/nyarly/testify/assert"
-	"github.com/opentable/sous/graph"
 	"github.com/opentable/sous/lib"
 )
 
 func TestHandlesGDMGet(t *testing.T) {
 	assert := assert.New(t)
 
-	th := &GDMHandler{graph.CurrentGDM{
+	th := &GDMHandler{&LiveGDM{
 		Deployments: sous.NewDeployments(),
 	}}
 	data, status := th.Exchange()

--- a/server/handle_servers.go
+++ b/server/handle_servers.go
@@ -1,10 +1,6 @@
 package server
 
-import (
-	"log"
-
-	"github.com/opentable/sous/config"
-)
+import "github.com/opentable/sous/config"
 
 type (
 	// ServerListResource dispatches /servers
@@ -31,8 +27,6 @@ func (slr *ServerListResource) Get() Exchanger { return &ServerListHandler{} }
 // Exchange implements Exchanger on ServerListHandler
 func (slh *ServerListHandler) Exchange() (interface{}, int) {
 	data := serverListData{Servers: []server{}}
-	log.Printf("%#v", slh)
-	log.Printf("%#v", slh.Config)
 	for name, url := range slh.Config.SiblingURLs {
 		data.Servers = append(data.Servers, server{ClusterName: name, URL: url})
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -1,11 +1,8 @@
 package server
 
 import (
-	"bytes"
 	"net/http"
-	"os"
 
-	"github.com/opentable/sous/config"
 	"github.com/opentable/sous/graph"
 )
 
@@ -18,14 +15,12 @@ func New(laddr string, gf GraphFactory) *http.Server {
 }
 
 // RunServer starts a server up.
-func RunServer(v *config.Verbosity, dff *config.DeployFilterFlags, laddr string) error {
-	mainGraph := graph.BuildGraph(&bytes.Buffer{}, os.Stdout, os.Stdout)
-	mainGraph.Add(v)
-	mainGraph.Add(dff)
-	mainGraph.Add(graph.DryrunNeither)
-
+func RunServer(mainGraph *graph.SousGraph, laddr string) error {
 	gf := func() Injector {
-		return mainGraph.Clone()
+		g := mainGraph.Clone()
+		AddsPerRequest(g)
+
+		return g
 	}
 	s := New(laddr, gf)
 	return s.ListenAndServe()

--- a/server/server_injection_test.go
+++ b/server/server_injection_test.go
@@ -17,12 +17,13 @@ import (
 func basicInjectedHandler(factory ExchangeFactory, t *testing.T) Exchanger {
 	require := require.New(t)
 
+	g := graph.TestGraphWithConfig(&bytes.Buffer{}, os.Stdout, os.Stdout, "StateLocation: '../ext/storage/testdata/in'\n")
+	g.Add(&config.Verbosity{})
+	g.Add(&config.DeployFilterFlags{Cluster: "test"})
+	g.Add(graph.DryrunBoth)
+
 	gf := func() Injector {
-		g := graph.TestGraphWithConfig(&bytes.Buffer{}, os.Stdout, os.Stdout, "StateLocation: '../ext/storage/testdata/in'\n")
-		g.Add(&config.Verbosity{})
-		g.Add(&config.DeployFilterFlags{Cluster: "test"})
-		g.Add(graph.DryrunBoth)
-		return g
+		return g.Clone()
 	}
 
 	r := httprouter.New()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -88,6 +88,7 @@ func TestOverallRouter(t *testing.T) {
 	gf := func() Injector {
 		g := graph.TestGraphWithConfig(&bytes.Buffer{}, os.Stdout, os.Stdout, "StateLocation: '../ext/storage/testdata/in'\n")
 		g.Add(&config.Verbosity{})
+		AddsPerRequest(g)
 		return g
 	}
 	ts := httptest.NewServer(SousRouteMap.BuildRouter(gf))

--- a/server/statusmiddleware.go
+++ b/server/statusmiddleware.go
@@ -1,7 +1,10 @@
 package server
 
 import (
+	"fmt"
+	"io"
 	"net/http"
+	"os"
 	"runtime/debug"
 
 	"github.com/opentable/sous/lib"
@@ -15,6 +18,31 @@ type (
 	}
 )
 
+func (ph *StatusMiddleware) errorBody(status int, rq *http.Request, w io.Writer, data interface{}, err error, stack []byte) {
+	gatelatch := os.Getenv("GATELATCH")
+	if gatelatch == "" {
+		return
+	}
+
+	if header := rq.Header.Get("X-Gatelatch"); header != gatelatch {
+		ph.LogSet.Warn.Printf("Gatelatch header (%q) didn't match gatelatch env (%s)", gatelatch, header)
+		return
+	}
+
+	w.Write([]byte(fmt.Sprintf("Error status: %d\n", status)))
+	w.Write([]byte(fmt.Sprintf("Data: %#v\n", data)))
+	w.Write([]byte(fmt.Sprintf("Error: %+v\n", err)))
+
+	if stack == nil {
+		w.Write([]byte("Created stack: \n"))
+		w.Write(debug.Stack())
+	} else {
+		w.Write([]byte("Passed (panic) stack: \n"))
+		w.Write(stack)
+	}
+	return
+}
+
 // HandleResponse returns a 500 and logs the error.
 // It uses the LogSet provided by the graph.
 func (ph *StatusMiddleware) HandleResponse(status int, r *http.Request, w http.ResponseWriter, data interface{}) {
@@ -23,6 +51,7 @@ func (ph *StatusMiddleware) HandleResponse(status int, r *http.Request, w http.R
 	ph.LogSet.Warn.Printf("Responding: %d %s: %s %s", status, http.StatusText(status), r.Method, r.URL)
 	if status >= 400 {
 		ph.LogSet.Warn.Printf("%+v", data)
+		ph.errorBody(status, r, w, data, nil, nil)
 	}
 	if status >= 200 && status < 300 {
 		ph.LogSet.Debug.Printf("%+v", data)
@@ -35,9 +64,14 @@ func (ph *StatusMiddleware) HandleResponse(status int, r *http.Request, w http.R
 // It uses the LogSet provided by the graph.
 func (ph *StatusMiddleware) HandlePanic(w http.ResponseWriter, r *http.Request, recovered interface{}) {
 	w.WriteHeader(http.StatusInternalServerError)
+	stack := debug.Stack()
+	if ph.LogSet == nil {
+		ph.LogSet = &sous.Log
+	}
 	ph.LogSet.Warn.Printf("%+v", recovered)
-	ph.LogSet.Warn.Print(string(debug.Stack()))
+	ph.LogSet.Warn.Print(string(stack))
 	ph.LogSet.Warn.Print("Recovered, returned 500")
+	ph.errorBody(http.StatusInternalServerError, r, w, nil, recovered.(error), stack)
 	// XXX in a dev mode, print the panic in the response body
 	// (normal ops it might leak secure data)
 }

--- a/test/http_state_manager_test.go
+++ b/test/http_state_manager_test.go
@@ -75,7 +75,9 @@ func TestWriteState(t *testing.T) {
 	di.Add(&config.Verbosity{})
 
 	gf := func() server.Injector {
-		return di.Clone()
+		cdi := di.Clone()
+		server.AddsPerRequest(cdi)
+		return cdi
 	}
 
 	testServer := httptest.NewServer(server.SousRouteMap.BuildRouter(gf))

--- a/vendor/github.com/samsalisbury/psyringe/ctor.go
+++ b/vendor/github.com/samsalisbury/psyringe/ctor.go
@@ -61,12 +61,6 @@ func newCtor(t reflect.Type, v reflect.Value) *ctor {
 	}
 }
 
-func (c ctor) clone() *ctor {
-	c.once = &sync.Once{}
-	c.errChan = make(chan error)
-	return &c
-}
-
 func (c *ctor) testParametersAreRegisteredIn(s *Psyringe) error {
 	for paramIndex, paramType := range c.inTypes {
 		if err := s.testValueOrConstructorIsRegistered(paramType); err != nil {

--- a/vendor/github.com/samsalisbury/psyringe/psyringe.go
+++ b/vendor/github.com/samsalisbury/psyringe/psyringe.go
@@ -136,7 +136,7 @@ func (p *Psyringe) Clone() *Psyringe {
 	q.values = map[reflect.Type]reflect.Value{}
 	q.injectionTypes = map[reflect.Type]struct{}{}
 	for t, c := range p.ctors {
-		q.ctors[t] = c.clone()
+		q.ctors[t] = c
 	}
 	for t, v := range p.values {
 		q.values[t] = v

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -225,10 +225,10 @@
 			"revisionTime": "2016-01-10T10:55:54Z"
 		},
 		{
-			"checksumSHA1": "maZ/ziYzdyN8LZH6q00lkXYt3CQ=",
+			"checksumSHA1": "ji8TTcw9KjodDxt93It1Mj/vt9c=",
 			"path": "github.com/samsalisbury/psyringe",
-			"revision": "79447a07959c81e5d4119b6cbd9ab2efd2b13f27",
-			"revisionTime": "2016-10-19T12:33:10Z"
+			"revision": "9006fc082d65ac138317a7fd49b082d17a04578c",
+			"revisionTime": "2017-01-14T00:10:57Z"
 		},
 		{
 			"checksumSHA1": "IRgb8yeKkWGY5gp1TLk9rpGitB0=",


### PR DESCRIPTION
The proximate cause was the the AutoResolver that `sous server` starts *was
not* the AutoResolver that the StatusHandler queried to get its status fields.

The cause of that was that Psyringe treats cloning as a horizon for all
constructed values: the cloned version will build brand new instances of
everything. This PR includes a vendored-in version of psyringe that changes
that behavior. That version is in a PR to that project.

A consequence of the change was that the (afaik accidental) use of that
.Clone() semantic to get a fresh GDM per request needed to be replaced with an
explicit server-local Add() of a new LiveGDM type.