### PR TITLE
Treat Offset "" and Flavor "" as real values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ with respect to its command line interface and HTTP interface.
 
 ## [Unreleased]
 
+
 ### Added
 
 - 'sous init -use-otpl-deploy' now supports flavors
@@ -25,6 +26,9 @@ with respect to its command line interface and HTTP interface.
 - `sous deploy`
   (and `sous plumbing status`)
   now await Singularity marking the indended deployment as active before returning.
+### Fixed
+- Deployment filters (which are used extensively) now treat "" dirs and flavors
+  as real values, rather than wildcards.
 
 ## [0.1.8] - 2017-01-17
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"testing"
 
 	"github.com/nyarly/testify/assert"
@@ -298,7 +297,6 @@ func TestInvokeBareSous(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	log.SetFlags(log.Flags() | log.Lshortfile)
 	c, exe, _, _ := prepareCommand(t, []string{`sous`})
 	assert.Len(exe.Args, 0)
 
@@ -332,7 +330,6 @@ options:
 */
 
 func TestInvokeWithUnknownFlags(t *testing.T) {
-	log.SetFlags(log.Flags() | log.Lshortfile)
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -349,6 +346,9 @@ func TestInvokeWithUnknownFlags(t *testing.T) {
 }
 
 func TestInvokeRectifyWithoutFilterFlags(t *testing.T) {
+	sous.Log.BeChatty()
+	defer sous.Log.BeQuiet()
+
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -363,6 +363,8 @@ func TestInvokeRectifyWithoutFilterFlags(t *testing.T) {
 	require.NotNil(rect.SourceFlags)
 	assert.Equal(rect.SourceFlags.All, false)
 	require.NotNil(rect.Resolver.ResolveFilter)
+
+	sous.Log.Vomit.Printf("%#v", rect.Resolver.ResolveFilter)
 	assert.Equal(rect.Resolver.ResolveFilter.All(), true)
 }
 

--- a/cli/rectify_test.go
+++ b/cli/rectify_test.go
@@ -40,7 +40,7 @@ func TestPredicateBuilder(t *testing.T) {
 	//		fmt.Printf("%d: %#v\n", i, d)
 	//	}
 	//
-	f := config.DeployFilterFlags{}
+	f := config.DeployFilterFlags{Offset: "*", Flavor: "*"}
 
 	rf, err := f.BuildFilter(parseSL)
 	assert.NoError(err)
@@ -74,7 +74,7 @@ func TestPredicateBuilder(t *testing.T) {
 	assert.Contains(filtered, ds[0])
 	assert.Len(filtered, 1)
 
-	f = config.DeployFilterFlags{Cluster: cs[1]}
+	f = config.DeployFilterFlags{Offset: "*", Flavor: "*", Cluster: cs[1]}
 	pd, err = f.BuildPredicate(parseSL)
 	assert.NoError(err)
 	assert.NotNil(pd)

--- a/cli/sous_rectify.go
+++ b/cli/sous_rectify.go
@@ -50,7 +50,8 @@ func (*SousRectify) Help() string { return sousRectifyHelp }
 
 // AddFlags adds flags for sous rectify.
 func (sr *SousRectify) AddFlags(fs *flag.FlagSet) {
-	MustAddFlags(fs, &sr.SourceFlags, RectifyFilterFlagsHelp)
+	MustAddFlags(fs, &sr.SourceFlags, RectifyFilterFlagsHelp,
+		map[string]interface{}{"offset": "*", "flavor": "*"})
 
 	fs.StringVar(&sr.flags.dryrun, "dry-run", "none",
 		"prevent rectify from actually changing things - "+

--- a/config/deploy_filter.go
+++ b/config/deploy_filter.go
@@ -25,11 +25,12 @@ func (f *DeployFilterFlags) BuildFilter(parseSL func(string) (sous.SourceLocatio
 	rf := &sous.ResolveFilter{}
 
 	rf.Repo = f.Repo
-	rf.Offset = f.Offset
-	rf.Flavor = f.Flavor
 	rf.Cluster = f.Cluster
 	rf.Tag = f.Tag
 	rf.Revision = f.Revision
+
+	rf.Offset = f.Offset
+	rf.Flavor = f.Flavor
 
 	if f.Source != "" {
 		if f.Repo != "" {

--- a/config/deploy_filter.go
+++ b/config/deploy_filter.go
@@ -29,8 +29,16 @@ func (f *DeployFilterFlags) BuildFilter(parseSL func(string) (sous.SourceLocatio
 	rf.Tag = f.Tag
 	rf.Revision = f.Revision
 
-	rf.Offset = f.Offset
-	rf.Flavor = f.Flavor
+	if f.Offset == "*" || (f.Offset == "" && f.All) {
+		rf.Offset = sous.ResolveFieldMatcher{All: true}
+	} else {
+		rf.Offset = sous.ResolveFieldMatcher{Match: f.Offset}
+	}
+	if f.Flavor == "*" || (f.Flavor == "" && f.All) {
+		rf.Flavor = sous.ResolveFieldMatcher{All: true}
+	} else {
+		rf.Flavor = sous.ResolveFieldMatcher{Match: f.Flavor}
+	}
 
 	if f.Source != "" {
 		if f.Repo != "" {
@@ -44,7 +52,7 @@ func (f *DeployFilterFlags) BuildFilter(parseSL func(string) (sous.SourceLocatio
 			return nil, errors.Wrap(err, "error parsing -source flag")
 		}
 		rf.Repo = sl.Repo
-		rf.Offset = sl.Dir
+		rf.Offset.Match = sl.Dir
 	}
 
 	if f.All && !rf.All() {

--- a/config/deploy_filter_test.go
+++ b/config/deploy_filter_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/nyarly/testify/assert"
+	"github.com/opentable/sous/ext/github"
+	sous "github.com/opentable/sous/lib"
+)
+
+func TestDeployFilter(t *testing.T) {
+	shc := sous.SourceHostChooser{SourceHosts: []sous.SourceHost{github.SourceHost{}}}
+
+	dep := func(repo, offset, flavor string) *sous.Deployment {
+		return &sous.Deployment{
+			SourceID: sous.SourceID{
+				Location: sous.SourceLocation{
+					Repo: repo,
+					Dir:  offset,
+				},
+			},
+			Flavor: flavor,
+		}
+	}
+
+	deploys := []*sous.Deployment{
+		dep("github.com/opentable/example", "", ""),
+		dep("github.com/opentable/other", "", ""),
+		dep("github.com/opentable/example", "somewhere", ""),
+		dep("github.com/opentable/flavored", "", "choc"),
+		dep("github.com/opentable/flavored", "", "van"),
+	}
+
+	testFilter := func(df DeployFilterFlags, idxs ...int) {
+		rf, err := df.BuildFilter(shc.ParseSourceLocation)
+		assert.NoError(t, err)
+
+		for n, dep := range deploys {
+			if len(idxs) > 0 && idxs[0] == n {
+				assert.True(t, rf.FilterDeployment(dep), "%v doesn't match #%d %v", rf, n, dep)
+				idxs = idxs[1:]
+			} else {
+				assert.False(t, rf.FilterDeployment(dep), "%v matches #%d %v", rf, n, dep)
+			}
+		}
+	}
+
+	testFilter(DeployFilterFlags{All: true}, 0, 1, 2, 3, 4)
+	testFilter(DeployFilterFlags{Repo: deploys[0].SourceID.Location.Repo}, 0)
+	testFilter(DeployFilterFlags{Repo: deploys[1].SourceID.Location.Repo}, 1)
+	testFilter(DeployFilterFlags{}, 0, 1)
+	testFilter(DeployFilterFlags{Offset: ""}, 0, 1)
+	testFilter(DeployFilterFlags{Offset: "*"}, 0, 1, 2)
+	testFilter(DeployFilterFlags{Offset: "*", Flavor: "*"}, 0, 1, 2, 3, 4)
+	testFilter(DeployFilterFlags{Flavor: "choc"}, 3)
+
+}

--- a/graph/sourcecontext_test.go
+++ b/graph/sourcecontext_test.go
@@ -14,12 +14,10 @@ type resolveSourceLocationInput struct {
 }
 
 func TestResolveSourceLocation_failure(t *testing.T) {
-	assertSourceContextError(t, &sous.ResolveFilter{}, &SourceContextDiscovery{}, "no repo specified, please use -repo or run sous inside a git repo with a configured remote")
-	assertSourceContextError(t, nil, &SourceContextDiscovery{}, "no repo specified, please use -repo or run sous inside a git repo with a configured remote")
-	assertSourceContextError(t,
-		&sous.ResolveFilter{Offset: "some/offset"},
-		&SourceContextDiscovery{},
-		"-offset.*without.*-repo")
+	assertSourceContextError(t, &sous.ResolveFilter{}, &SourceContextDiscovery{},
+		"no repo specified, please use -repo or run sous inside a git repo with a configured remote")
+	assertSourceContextError(t, nil, &SourceContextDiscovery{},
+		"no repo specified, please use -repo or run sous inside a git repo with a configured remote")
 }
 
 func assertSourceContextError(t *testing.T, flags *sous.ResolveFilter, ctx *SourceContextDiscovery, msgPattern string) {
@@ -47,7 +45,7 @@ func TestResolveSourceLocation_success(t *testing.T) {
 	)
 	assertSourceContextSuccess(t,
 		sous.ManifestID{Source: sous.SourceLocation{Repo: "github.com/user/project", Dir: "some/path"}},
-		&sous.ResolveFilter{Repo: "github.com/user/project", Offset: "some/path"},
+		&sous.ResolveFilter{Repo: "github.com/user/project", Offset: sous.ResolveFieldMatcher{Match: "some/path"}},
 		&sous.SourceContext{
 			PrimaryRemoteURL: "github.com/user/project",
 			OffsetDir:        "some/path",

--- a/graph/targetmanifest.go
+++ b/graph/targetmanifest.go
@@ -12,20 +12,18 @@ func newRefinedResolveFilter(f *sous.ResolveFilter, discovered *SourceContextDis
 	if f == nil { // XXX I think this needs to be supplied anyway by consumers...
 		f = &sous.ResolveFilter{}
 	}
-	var repo, offset = c.PrimaryRemoteURL, c.OffsetDir
+	repo := c.PrimaryRemoteURL
+	offset := sous.ResolveFieldMatcher{Match: c.OffsetDir}
 
 	if f.Repo != "" {
 		repo = f.Repo
-		offset = ""
-	}
-	if f.Offset != "" {
-		if f.Repo == "" {
-			return nil, errors.Errorf("-offset doesn't make sense without a -repo or workspace remote")
-		}
-		offset = f.Offset
+		offset = sous.ResolveFieldMatcher{All: true}
 	}
 	if repo == "" {
 		return nil, errors.Errorf("no repo specified, please use -repo or run sous inside a git repo with a configured remote")
+	}
+	if !f.Offset.All {
+		offset = f.Offset
 	}
 	rrf := RefinedResolveFilter(*f)
 	rrf.Repo = repo
@@ -46,8 +44,8 @@ func newTargetManifestID(rrf *RefinedResolveFilter) (tmid TargetManifestID, err 
 		return
 	}
 	tmid.Source.Repo = rrf.Repo
-	tmid.Source.Dir = rrf.Offset
-	tmid.Flavor = rrf.Flavor
+	tmid.Source.Dir = rrf.Offset.Match
+	tmid.Flavor = rrf.Flavor.Match
 
 	return
 }

--- a/lib/status_poller_test.go
+++ b/lib/status_poller_test.go
@@ -39,7 +39,7 @@ func TestResolveState_String(t *testing.T) {
 
 func TestSubPoller_ComputeState(t *testing.T) {
 	testRepo := "github.com/opentable/example"
-	testDir := "test"
+	testDir := ""
 
 	rezErr := &ChangeError{}
 	permErr := fmt.Errorf("something bad")


### PR DESCRIPTION
This is in response to a StatusPoller bug I observed: empty offset or flavors
match all offsets or flavors, even though empty offsets and flavors are
(relatively) common. Maybe the rest of the filterable fields should be treated
the same way (with the defaults being "*" instead of "")? But in the meantime
this was a quick fix for an immediate problem.