### PR TITLE
Undoing nil Manifest from newManifest

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -100,6 +100,8 @@ func TestInvokeDeploy_RepoFlag(t *testing.T) {
 	sd.CLI.Plumb(su, sps)
 
 	assert.Equal(su.ResolveFilter.Repo, "")
+	sous.Log.Debug.Printf("%#v", su.Manifest)
+	sous.Log.Debug.Printf("%#v", su.Manifest.ID())
 	assert.NotEqual(su.Manifest.ID().Source.Repo, "")
 	assert.NotEqual(su.Manifest.ID().Source.Repo, "github.com/example/project")
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -86,9 +86,6 @@ func TestInvokeDeploy(t *testing.T) {
 }
 
 func TestInvokeDeploy_RepoFlag(t *testing.T) {
-	sous.Log.BeChatty()
-	defer sous.Log.BeQuiet()
-
 	assert := assert.New(t)
 	require := require.New(t)
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -94,11 +94,10 @@ func TestInvokeDeploy_RepoFlag(t *testing.T) {
 	require.True(ok)
 	su := &SousUpdate{}
 	sps := &SousPlumbingStatus{}
-	sd.CLI.Plumb(su, sps)
+	sous.Log.Debug.Printf("Plumbing Update...")
+	require.NoError(sd.CLI.Plumb(su, sps))
 
 	assert.Equal(su.ResolveFilter.Repo, "")
-	sous.Log.Debug.Printf("%#v", su.Manifest)
-	sous.Log.Debug.Printf("%#v", su.Manifest.ID())
 	assert.NotEqual(su.Manifest.ID().Source.Repo, "")
 	assert.NotEqual(su.Manifest.ID().Source.Repo, "github.com/example/project")
 

--- a/cli/sous_deploy.go
+++ b/cli/sous_deploy.go
@@ -47,7 +47,7 @@ func (sd *SousDeploy) AddFlags(fs *flag.FlagSet) {
 // labeller and registrar.
 func (sd *SousDeploy) RegisterOn(psy Addable) {
 	psy.Add(&sd.DeployFilterFlags)
-	//psy.Add(&sd.OTPLFlags)
+	psy.Add(&sd.OTPLFlags)
 	psy.Add(graph.DryrunOption(sd.dryrunOption))
 }
 

--- a/cli/sous_deploy.go
+++ b/cli/sous_deploy.go
@@ -34,7 +34,7 @@ func (sd *SousDeploy) Help() string { return sousDeployHelp }
 // AddFlags adds the flags for sous init.
 func (sd *SousDeploy) AddFlags(fs *flag.FlagSet) {
 	MustAddFlags(fs, &sd.DeployFilterFlags, DeployFilterFlagsHelp)
-	MustAddFlags(fs, &sd.OTPLFlags, OtplFlagsHelp)
+	//MustAddFlags(fs, &sd.OTPLFlags, OtplFlagsHelp)
 
 	fs.BoolVar(&sd.waitStable, "wait-stable", true,
 		"wait for the deploy to complete before returning (otherwise, use --wait-stable=false)")
@@ -47,7 +47,7 @@ func (sd *SousDeploy) AddFlags(fs *flag.FlagSet) {
 // labeller and registrar.
 func (sd *SousDeploy) RegisterOn(psy Addable) {
 	psy.Add(&sd.DeployFilterFlags)
-	psy.Add(&sd.OTPLFlags)
+	//psy.Add(&sd.OTPLFlags)
 	psy.Add(graph.DryrunOption(sd.dryrunOption))
 }
 

--- a/cli/sous_update.go
+++ b/cli/sous_update.go
@@ -38,7 +38,6 @@ func (su *SousUpdate) Help() string { return sousUpdateHelp }
 // AddFlags adds the flags for sous init.
 func (su *SousUpdate) AddFlags(fs *flag.FlagSet) {
 	MustAddFlags(fs, &su.DeployFilterFlags, DeployFilterFlagsHelp)
-	MustAddFlags(fs, &su.OTPLFlags, OtplFlagsHelp)
 }
 
 // RegisterOn adds the DeploymentConfig to the psyringe to configure the

--- a/graph/targetmanifest.go
+++ b/graph/targetmanifest.go
@@ -40,15 +40,19 @@ func newTargetManifest(auto userSelectedOTPLDeployManifest, tmid TargetManifestI
 	if ok {
 		return TargetManifest{m}
 	}
-	if auto.Manifest == nil {
-		return TargetManifest{}
+
+	var deploySpecs sous.DeploySpecs
+	if auto.Manifest != nil {
+		deploySpecs = auto.Manifest.Deployments
+		m = auto.Clone()
 	}
-	deploySpecs := auto.Manifest.Deployments
+	if m == nil {
+		m = &sous.Manifest{}
+	}
 	if len(deploySpecs) == 0 {
 		deploySpecs = defaultDeploySpecs(s.Defs.Clusters)
 	}
 
-	m = auto.Clone()
 	m.Deployments = deploySpecs
 	m.SetID(mid)
 

--- a/graph/targetmanifest.go
+++ b/graph/targetmanifest.go
@@ -37,6 +37,7 @@ func newTargetManifestID(f *sous.ResolveFilter, discovered *SourceContextDiscove
 func newTargetManifest(auto userSelectedOTPLDeployManifest, tmid TargetManifestID, s *sous.State) TargetManifest {
 	mid := sous.ManifestID(tmid)
 	m, ok := s.Manifests.Get(mid)
+
 	if ok {
 		return TargetManifest{m}
 	}

--- a/graph/targetmanifest_test.go
+++ b/graph/targetmanifest_test.go
@@ -133,8 +133,6 @@ func TestNewUserSelectedOTPLDeploySpecs(t *testing.T) {
 }
 
 func TestNewTargetManifest_Existing(t *testing.T) {
-	sous.Log.BeChatty()
-	defer sous.Log.BeQuiet()
 	detected := userSelectedOTPLDeployManifest{}
 	sl := sous.MustParseSourceLocation("github.com/user/project")
 	flavor := "some-flavor"

--- a/graph/targetmanifest_test.go
+++ b/graph/targetmanifest_test.go
@@ -133,6 +133,8 @@ func TestNewUserSelectedOTPLDeploySpecs(t *testing.T) {
 }
 
 func TestNewTargetManifest_Existing(t *testing.T) {
+	sous.Log.BeChatty()
+	defer sous.Log.BeQuiet()
 	detected := userSelectedOTPLDeployManifest{}
 	sl := sous.MustParseSourceLocation("github.com/user/project")
 	flavor := "some-flavor"

--- a/lib/status_poller_test.go
+++ b/lib/status_poller_test.go
@@ -37,8 +37,6 @@ func TestResolveState_String(t *testing.T) {
 }
 
 func TestSubPoller_ComputeState(t *testing.T) {
-	Log.BeChatty()
-	defer Log.BeQuiet()
 	testRepo := "github.com/opentable/example"
 	testDir := "test"
 

--- a/test/http_state_manager_test.go
+++ b/test/http_state_manager_test.go
@@ -35,8 +35,6 @@ func buildManifest(cluster, repo, version string) *sous.Manifest {
 }
 
 func TestWriteState(t *testing.T) {
-	sous.Log.BeChatty()
-	defer sous.Log.BeQuiet()
 	steadyManifest := buildManifest("test-cluster", "github.com/opentable/steady", "1.2.3")
 	diesManifest := buildManifest("test-cluster", "github.com/opentable/dies", "133.56.987431")
 	changesManifest := buildManifest("test-cluster", "github.com/opentable/changes", "0.17.19")


### PR DESCRIPTION
Consequent to changes in the way otpl flags are processed,
newTargetManifest could (effectively) return a nil Manifest. None of its
consumers expect this behavior, so I'm reverting it, ensuring that an
empty Manifest (with default DeploySpecs) is always returned.