### PR TITLE
Several enhancements and fixes.

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -97,7 +97,8 @@ func TestInvokeDeploy_RepoFlag(t *testing.T) {
 	sous.Log.Debug.Printf("Plumbing Update...")
 	require.NoError(sd.CLI.Plumb(su, sps))
 
-	assert.Equal(su.ResolveFilter.Repo, "")
+	assert.NotEqual(su.ResolveFilter.Repo, "")
+	assert.NotEqual(su.ResolveFilter.Repo, "github.com/example/project")
 	assert.NotEqual(su.Manifest.ID().Source.Repo, "")
 	assert.NotEqual(su.Manifest.ID().Source.Repo, "github.com/example/project")
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -101,9 +101,11 @@ func TestInvokeDeploy_RepoFlag(t *testing.T) {
 	assert.NotEqual(su.Manifest.ID().Source.Repo, "")
 	assert.NotEqual(su.Manifest.ID().Source.Repo, "github.com/example/project")
 
-	//	if assert.NotNil(sps.StatusPoller) {
-	//		assert.NotEqual(sps.StatusPoller.Repo, "")
-	//	}
+	sous.Log.Debug.Printf("%#v", sps)
+	if assert.NotNil(sps.StatusPoller) {
+		assert.NotEqual(sps.StatusPoller.Repo, "")
+		assert.Equal(sps.StatusPoller.Repo, su.Manifest.ID().Source.Repo)
+	}
 
 	exe = justCommand(t, []string{`sous`, `deploy`, `-cluster`, `ci-sf`, `-repo`, `github.com/example/project`, `-tag`, `1.2.3`})
 	sd, ok = exe.Cmd.(*SousDeploy)
@@ -111,9 +113,9 @@ func TestInvokeDeploy_RepoFlag(t *testing.T) {
 	su = &SousUpdate{}
 	sd.CLI.Plumb(su, sps)
 	assert.Equal(su.ResolveFilter.Repo, "github.com/example/project")
-	assert.Equal(su.Manifest.ID().Source.Repo, "github.com/example/project")
 
-	//	assert.Equal(sps.StatusPoller.Repo, "github.com/example/project")
+	assert.Equal(su.Manifest.ID().Source.Repo, sps.StatusPoller.Repo)
+	assert.Equal(su.Manifest.ID().Source.Repo, "github.com/example/project")
 
 }
 
@@ -437,16 +439,4 @@ func TestInvokeBuildWithRepoSelector(t *testing.T) {
 	assert.NotNil(build.Labeller)
 	assert.NotNil(build.Registrar)
 	assert.Equal(build.DeployFilterFlags.Repo, `github.com/opentable/sous`)
-
-}
-
-func TestInvokePlumbingStatus_noServer(t *testing.T) {
-	assert := assert.New(t)
-
-	_, exe, _, _ := prepareCommand(t, []string{`sous`, `plumbing`, `status`})
-	assert.Len(exe.Args, 0)
-
-	status := exe.Cmd.(*SousPlumbingStatus)
-
-	assert.Nil(status.StatusPoller)
 }

--- a/cli/sous_update.go
+++ b/cli/sous_update.go
@@ -19,14 +19,14 @@ type SousUpdate struct {
 	State             *sous.State
 	StateWriter       graph.StateWriter
 	StateReader       graph.StateReader
-	*sous.ResolveFilter
+	ResolveFilter     *graph.RefinedResolveFilter
 }
 
 func init() { TopLevelCommands["update"] = &SousUpdate{} }
 
 const sousUpdateHelp = `update the version to be deployed in a cluster
 
-usage: sous update -cluster <name> -tag <semver> [-use-otpl-deploy|-ignore-otpl-deploy]
+usage: sous update -cluster <name> [-tag <semver>] [-use-otpl-deploy|-ignore-otpl-deploy]
 
 sous update will update the version tag for this application in the named
 cluster. You can then use 'sous rectify' to have that version deployed.
@@ -50,7 +50,7 @@ func (su *SousUpdate) RegisterOn(psy Addable) {
 // Execute fulfills the cmdr.Executor interface.
 func (su *SousUpdate) Execute(args []string) cmdr.Result {
 	sl := su.Manifest.ID()
-	sid, did, err := getIDs(su.ResolveFilter, sl)
+	sid, did, err := getIDs((*sous.ResolveFilter)(su.ResolveFilter), sl)
 	if err != nil {
 		return EnsureErrorResult(err)
 	}

--- a/cli/sous_update_test.go
+++ b/cli/sous_update_test.go
@@ -147,7 +147,7 @@ func TestSousUpdate_Execute(t *testing.T) {
 		StateWriter:   graph.StateWriter{StateWriter: dsm},
 		GDM:           graph.CurrentGDM{Deployments: sous.MakeDeployments(0)},
 		Manifest:      graph.TargetManifest{Manifest: &sous.Manifest{}},
-		ResolveFilter: &sous.ResolveFilter{},
+		ResolveFilter: &graph.RefinedResolveFilter{},
 	}
 	su.Execute(nil)
 }

--- a/graph/sourcecontext_test.go
+++ b/graph/sourcecontext_test.go
@@ -23,15 +23,17 @@ func TestResolveSourceLocation_failure(t *testing.T) {
 }
 
 func assertSourceContextError(t *testing.T, flags *sous.ResolveFilter, ctx *SourceContextDiscovery, msgPattern string) {
-	_, actualErr := newTargetManifestID(flags, ctx)
+	_, actualErr := newRefinedResolveFilter(flags, ctx)
 	assert.NotNil(t, actualErr)
 	assert.Regexp(t, msgPattern, actualErr.Error())
 }
 
 func assertSourceContextSuccess(t *testing.T, expected sous.ManifestID, flags *sous.ResolveFilter, ctx *sous.SourceContext) {
 	disco := &SourceContextDiscovery{SourceContext: ctx}
-	actual, err := newTargetManifestID(flags, disco)
+	rrf, err := newRefinedResolveFilter(flags, disco)
 	require.NoError(t, err)
+
+	actual, err := newTargetManifestID(rrf)
 	assert.Equal(t, actual.Source.Repo, expected.Source.Repo, "repos differ")
 	assert.Equal(t, actual.Source.Dir, expected.Source.Dir, "offsets differ")
 	assert.Equal(t, actual.Flavor, expected.Flavor, "flavors differ")

--- a/graph/targetmanifest.go
+++ b/graph/targetmanifest.go
@@ -5,7 +5,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-func newTargetManifestID(f *sous.ResolveFilter, discovered *SourceContextDiscovery) (TargetManifestID, error) {
+type RefinedResolveFilter sous.ResolveFilter
+
+func newRefinedResolveFilter(f *sous.ResolveFilter, discovered *SourceContextDiscovery) (*RefinedResolveFilter, error) {
 	c := discovered.GetContext()
 	if f == nil { // XXX I think this needs to be supplied anyway by consumers...
 		f = &sous.ResolveFilter{}
@@ -18,20 +20,33 @@ func newTargetManifestID(f *sous.ResolveFilter, discovered *SourceContextDiscove
 	}
 	if f.Offset != "" {
 		if f.Repo == "" {
-			return TargetManifestID{}, errors.Errorf("-offset doesn't make sense without a -repo or workspace remote")
+			return nil, errors.Errorf("-offset doesn't make sense without a -repo or workspace remote")
 		}
 		offset = f.Offset
 	}
 	if repo == "" {
-		return TargetManifestID{}, errors.Errorf("no repo specified, please use -repo or run sous inside a git repo with a configured remote")
+		return nil, errors.Errorf("no repo specified, please use -repo or run sous inside a git repo with a configured remote")
 	}
-	return TargetManifestID{
-		Source: sous.SourceLocation{
-			Repo: repo,
-			Dir:  offset,
-		},
-		Flavor: f.Flavor,
-	}, nil
+	rrf := RefinedResolveFilter(*f)
+	rrf.Repo = repo
+	rrf.Offset = offset
+	return &rrf, nil
+}
+
+func newTargetManifestID(rrf *RefinedResolveFilter) (tmid TargetManifestID, err error) {
+	if rrf == nil {
+		err = errors.Errorf("nil ResolveFilter")
+		return
+	}
+	if rrf.Repo == "" {
+		err = errors.Errorf("empty Repo")
+		return
+	}
+	tmid.Source.Repo = rrf.Repo
+	tmid.Source.Dir = rrf.Offset
+	tmid.Flavor = rrf.Flavor
+
+	return
 }
 
 func newTargetManifest(auto userSelectedOTPLDeployManifest, tmid TargetManifestID, s *sous.State) TargetManifest {

--- a/graph/targetmanifest.go
+++ b/graph/targetmanifest.go
@@ -30,6 +30,9 @@ func newRefinedResolveFilter(f *sous.ResolveFilter, discovered *SourceContextDis
 	rrf := RefinedResolveFilter(*f)
 	rrf.Repo = repo
 	rrf.Offset = offset
+	if f.Tag == "" {
+		rrf.Tag = discovered.TagVersion()
+	}
 	return &rrf, nil
 }
 

--- a/graph/testsupport.go
+++ b/graph/testsupport.go
@@ -3,6 +3,8 @@ package graph
 import (
 	"io"
 
+	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/docker_registry"
 	"github.com/opentable/sous/util/yaml"
 )
 
@@ -25,12 +27,26 @@ func BuildTestGraph(in io.Reader, out, err io.Writer) *SousGraph {
 func TestGraphWithConfig(in io.Reader, out, err io.Writer, cfg string) *SousGraph {
 	graph := buildBaseGraph(in, out, err)
 	addTestFilesystem(graph)
+	addTestNetwork(graph)
 	graph.Add(configYAML(cfg))
 	return graph
 }
 
 func addTestFilesystem(graph adder) {
 	graph.Add(newTestConfigLoader)
+}
+
+func addTestNetwork(graph adder) {
+	graph.Add(newDummyHTTPClient)
+	graph.Add(newDummyDockerClient)
+}
+
+func newDummyHTTPClient() HTTPClient {
+	return HTTPClient{HTTPClient: &sous.DummyHTTPClient{}}
+}
+
+func newDummyDockerClient() LocalDockerClient {
+	return LocalDockerClient{Client: docker_registry.NewDummyClient()}
 }
 
 func newTestConfigLoader(configYAML configYAML) *ConfigLoader {

--- a/lib/auto_resolver.go
+++ b/lib/auto_resolver.go
@@ -20,6 +20,7 @@ type (
 	AutoResolver struct {
 		UpdateTime time.Duration
 		StateReader
+		GDM Deployments
 		*Resolver
 		*LogSet
 		listeners []autoResolveListener
@@ -162,7 +163,7 @@ func (ar *AutoResolver) resolveOnce(ac announceChannel) {
 		ac <- err
 		return
 	}
-	gdm, err := state.Deployments()
+	ar.GDM, err = state.Deployments()
 	ar.LogSet.Debug.Printf("Reading GDM from state: err: %v", err)
 
 	if err != nil {
@@ -171,7 +172,7 @@ func (ar *AutoResolver) resolveOnce(ac announceChannel) {
 	}
 
 	ar.write(func() {
-		ar.currentRecorder = ar.Resolver.Begin(gdm, state.Defs.Clusters)
+		ar.currentRecorder = ar.Resolver.Begin(ar.GDM, state.Defs.Clusters)
 	})
 	defer ar.write(func() {
 		ar.currentRecorder = nil

--- a/lib/http_state_manager.go
+++ b/lib/http_state_manager.go
@@ -11,7 +11,7 @@ type (
 	// back to that server.
 	HTTPStateManager struct {
 		cached *State
-		*HTTPClient
+		HTTPClient
 	}
 
 	gdmWrapper struct {
@@ -28,7 +28,7 @@ func (g *gdmWrapper) manifests(defs Defs) (Manifests, error) {
 }
 
 // NewHTTPStateManager creates a new HTTPStateManager.
-func NewHTTPStateManager(client *HTTPClient) *HTTPStateManager {
+func NewHTTPStateManager(client HTTPClient) *HTTPStateManager {
 	return &HTTPStateManager{HTTPClient: client}
 }
 

--- a/lib/httpclient.go
+++ b/lib/httpclient.go
@@ -261,7 +261,7 @@ func (client *LiveHTTPClient) getBody(rz *http.Response, rzBody interface{}, err
 func logBody(dir, chName string, req *http.Request, b []byte, n int, err error) {
 	Log.Vomit.Printf("%s %s %q", chName, req.Method, req.URL)
 	comp := &bytes.Buffer{}
-	if err := json.Compact(comp, b); err != nil {
+	if err := json.Compact(comp, b[0:n]); err != nil {
 		Log.Vomit.Print(string(b))
 		Log.Vomit.Printf("(problem compacting JSON for logging: %s)", err)
 	} else {

--- a/lib/source_context.go
+++ b/lib/source_context.go
@@ -58,6 +58,16 @@ func (sc *SourceContext) AbsDir() string {
 	return filepath.Join(sc.RootDir, sc.OffsetDir)
 }
 
+// TagVersion returns a semver string if the most recent tag conforms to a
+// semver format. Otherwise it returns an empty string
+func (sc *SourceContext) TagVersion() string {
+	v, err := semv.Parse(sc.NearestTagName)
+	if err != nil {
+		return ""
+	}
+	return v.Format("M.m.p")
+}
+
 func nearestVersion(tags []Tag) semv.Version {
 	for _, t := range tags {
 		v, err := semv.Parse(t.Name)

--- a/lib/status_poller.go
+++ b/lib/status_poller.go
@@ -9,12 +9,12 @@ import (
 type (
 	// StatusPoller polls servers for status.
 	StatusPoller struct {
-		*HTTPClient
+		HTTPClient
 		*ResolveFilter
 	}
 
 	subPoller struct {
-		*HTTPClient
+		HTTPClient
 		ClusterName, URL string
 		*Deployments
 		locationFilter, idFilter *ResolveFilter
@@ -127,7 +127,7 @@ func (rs ResolveState) String() string {
 }
 
 // NewStatusPoller returns a new *StatusPoller.
-func NewStatusPoller(cl *HTTPClient, rf *ResolveFilter) *StatusPoller {
+func NewStatusPoller(cl HTTPClient, rf *ResolveFilter) *StatusPoller {
 	return &StatusPoller{
 		HTTPClient:    cl,
 		ResolveFilter: rf,

--- a/lib/status_poller.go
+++ b/lib/status_poller.go
@@ -294,7 +294,7 @@ func (sub *subPoller) pollOnce() ResolveState {
 // current DiffResolutions and computes the state of resolution for the
 // deployment based on that data.
 func (sub *subPoller) computeState(srvIntent *Deployment, stable, current *DiffResolution) ResolveState {
-	Log.Debug.Printf("%s reports intent to resolve %v", sub.URL, srvIntent)
+	Log.Debug.Printf("%s reports intent to resolve [%v]", sub.URL, srvIntent)
 	Log.Debug.Printf("%s reports stable rez: %v", sub.URL, stable)
 	Log.Debug.Printf("%s reports in-progress rez: %v", sub.URL, current)
 
@@ -359,7 +359,8 @@ func (sub *subPoller) computeState(srvIntent *Deployment, stable, current *DiffR
 }
 
 func (sub *subPoller) serverIntent() *Deployment {
-	Log.Vomit.Printf("Filtering %#v with %s", sub.Deployments, sub.locationFilter)
+	Log.Vomit.Printf("Filtering %#v", sub.Deployments)
+	Log.Debug.Printf("Filtering with %q", sub.locationFilter)
 	dep, exactlyOne := sub.Deployments.Single(sub.locationFilter.FilterDeployment)
 	if !exactlyOne {
 		Log.Debug.Printf("With %s we didn't match exactly one deployment! %#v", sub.locationFilter)

--- a/server/handle_gdm.go
+++ b/server/handle_gdm.go
@@ -21,6 +21,7 @@ func (gr *GDMResource) Get() Exchanger { return &GDMHandler{} }
 
 // Exchange implements the Handler interface
 func (h *GDMHandler) Exchange() (interface{}, int) {
+	sous.Log.Debug.Print(h.GDM)
 	data := gdmWrapper{Deployments: make([]*sous.Deployment, 0)}
 	for _, d := range h.GDM.Snapshot() {
 		data.Deployments = append(data.Deployments, d)

--- a/server/handle_status.go
+++ b/server/handle_status.go
@@ -3,7 +3,6 @@ package server
 import (
 	"net/http"
 
-	"github.com/opentable/sous/graph"
 	"github.com/opentable/sous/lib"
 )
 
@@ -14,7 +13,6 @@ type (
 
 	// StatusHandler handles requests for status.
 	StatusHandler struct {
-		GDM          graph.CurrentGDM
 		AutoResolver *sous.AutoResolver
 		*sous.ResolveFilter
 	}
@@ -31,7 +29,7 @@ func (*StatusResource) Get() Exchanger { return &StatusHandler{} }
 // Exchange implements the Handler interface.
 func (h *StatusHandler) Exchange() (interface{}, int) {
 	status := statusData{}
-	for _, d := range h.GDM.Filter(h.ResolveFilter.FilterDeployment).Snapshot() {
+	for _, d := range h.AutoResolver.GDM.Filter(h.ResolveFilter.FilterDeployment).Snapshot() {
 		status.Deployments = append(status.Deployments, d)
 	}
 	status.Completed, status.InProgress = h.AutoResolver.Statuses()

--- a/server/handle_status_test.go
+++ b/server/handle_status_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/nyarly/testify/assert"
-	"github.com/opentable/sous/graph"
 	"github.com/opentable/sous/lib"
 )
 
@@ -12,10 +11,9 @@ func TestHandlesStatusGet(t *testing.T) {
 	assert := assert.New(t)
 
 	th := &StatusHandler{
-		GDM: graph.CurrentGDM{
-			Deployments: sous.NewDeployments(),
+		AutoResolver: &sous.AutoResolver{
+			GDM: sous.NewDeployments(),
 		},
-		AutoResolver: &sous.AutoResolver{},
 	}
 	data, status := th.Exchange()
 	assert.Equal(status, 200)

--- a/server/server_injection_test.go
+++ b/server/server_injection_test.go
@@ -65,6 +65,6 @@ func TestStatusHandlerInjection(t *testing.T) {
 
 	sous.Log.Debug.Printf("%#v", statusGet)
 	assert.NotPanics(func() {
-		statusGet.GDM.Snapshot()
+		statusGet.AutoResolver.String()
 	})
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -86,7 +86,8 @@ func TestOverallRouter(t *testing.T) {
 	assert := assert.New(t)
 
 	gf := func() Injector {
-		g := graph.TestGraphWithConfig(&bytes.Buffer{}, os.Stdout, os.Stdout, "StateLocation: '../ext/storage/testdata/in'\n")
+		g := graph.TestGraphWithConfig(&bytes.Buffer{}, os.Stdout, os.Stdout,
+			"StateLocation: '../ext/storage/testdata/in'\n")
 		g.Add(&config.Verbosity{})
 		AddsPerRequest(g)
 		return g


### PR DESCRIPTION
(sorry this is scattered - juggling with office work & meetings)

sous update, if run in a properly tagged workspace, no longer requires a
-tag or -repo flags.

A significant issue with status polling is fixed: the status endpoint
handler reports the GDM as known to the AutoResolver, rather than the GDM
loaded at boot time. This bug was causing spurious ResolveNotVersion
results, because servers were reporting that they did not know of the
version we were waiting on - in fact they did, but they were reporting a
snapshot of the GDM from when they booted.