### PR TITLE
(wip) DI update

### DIFF
--- a/server/graph.go
+++ b/server/graph.go
@@ -13,8 +13,8 @@ type (
 )
 
 // AddsPerRequest registers items into a SousGraph that need to be fresh per request
-func AddsPerRequest(g Injector) {
-	g.Add(liveGDM)
+func AddsPerRequest(g Injector, sr sous.StateReader) {
+	g.Add(liveGDM, sr)
 }
 
 func liveGDM(sr graph.StateReader) (*LiveGDM, error) {

--- a/server/routemap.go
+++ b/server/routemap.go
@@ -27,7 +27,7 @@ type (
 	// RouteMap is a list of entries for routing
 	RouteMap []routeEntry
 
-	// A ResourceFamily bundles up the exchangers that deal with a kind of resources
+	// A Resource bundles up the exchangers that deal with a kind of resources
 	// (n.b. that properly, URL == resource, so a URL pattern == many resources
 	Resource interface{}
 

--- a/server/routemap.go
+++ b/server/routemap.go
@@ -60,10 +60,11 @@ type (
 	*/
 )
 
-func (rm *RouteMap) buildMetaHandler(r *httprouter.Router, grf func() Injector) *MetaHandler {
+func (rm *RouteMap) buildMetaHandler(r *httprouter.Router, processGraph, requestGraph Injector) *MetaHandler {
 	ph := &StatusMiddleware{}
 	mh := &MetaHandler{
-		graphFac:      grf,
+		processGraph:  processGraph,
+		requestGraph:  requestGraph,
 		router:        r,
 		statusHandler: ph,
 	}
@@ -72,10 +73,11 @@ func (rm *RouteMap) buildMetaHandler(r *httprouter.Router, grf func() Injector) 
 	return mh
 }
 
-// BuildRouter builds a returns an http.Handler based on some constant configuration
-func (rm *RouteMap) BuildRouter(grf func() Injector) http.Handler {
+// BuildRouter builds a returns an http.Handler based on some constant
+// configuration.
+func (rm *RouteMap) BuildRouter(processGraph, requestGraph Injector) http.Handler {
 	r := httprouter.New()
-	mh := rm.buildMetaHandler(r, grf)
+	mh := rm.buildMetaHandler(r, processGraph, requestGraph)
 
 	for _, e := range *rm {
 		get, canGet := e.Resource.(Getable)

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -14,18 +14,20 @@ import (
 )
 
 func testInject(thing interface{}) error {
-	gf := func() Injector {
-		g := graph.BuildTestGraph(&bytes.Buffer{}, os.Stdout, os.Stdout)
-		g.Add(&config.Verbosity{})
-		return g
-	}
-	mh := &MetaHandler{graphFac: gf}
+	processGraph := graph.BuildTestGraph(&bytes.Buffer{}, os.Stdout, os.Stdout)
+	processGraph.Add(&config.Verbosity{})
+
+	requestGraph := BuildRequestGraph(processGraph)
+
+	mh := &MetaHandler{processGraph: processGraph, requestGraph: requestGraph}
 	w := httptest.NewRecorder()
 	r, err := http.NewRequest("GET", "/test", nil)
 	if err != nil {
 		panic(err)
 	}
 	p := httprouter.Params{}
+
+	processGraph.MustInject(thing)
 
 	return mh.ExchangeGraph(w, r, p).Inject(thing)
 }

--- a/vendor/github.com/samsalisbury/psyringe/ctor.go
+++ b/vendor/github.com/samsalisbury/psyringe/ctor.go
@@ -61,6 +61,12 @@ func newCtor(t reflect.Type, v reflect.Value) *ctor {
 	}
 }
 
+func (c ctor) clone() *ctor {
+	c.once = &sync.Once{}
+	c.errChan = make(chan error)
+	return &c
+}
+
 func (c *ctor) testParametersAreRegisteredIn(s *Psyringe) error {
 	for paramIndex, paramType := range c.inTypes {
 		if err := s.testValueOrConstructorIsRegistered(paramType); err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -225,10 +225,10 @@
 			"revisionTime": "2016-01-10T10:55:54Z"
 		},
 		{
-			"checksumSHA1": "ji8TTcw9KjodDxt93It1Mj/vt9c=",
+			"checksumSHA1": "5m3xP7Zeq2pBmc++h/UhPFPsFYA=",
 			"path": "github.com/samsalisbury/psyringe",
-			"revision": "9006fc082d65ac138317a7fd49b082d17a04578c",
-			"revisionTime": "2017-01-14T00:10:57Z"
+			"revision": "f1058a6a68cfc188137fc2223ab3969978405e0e",
+			"revisionTime": "2017-01-16T11:38:28Z"
 		},
 		{
 			"checksumSHA1": "IRgb8yeKkWGY5gp1TLk9rpGitB0=",


### PR DESCRIPTION
This needs a bit more tidy up, the idea was to remove the need for graph factories and replace them with a working `Psyringe.Clone` call (via newly-vendored psyringe library). To get this working, I added a method `BuildRequestGraph` which derives a request-scoped graph from the process-scoped main graph, this is used throughout. The aim of this change is that it's a refactoring, and should not affect functionality, but hopefully it will be a bit easier to reason about. Opening a PR early, more commits to come...