### PR TITLE
Nuke containers from Makefile with clean-containers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,11 @@ clean:
 	rm -rf $(COVER_DIR)
 	git ls-files -o | xargs rm -rf
 
+clean-containers:
+	docker ps -q | xargs -r docker kill
+	docker ps -aq | xargs -r docker rm
+	if docker images | egrep ^testregistry_registry; then docker rmi testregistry_registry; fi
+
 gitlog:
 	git log `git describe --abbrev=0`..HEAD
 


### PR DESCRIPTION
This is super-destructive, so I've hesitated to add something like this to `make clean`. I only use containers for development on my local machine, so this is helpful for me:

1. Kill all running containers
2. rm all stopped containers
3. Delete the generated testregistry_registry image.