### PR TITLE
Bugfix init offset

### DIFF
--- a/ext/git/context_test.go
+++ b/ext/git/context_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/nyarly/testify/assert"
 )
 
-func TestRemoteProcessing(t *testing.T) {
+func TestGuessPrimaryRemote(t *testing.T) {
 	assert := assert.New(t)
 
 	rs := Remotes{

--- a/graph/targetmanifest.go
+++ b/graph/targetmanifest.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// RefinedResolveFilter is a sous.ResolveFilter refined by user-requested flags.
 type RefinedResolveFilter sous.ResolveFilter
 
 func newRefinedResolveFilter(f *sous.ResolveFilter, discovered *SourceContextDiscovery) (*RefinedResolveFilter, error) {

--- a/graph/targetmanifest.go
+++ b/graph/targetmanifest.go
@@ -10,7 +10,7 @@ type RefinedResolveFilter sous.ResolveFilter
 
 func newRefinedResolveFilter(f *sous.ResolveFilter, discovered *SourceContextDiscovery) (*RefinedResolveFilter, error) {
 	c := discovered.GetContext()
-	if f == nil { // XXX I think this needs to be supplied anyway by consumers...
+	if f == nil { // XXX I think this needs to be supplied anyway by consumers..
 		f = &sous.ResolveFilter{}
 	}
 	repo := c.PrimaryRemoteURL
@@ -23,7 +23,7 @@ func newRefinedResolveFilter(f *sous.ResolveFilter, discovered *SourceContextDis
 	if repo == "" {
 		return nil, errors.Errorf("no repo specified, please use -repo or run sous inside a git repo with a configured remote")
 	}
-	if !f.Offset.All {
+	if !f.Offset.All && offset.Match == "" {
 		offset = f.Offset
 	}
 	rrf := RefinedResolveFilter(*f)
@@ -35,20 +35,20 @@ func newRefinedResolveFilter(f *sous.ResolveFilter, discovered *SourceContextDis
 	return &rrf, nil
 }
 
-func newTargetManifestID(rrf *RefinedResolveFilter) (tmid TargetManifestID, err error) {
+func newTargetManifestID(rrf *RefinedResolveFilter) (TargetManifestID, error) {
 	if rrf == nil {
-		err = errors.Errorf("nil ResolveFilter")
-		return
+		return TargetManifestID{}, errors.Errorf("nil ResolveFilter")
 	}
 	if rrf.Repo == "" {
-		err = errors.Errorf("empty Repo")
-		return
+		return TargetManifestID{}, errors.Errorf("empty Repo")
 	}
-	tmid.Source.Repo = rrf.Repo
-	tmid.Source.Dir = rrf.Offset.Match
-	tmid.Flavor = rrf.Flavor.Match
-
-	return
+	return TargetManifestID{
+		Source: sous.SourceLocation{
+			Repo: rrf.Repo,
+			Dir:  rrf.Offset.Match,
+		},
+		Flavor: rrf.Flavor.Match,
+	}, nil
 }
 
 func newTargetManifest(auto userSelectedOTPLDeployManifest, tmid TargetManifestID, s *sous.State) TargetManifest {

--- a/lib/source_context_test.go
+++ b/lib/source_context_test.go
@@ -1,6 +1,8 @@
 package sous
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/nyarly/testify/assert"
@@ -18,4 +20,25 @@ func TestVersion(t *testing.T) {
 	assert.Equal("github.com/opentable/test", id.Location.Repo)
 	assert.Equal("sub", string(id.Location.Dir))
 	assert.Equal("1.2.3", id.Version.String())
+}
+
+func TestNormalisedOffset_nosymlinks(t *testing.T) {
+	rootDir := os.TempDir()
+	rootDir = filepath.Join("tempDir", "TestNormalisedOffset_nosymlinks")
+	if err := os.RemoveAll(rootDir); err != nil {
+		t.Fatal(err)
+	}
+	offsetDir := filepath.Join(rootDir, "some-offset")
+
+	os.MkdirAll(rootDir, 0777)
+	os.MkdirAll(offsetDir, 0777)
+
+	actual, err := NormalizedOffset(rootDir, offsetDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "some-offset"
+	if actual != expected {
+		t.Errorf("got %q; want %q", actual, expected)
+	}
 }

--- a/test/projects/fail-immediately/Dockerfile
+++ b/test/projects/fail-immediately/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+CMD echo "This image fails immediately."; exit 1
+


### PR DESCRIPTION
This is a little noisy and corrects a number of issues. See commits for details.

Most important bit is that a bug is fixed where 'sous init' (and every other command that relies on graph.TargetManifest) was not correctly picking up the source location offset. See the self review which follows for details.