### PR TITLE
Sous deploy -repo tag

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -64,10 +64,20 @@ func SuccessYAML(v interface{}) cmdr.Result {
 // Plumbing injects a command with the current psyringe,
 // then it Executes it, returning the result.
 func (cli *CLI) Plumbing(cmd cmdr.Executor, args []string) cmdr.Result {
-	if err := cli.SousGraph.Inject(cmd); err != nil {
+	if err := cli.Plumb(cmd); err != nil {
 		return cmdr.EnsureErrorResult(err)
 	}
 	return cmd.Execute(args)
+}
+
+// Plumb injects a lists of commands with the currect psyringe, returning early in the event of an error
+func (cli *CLI) Plumb(cmds ...cmdr.Executor) error {
+	for _, cmd := range cmds {
+		if err := cli.SousGraph.Inject(cmd); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // BuildCLIGraph builds the CLI DI graph.

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -85,6 +85,28 @@ func TestInvokeDeploy(t *testing.T) {
 	assert.Equal(deploy.DeployFilterFlags.Tag, `1.2.3`)
 }
 
+func TestInvokeDeploy_RepoFlag(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	exe := justCommand(t, []string{`sous`, `deploy`, `-cluster`, `ci-sf`, `-tag`, `1.2.3`})
+	sd, ok := exe.Cmd.(*SousDeploy)
+	require.True(ok)
+	su := &SousUpdate{}
+	sd.CLI.Plumb(su)
+	assert.Equal(su.ResolveFilter.Repo, "")
+	assert.NotEqual(su.Manifest.ID().Source.Repo, "")
+	assert.NotEqual(su.Manifest.ID().Source.Repo, "github.com/example/project")
+
+	exe = justCommand(t, []string{`sous`, `deploy`, `-cluster`, `ci-sf`, `-repo`, `github.com/example/project`, `-tag`, `1.2.3`})
+	sd, ok = exe.Cmd.(*SousDeploy)
+	require.True(ok)
+	su = &SousUpdate{}
+	sd.CLI.Plumb(su)
+	assert.Equal(su.ResolveFilter.Repo, "github.com/example/project")
+	assert.Equal(su.Manifest.ID().Source.Repo, "github.com/example/project")
+}
+
 /*
 usage: sous context
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -86,6 +86,9 @@ func TestInvokeDeploy(t *testing.T) {
 }
 
 func TestInvokeDeploy_RepoFlag(t *testing.T) {
+	sous.Log.BeChatty()
+	defer sous.Log.BeQuiet()
+
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -93,18 +96,27 @@ func TestInvokeDeploy_RepoFlag(t *testing.T) {
 	sd, ok := exe.Cmd.(*SousDeploy)
 	require.True(ok)
 	su := &SousUpdate{}
-	sd.CLI.Plumb(su)
+	sps := &SousPlumbingStatus{}
+	sd.CLI.Plumb(su, sps)
+
 	assert.Equal(su.ResolveFilter.Repo, "")
 	assert.NotEqual(su.Manifest.ID().Source.Repo, "")
 	assert.NotEqual(su.Manifest.ID().Source.Repo, "github.com/example/project")
+
+	//	if assert.NotNil(sps.StatusPoller) {
+	//		assert.NotEqual(sps.StatusPoller.Repo, "")
+	//	}
 
 	exe = justCommand(t, []string{`sous`, `deploy`, `-cluster`, `ci-sf`, `-repo`, `github.com/example/project`, `-tag`, `1.2.3`})
 	sd, ok = exe.Cmd.(*SousDeploy)
 	require.True(ok)
 	su = &SousUpdate{}
-	sd.CLI.Plumb(su)
+	sd.CLI.Plumb(su, sps)
 	assert.Equal(su.ResolveFilter.Repo, "github.com/example/project")
 	assert.Equal(su.Manifest.ID().Source.Repo, "github.com/example/project")
+
+	//	assert.Equal(sps.StatusPoller.Repo, "github.com/example/project")
+
 }
 
 /*

--- a/cli/sous_update.go
+++ b/cli/sous_update.go
@@ -58,25 +58,7 @@ func (su *SousUpdate) Execute(args []string) cmdr.Result {
 
 	_, ok := su.State.Manifests.Get(sl)
 	if !ok {
-		sous.Log.Info.Printf("adding new manifest %q", did)
-		su.State.Manifests.Add(su.Manifest.Manifest)
-		if err := su.StateWriter.WriteState(su.State); err != nil {
-			return EnsureErrorResult(err)
-		}
-		newState, err := su.StateReader.ReadState()
-		if err != nil {
-			return EnsureErrorResult(err)
-		}
-		su.State = newState
-		newGDM, err := su.State.Deployments()
-		if err != nil {
-			return EnsureErrorResult(err)
-		}
-		su.GDM = graph.CurrentGDM{Deployments: newGDM}
-		_, ok := su.State.Manifests.Get(sl)
-		if !ok {
-			return GeneralErrorf("failed to add manifest %q", did)
-		}
+		return cmdr.UsageErrorf("No manifest found for %q - try 'sous init' first.", did)
 	}
 	if err := updateState(su.State, su.GDM, sid, did); err != nil {
 		return EnsureErrorResult(err)

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -477,10 +477,12 @@ func newStateManager(cl *sous.HTTPClient, c LocalSousConfig) *StateManager {
 }
 
 func newStatusPoller(cl *sous.HTTPClient, rf *sous.ResolveFilter) *sous.StatusPoller {
+	sous.Log.Debug.Printf("Building StatusPoller...")
 	if cl == nil {
-		sous.Log.Warn.Println("Unable to poll for status.")
+		sous.Log.Warn.Printf("Unable to poll for status.")
 		return nil
 	}
+	sous.Log.Debug.Printf("...looks good...")
 	return sous.NewStatusPoller(cl, rf)
 }
 

--- a/lib/logging.go
+++ b/lib/logging.go
@@ -57,6 +57,8 @@ func NewLogSet(warn, debug, vomit io.Writer) *LogSet {
 
 // BeChatty gets the LogSet to print all its output - useful for temporary debugging
 func (ls LogSet) BeChatty() {
+	ls.Warn.SetOutput(os.Stderr)
+	ls.Warn.SetFlags(log.Llongfile | log.Ltime)
 	ls.Vomit.SetOutput(os.Stderr)
 	ls.Vomit.SetFlags(log.Llongfile | log.Ltime)
 	ls.Debug.SetOutput(os.Stderr)


### PR DESCRIPTION
I couldn't reproduce the issue described in a test - if you note the tests
added to cli_test.go, you'll see that testing with and without -repo produces
the expected behavior.

Along the way I noted that `sous update` (which should perhaps properly be
moved to `plumbing`) will automatically perform a manifest creation, in a way
that is similar to, but separate from `sous init`. Given that manifests cannot
be deleted (at the moment, it's a git operation that requires rebooting all the
running sous servers), creating them automatically seems like a problem to me.
I've removed that option, with a warning to `sous init.`

Finally, I started to see how the StatusPoller doesn't quite align with other
tools that read from the git context. This bears more discussion, but part of
the upshot is that the poller (and therefore `deploy`) does respect the
workspace git context, then the interface to e.g. wait for a completely stable
cluster becomes harder.