### PR TITLE
Quick stab at mechanizing WIP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ install:
 - "./bin/vendor-check"
 script:
 - make -j2 test && make coverage
-- cat doc/shellexamples/*.blended
+- make reject_wip
+  #- cat doc/shellexamples/*.blended
 after_success:
 - bin/codecov -f /tmp/sous-cover/count_merged.txt
 env:

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ reject_wip:
 wip:
 	touch workinprogress
 	git add workinprogress
-	git commit -m "Making WIP"
+	git commit -m "Making WIP" --no-gpg-sign --no-verify
 
 coverage: $(COVER_DIR)
 	engulf -s --coverdir=$(COVER_DIR) \

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ help:
 	@echo "make release:  Both linux and darwin"
 	@echo "make test: unit and integration"
 	@echo "make test-unit"
+	@echo "make wip: puts a marker file into workspace to prevent Travis from passing the build."
 	@echo
 	@echo "Add VERBOSE=1 for tons of extra output."
 
@@ -74,7 +75,6 @@ install_build_tools:
 	go get github.com/kardianos/govendor
 	go get github.com/nyarly/engulf
 
-
 linux-build: artifacts/$(LINUX_RELEASE_DIR)/sous
 	ln -sf ../$< dev_support/sous_linux
 
@@ -85,6 +85,14 @@ sous_qa_setup: ./dev_support/sous_qa_setup/*.go ./util/test_with_docker/*.go
 	go build ./dev_support/sous_qa_setup
 
 test: test-gofmt test-unit test-integration
+
+reject_wip:
+	test ! -f workinprogress
+
+wip:
+	touch workinprogress
+	git add workinprogress
+	git commit -m "Making WIP"
 
 coverage: $(COVER_DIR)
 	engulf -s --coverdir=$(COVER_DIR) \
@@ -141,4 +149,4 @@ artifacts/$(DARWIN_TARBALL): artifacts/$(DARWIN_RELEASE_DIR)/sous
 	cd artifacts && tar czv $(DARWIN_RELEASE_DIR) > $(DARWIN_TARBALL)
 
 
-.PHONY: clean coverage install-ggen legendary release semvertagchk test test-gofmt test-integration test-setup test-unit
+.PHONY: clean coverage install-ggen legendary release semvertagchk test test-gofmt test-integration test-setup test-unit reject_wip wip


### PR DESCRIPTION
Concept here is simple: there's an extra make target called "wip" that creates
and commits a specially named file to the repo. There's a Travis build script
step that fails if that file exists. Since we don't merge failing PRs, there's
no chance we'll accidentally merge an outstanding PR with the WIP tag file.

On the other hand, this means that using a WIP PR to build on Travis becomes
slightly more annoying, since you'll need to inspect the logs to check for
issues. The ideal case would be a separate check that simply looked for the
file and issued a failing check.