### PR TITLE
sous-init -use-otpl respects flavors

### DIFF
--- a/config/otpl.go
+++ b/config/otpl.go
@@ -5,4 +5,7 @@ package config
 type OTPLFlags struct {
 	UseOTPLDeploy    bool `flag:"use-otpl-deploy"`
 	IgnoreOTPLDeploy bool `flag:"ignore-otpl-deploy"`
+	// Flavor is required when multiple flavors are present in otpl-deploy
+	// config.
+	Flavor string `flag:"flavor"`
 }

--- a/doc/sous0.1.md
+++ b/doc/sous0.1.md
@@ -2,6 +2,14 @@
 
 ## Patches
 
+### 0.1.9 DRAFT
+
+- 'sous init -use-otpl-deploy' now supports flavors
+  defined by otpl config directories in the `<cluster>.<flavor>` format.
+  If there is a single flavor defined, behaviour is like before.
+  Otherwise you may supply a -flavor flag to import configurations of a particular flavor.
+
+
 ### 0.1.8
 
 - Feature: 'sous init' -use-otpl-config now imports owners from singularity-request.json

--- a/ext/otpl/otpl.go
+++ b/ext/otpl/otpl.go
@@ -60,7 +60,7 @@ func NewManifestParser() *ManifestParser {
 	return &ManifestParser{debugf: sous.Log.Debug.Printf, debug: sous.Log.Debug.Println}
 }
 
-type namedDeploySpec struct {
+type otplDeployConfig struct {
 	Name string
 	Spec *sous.DeploySpec
 }
@@ -78,7 +78,7 @@ func (mp *ManifestParser) ParseManifests(wd shell.Shell) *sous.Manifest {
 		mp.debug(err)
 		return nil
 	}
-	c := make(chan namedDeploySpec)
+	c := make(chan otplDeployConfig)
 	manifestOwners := sous.NewOwnerSet()
 	wg := sync.WaitGroup{}
 	wg.Add(len(l))
@@ -97,7 +97,7 @@ func (mp *ManifestParser) ParseManifests(wd shell.Shell) *sous.Manifest {
 			}
 			if otplConfig, owners := mp.GetSingleDeploySpec(wd); otplConfig != nil {
 				name := path.Base(wd.Dir())
-				c <- namedDeploySpec{name, otplConfig}
+				c <- otplDeployConfig{name, otplConfig}
 				for o := range owners {
 					manifestOwners.Add(o)
 				}

--- a/ext/otpl/otpl.go
+++ b/ext/otpl/otpl.go
@@ -71,15 +71,16 @@ type otplDeployConfig struct {
 // ParseManifests searches the working directory of wd to find otpl-deploy
 // config files in their standard locations (config/{cluster-name}), and
 // converts them to sous.DeploySpecs.
-func (mp *ManifestParser) ParseManifests(wd shell.Shell) *sous.Manifest {
+func (mp *ManifestParser) ParseManifests(wd shell.Shell) sous.Manifests {
 	wd = wd.Clone()
+	manifests := sous.NewManifests()
 	if err := wd.CD("config"); err != nil {
-		return nil
+		return manifests
 	}
 	l, err := wd.List()
 	if err != nil {
 		mp.debug(err)
-		return nil
+		return manifests
 	}
 	c := make(chan *otplDeployConfig)
 	wg := sync.WaitGroup{}
@@ -110,10 +111,12 @@ func (mp *ManifestParser) ParseManifests(wd shell.Shell) *sous.Manifest {
 			owners.Add(o)
 		}
 	}
-	return &sous.Manifest{
-		Deployments: deployConfigs,
-		Owners:      owners.Slice(),
-	}
+	return sous.NewManifests(
+		&sous.Manifest{
+			Deployments: deployConfigs,
+			Owners:      owners.Slice(),
+		},
+	)
 }
 
 // ParseSingleOTPLConfig returns a single sous.DeploySpec from the working

--- a/ext/otpl/otpl_test.go
+++ b/ext/otpl/otpl_test.go
@@ -92,31 +92,33 @@ func TestManifestParser_ParseManifest(t *testing.T) {
 
 	actual := NewManifestParser().ParseManifests(wd)
 
-	expected := &sous.Manifest{
-		//Source: sous.MustParseSourceLocation("github.com/test/project"),
-		Flavor: "",
-		Owners: []string{"owner1@example.com"},
-		Kind:   "",
-		Deployments: sous.DeploySpecs{
-			"cluster1": sous.DeploySpec{
-				DeployConfig: sous.DeployConfig{
-					Resources: sous.Resources{
-						"cpus":   "0.002",
-						"memory": "96",
-						"ports":  "1",
+	expected := sous.NewManifests(
+		&sous.Manifest{
+			//Source: sous.MustParseSourceLocation("github.com/test/project"),
+			Flavor: "",
+			Owners: []string{"owner1@example.com"},
+			Kind:   "",
+			Deployments: sous.DeploySpecs{
+				"cluster1": sous.DeploySpec{
+					DeployConfig: sous.DeployConfig{
+						Resources: sous.Resources{
+							"cpus":   "0.002",
+							"memory": "96",
+							"ports":  "1",
+						},
+						Metadata: sous.Metadata(nil),
+						Args:     []string(nil),
+						Env: sous.Env{
+							"SOME_VAR": "22",
+						},
+						NumInstances: 2,
+						Volumes:      sous.Volumes(nil),
 					},
-					Metadata: sous.Metadata(nil),
-					Args:     []string(nil),
-					Env: sous.Env{
-						"SOME_VAR": "22",
-					},
-					NumInstances: 2,
-					Volumes:      sous.Volumes(nil),
+					Version: semv.MustParse("0.0.0"),
 				},
-				Version: semv.MustParse("0.0.0"),
 			},
 		},
-	}
+	)
 
 	if different, diffs := actual.Diff(expected); different {
 		t.Errorf("parsed manifest not as expected")

--- a/ext/otpl/otpl_test.go
+++ b/ext/otpl/otpl_test.go
@@ -90,7 +90,7 @@ func TestManifestParser_ParseManifest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actual := NewManifestParser().ParseManifest(wd)
+	actual := NewManifestParser().ParseManifests(wd)
 
 	expected := &sous.Manifest{
 		//Source: sous.MustParseSourceLocation("github.com/test/project"),

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -84,7 +84,7 @@ type (
 	TargetManifest struct{ *sous.Manifest }
 	// detectedOTPLDeployManifest is a set of otpl-deploy configured deployments
 	// that have been detected.
-	detectedOTPLDeployManifest struct{ *sous.Manifest }
+	detectedOTPLDeployManifest struct{ sous.Manifests }
 	// userSelectedOTPLDeployManifest is a set of otpl-deploy configured deploy
 	// specs that the user has explicitly selected. (May be empty.)
 	userSelectedOTPLDeployManifest struct{ *sous.Manifest }

--- a/graph/otpldeploy.go
+++ b/graph/otpldeploy.go
@@ -12,7 +12,7 @@ func newDetectedOTPLConfig(wd LocalWorkDirShell, otplFlags *config.OTPLFlags) (d
 		return detectedOTPLDeployManifest{}, nil
 	}
 	otplParser := otpl.NewManifestParser()
-	otplDeploySpecs := otplParser.ParseManifest(wd.Sh)
+	otplDeploySpecs := otplParser.ParseManifests(wd.Sh)
 	return detectedOTPLDeployManifest{otplDeploySpecs}, nil
 }
 

--- a/graph/otpldeploy.go
+++ b/graph/otpldeploy.go
@@ -1,6 +1,8 @@
 package graph
 
 import (
+	"fmt"
+
 	"github.com/opentable/sous/config"
 	"github.com/opentable/sous/ext/otpl"
 	"github.com/opentable/sous/lib"
@@ -18,7 +20,7 @@ func newDetectedOTPLConfig(wd LocalWorkDirShell, otplFlags *config.OTPLFlags) (d
 
 func newUserSelectedOTPLDeploySpecs(detected detectedOTPLDeployManifest, tmid TargetManifestID, flags *config.OTPLFlags, state *sous.State) (userSelectedOTPLDeployManifest, error) {
 	var nowt userSelectedOTPLDeployManifest
-	if detected.Manifest == nil {
+	if detected.Manifests.Len() == 0 {
 		return nowt, nil
 	}
 	mid := sous.ManifestID(tmid)
@@ -26,17 +28,36 @@ func newUserSelectedOTPLDeploySpecs(detected detectedOTPLDeployManifest, tmid Ta
 	if _, ok := state.Manifests.Get(mid); ok {
 		return nowt, nil
 	}
-	if !flags.UseOTPLDeploy && !flags.IgnoreOTPLDeploy && len(detected.Manifest.Deployments) != 0 {
+
+	var detectedManifest *sous.Manifest
+
+	if onlyManifest, err := detected.Manifests.Only(); err == nil {
+		// There is only one manifest, use it.
+		detectedManifest = onlyManifest
+		// There are multiple manifests, try to find one matching -flavor.
+	} else if flavoredManifest, ok := detected.Manifests.Single(func(m *sous.Manifest) bool {
+		return m.Flavor == flags.Flavor
+	}); ok {
+		detectedManifest = flavoredManifest
+	} else {
+		flavors := detected.Manifests.Flavors()
+		if flags.Flavor == "" {
+			defer sous.Log.Warn.Println("use the -flavor flag to pick a flavor")
+		}
+		return nowt, fmt.Errorf("flavor %q not detected; pick from: %s", flags.Flavor, flavors)
+	}
+
+	if !flags.UseOTPLDeploy && !flags.IgnoreOTPLDeploy && len(detectedManifest.Deployments) != 0 {
 		return nowt, errors.New("otpl-deploy detected in config/, please specify either -use-otpl-deploy, or -ignore-otpl-deploy to proceed")
 	}
 	if !flags.UseOTPLDeploy {
 		return nowt, nil
 	}
-	if len(detected.Manifest.Deployments) == 0 {
+	if len(detectedManifest.Deployments) == 0 {
 		return nowt, errors.New("use of otpl configuration was specified, but no valid deployments were found in config/")
 	}
 	deploySpecs := sous.DeploySpecs{}
-	for clusterName, spec := range detected.Manifest.Deployments {
+	for clusterName, spec := range detectedManifest.Deployments {
 		if _, ok := state.Defs.Clusters[clusterName]; !ok {
 			sous.Log.Warn.Printf("otpl-deploy config for cluster %q ignored", clusterName)
 			continue
@@ -48,7 +69,7 @@ func newUserSelectedOTPLDeploySpecs(detected detectedOTPLDeployManifest, tmid Ta
 	}
 	// Detach the user selected from the detected manifest, in case something
 	// else relies on the detected ones.
-	selectedManifest := detected.Manifest.Clone()
+	selectedManifest := detectedManifest.Clone()
 	selectedManifest.Deployments = deploySpecs
 	return userSelectedOTPLDeployManifest{selectedManifest}, nil
 }

--- a/graph/targetmanifest_test.go
+++ b/graph/targetmanifest_test.go
@@ -95,7 +95,7 @@ func TestNewUserSelectedOTPLDeploySpecs(t *testing.T) {
 
 		state.Defs.Clusters = test.Clusters
 		ds, err := newUserSelectedOTPLDeploySpecs(
-			detectedOTPLDeployManifest{Manifest: test.DetectedManifest},
+			detectedOTPLDeployManifest{Manifests: sous.NewManifests(test.DetectedManifest)},
 			test.TSL,
 			&test.Flags,
 			state,

--- a/lib/manifests.go
+++ b/lib/manifests.go
@@ -1,6 +1,11 @@
 package sous
 
-import "github.com/pkg/errors"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
 
 // Only returns the single Manifest in a Manifests
 //   XXX consider for inclusion in CMap
@@ -17,4 +22,38 @@ func (ms *Manifests) Only() (*Manifest, error) {
 		}
 		return p, nil
 	}
+}
+
+// Diff returns a true and a list of differences if ms and other are different.
+// Otherwise it returns (false, nil).
+func (ms Manifests) Diff(other Manifests) (bool, []string) {
+	o := other.Snapshot()
+	p := ms.Snapshot()
+	var diffs []string
+	diff := func(format string, a ...interface{}) { diffs = append(diffs, fmt.Sprintf(format, a...)) }
+	for mid, m := range p {
+		n, ok := o[mid]
+		if !ok {
+			diff("missing manifest %q", mid)
+			continue
+		}
+		_, diffs := m.Diff(n)
+		for _, d := range diffs {
+			diff("manifest %q: %s", mid, d)
+		}
+	}
+	for mid := range o {
+		if _, ok := p[mid]; !ok {
+			diff("extra manifest %q", mid)
+		}
+	}
+	return len(diffs) != 0, diffs
+}
+
+func (ms Manifests) String() string {
+	var mids []string
+	for _, mid := range ms.Keys() {
+		mids = append(mids, mid.String())
+	}
+	return fmt.Sprintf("Manifests(%s)", strings.Join(mids, ", "))
 }

--- a/lib/manifests.go
+++ b/lib/manifests.go
@@ -57,3 +57,16 @@ func (ms Manifests) String() string {
 	}
 	return fmt.Sprintf("Manifests(%s)", strings.Join(mids, ", "))
 }
+
+// Flavors returns all the flavors of manifests in this set of manifests.
+func (ms Manifests) Flavors() []string {
+	flavors := map[string]struct{}{}
+	for _, mid := range ms.Keys() {
+		flavors[mid.Flavor] = struct{}{}
+	}
+	var fs []string
+	for f := range flavors {
+		fs = append(fs, f)
+	}
+	return fs
+}

--- a/lib/manifests_test.go
+++ b/lib/manifests_test.go
@@ -1,0 +1,76 @@
+package sous
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestManifests_Diff(t *testing.T) {
+
+	manifest := func(id string, setFields ...func(m *Manifest)) *Manifest {
+		m := &Manifest{}
+		mid, err := ParseManifestID(id)
+		if err != nil {
+			panic(err)
+		}
+		m.SetID(mid)
+		for _, f := range setFields {
+			f(m)
+		}
+		return m
+	}
+
+	testCases := []struct {
+		A, B  Manifests
+		Diffs []string
+	}{
+		{
+			NewManifests(),
+			NewManifests(),
+			nil,
+		},
+		{
+			NewManifests(manifest("a")),
+			NewManifests(manifest("b")),
+			[]string{
+				`missing manifest "a"`,
+				`extra manifest "b"`,
+			},
+		},
+		{
+			NewManifests(manifest("a", func(m *Manifest) { m.Kind = ManifestKindWorker })),
+			NewManifests(manifest("a", func(m *Manifest) { m.Kind = ManifestKindWorker })),
+			nil,
+		},
+		{
+			NewManifests(manifest("a", func(m *Manifest) { m.Kind = ManifestKindWorker })),
+			NewManifests(manifest("a", func(m *Manifest) { m.Kind = ManifestKindOnDemand })),
+			[]string{
+				`manifest "a": kind; this: "worker"; other: "on-demand"`,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s.Diff(%s)", tc.A, tc.B), func(t *testing.T) {
+			different, actual := tc.A.Diff(tc.B)
+			expected := tc.Diffs
+			if expected == nil && actual == nil {
+				if different {
+					t.Errorf("different == true; want false")
+				}
+				return
+			}
+			for i, expectedDiff := range expected {
+				if len(actual) <= i {
+					t.Errorf("got %d diffs; want %d", len(actual), len(expected))
+					break
+				}
+				actualDiff := actual[i]
+				if actualDiff != expectedDiff {
+					t.Errorf("got diff %q; want %q", actualDiff, expectedDiff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
I figure the best time to add release notes is alongside a PR, so added the following to doc/sous0.1.md ...

# Release notes:

- 'sous init -use-otpl-deploy' now supports flavors defined by otpl config directories in the `<cluster>.<flavor>` format. If there is a single flavor defined, behaviour is like before. Otherwise you may supply a -flavor flag to import configurations of a particular flavor.