### PR TITLE
A couple of output fixes for sous build and sous deploy

### DIFF
--- a/cli/sous_deploy.go
+++ b/cli/sous_deploy.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/opentable/sous/config"
 	"github.com/opentable/sous/graph"
@@ -66,6 +67,7 @@ func (sd *SousDeploy) Execute(args []string) cmdr.Result {
 	}
 
 	if sd.waitStable {
+		fmt.Fprintf(sd.CLI.Out, "Waiting for server to report that deploy has stabilized...")
 		return sd.CLI.Plumbing(&SousPlumbingStatus{}, []string{})
 	}
 	return cmdr.Successf("Updated the global deploy manifest. Deploy in process.")

--- a/cli/sous_update.go
+++ b/cli/sous_update.go
@@ -66,7 +66,7 @@ func (su *SousUpdate) Execute(args []string) cmdr.Result {
 	if err := su.StateWriter.WriteState(su.State, su.User); err != nil {
 		return EnsureErrorResult(err)
 	}
-	return cmdr.Success()
+	return cmdr.Success("Updated global manifest.")
 }
 
 func updateState(s *sous.State, gdm graph.CurrentGDM, sid sous.SourceID, did sous.DeployID) error {

--- a/ext/docker/dockerfile_buildpack.go
+++ b/ext/docker/dockerfile_buildpack.go
@@ -89,7 +89,9 @@ func (d *DockerfileBuildpack) Detect(c *sous.BuildContext) (*sous.DetectResult, 
 	if !c.Sh.Exists(dfPath) {
 		return nil, fmt.Errorf("%s does not exist", dfPath)
 	}
-	df, err := c.Sh.Stdout("cat", dfPath)
+	sh := c.Sh.Clone()
+	sh.LongRunning(false)
+	df, err := sh.Stdout("cat", dfPath)
 	if err != nil {
 		return nil, err
 	}

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -334,7 +334,9 @@ func (scd *SourceContextDiscovery) GetContext() *sous.SourceContext {
 }
 
 func newBuildContext(wd LocalWorkDirShell, c *sous.SourceContext) *sous.BuildContext {
-	return &sous.BuildContext{Sh: wd.Sh, Source: *c}
+	sh := wd.Sh.Clone()
+	sh.LongRunning(true)
+	return &sous.BuildContext{Sh: sh, Source: *c}
 }
 
 func newBuildConfig(f *config.DeployFilterFlags, p *config.PolicyFlags, bc *sous.BuildContext) *sous.BuildConfig {
@@ -423,7 +425,7 @@ func newDockerBuilder(cfg LocalSousConfig, cl LocalDockerClient, ctx *sous.Sourc
 	}
 	drh := cfg.Docker.RegistryHost
 	source.Sh = source.Sh.Clone().(*shell.Sh)
-	source.Sh.LongRunning = true
+	source.Sh.LongRunning(true)
 	return docker.NewBuilder(nc, drh, source.Sh, scratch.Sh)
 }
 

--- a/util/shell/sh.go
+++ b/util/shell/sh.go
@@ -28,10 +28,8 @@ type (
 		TeeErr io.Writer
 		// Debug sets each command issued by this shell into debug mode, or not
 		// depending on this value.
-		Debug bool
-		// LongRunning sets each command issued by this shell to be a
-		// long-running command. See Command.LongRunning for details.
-		LongRunning bool
+		Debug       bool
+		longRunning bool
 	}
 )
 
@@ -112,8 +110,13 @@ func (s *Sh) Cmd(name string, args ...interface{}) Cmd {
 		TeeOut:      s.TeeOut,
 		TeeErr:      s.TeeErr,
 		Debug:       s.Debug,
-		LongRunning: s.LongRunning,
+		LongRunning: s.longRunning,
 	}
+}
+
+// LongRunning sets the longRunning flag
+func (s *Sh) LongRunning(yes bool) {
+	s.longRunning = yes
 }
 
 // ConsoleEcho prints the command that sous is executing out

--- a/util/shell/shell.go
+++ b/util/shell/shell.go
@@ -42,6 +42,8 @@ type (
 		Exists(path string) bool
 		// ConsoleEcho outputs the line as if it were typed at the console
 		ConsoleEcho(line string)
+		// LongRunning marks a Shell as dealing with long running commands
+		LongRunning(bool)
 		// Cmd creates a new Command based on this shell.
 		Cmd(name string, args ...interface{}) Cmd
 		// CD changes the directory of this shell to the path specified. If the path is


### PR DESCRIPTION
`sous build` now reports the output of docker build (and docker push) on a
Linewise basis.

`sous deploy` emits a couple of lines to explain the ~20 second delay.