### PR TITLE
Docker Labels in Singularity Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## [Unreleased](//github.com/opentable/sous/compare/0.2.0...HEAD)
+
+### Added
+
+- singularity.Deploy() adds Docker labels to the SingularityDeploy 'Metadata' field.
+- Added the 'labeller' element to the singularity.RectiAgent type.
+
 ## [0.2.0](//github.com/opentable/sous/compare/0.1.9...0.2.0) - 2017-03-06
 
 ### Added

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -34,12 +34,14 @@ func stripMetadata(in string) string {
 type RectiAgent struct {
 	singClients map[string]*singularity.Client
 	sync.RWMutex
+	labeller sous.ImageLabeller
 }
 
 // NewRectiAgent returns a set-up RectiAgent
-func NewRectiAgent() *RectiAgent {
+func NewRectiAgent(l sous.ImageLabeller) *RectiAgent {
 	return &RectiAgent{
 		singClients: make(map[string]*singularity.Client),
+		labeller:    l,
 	}
 }
 
@@ -56,8 +58,13 @@ func mapResources(r sous.Resources) dtoMap {
 // Deploy sends requests to Singularity to make a deployment happen
 func (ra *RectiAgent) Deploy(cluster, depID, reqID, dockerImage string,
 	r sous.Resources, e sous.Env, vols sous.Volumes) error {
+	labels, err := ra.labeller.ImageLabels(dockerImage)
+	if err != nil {
+		return err
+	}
+	Log.Debug.Printf("Collected docker image labels %#v", labels)
 	Log.Debug.Printf("Deploying instance %s %s %s %s %v %v", cluster, depID, reqID, dockerImage, r, e)
-	depReq, err := buildDeployRequest(dockerImage, e, r, reqID, depID, vols)
+	depReq, err := buildDeployRequest(dockerImage, e, r, reqID, depID, vols, labels)
 	if err != nil {
 		return err
 	}
@@ -67,7 +74,7 @@ func (ra *RectiAgent) Deploy(cluster, depID, reqID, dockerImage string,
 	return err
 }
 
-func buildDeployRequest(dockerImage string, e sous.Env, r sous.Resources, reqID string, depID string, vols sous.Volumes) (*dtos.SingularityDeployRequest, error) {
+func buildDeployRequest(dockerImage string, e sous.Env, r sous.Resources, reqID string, depID string, vols sous.Volumes, metadata map[string]string) (*dtos.SingularityDeployRequest, error) {
 	var depReq swaggering.Fielder
 	dockerInfo, err := swaggering.LoadMap(&dtos.SingularityDockerInfo{}, dtoMap{
 		"Image":   dockerImage,
@@ -114,10 +121,11 @@ func buildDeployRequest(dockerImage string, e sous.Env, r sous.Resources, reqID 
 		"Resources":     res,
 		"ContainerInfo": ci,
 		"Env":           map[string]string(e),
+		"Metadata":      metadata,
 	})
-	Log.Debug.Printf("Deploy: %+ v", dep)
-	Log.Debug.Printf("  Container: %+ v", ci)
-	Log.Debug.Printf("  Docker: %+ v", dockerInfo)
+	fmt.Printf("Deploy: %+ v", dep)
+	fmt.Printf("  Container: %+ v", ci)
+	fmt.Printf("  Docker: %+ v", dockerInfo)
 
 	depReq, err = swaggering.LoadMap(&dtos.SingularityDeployRequest{}, dtoMap{"Deploy": dep})
 	if err != nil {

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -123,9 +123,9 @@ func buildDeployRequest(dockerImage string, e sous.Env, r sous.Resources, reqID 
 		"Env":           map[string]string(e),
 		"Metadata":      metadata,
 	})
-	fmt.Printf("Deploy: %+ v", dep)
-	fmt.Printf("  Container: %+ v", ci)
-	fmt.Printf("  Docker: %+ v", dockerInfo)
+	Log.Debug.Printf("Deploy: %+ v", dep)
+	Log.Debug.Printf("  Container: %+ v", ci)
+	Log.Debug.Printf("  Docker: %+ v", dockerInfo)
 
 	depReq, err = swaggering.LoadMap(&dtos.SingularityDeployRequest{}, dtoMap{"Deploy": dep})
 	if err != nil {

--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -23,10 +23,44 @@ func TestBuildDeployRequest(t *testing.T) {
 	rez := sous.Resources{"cpus": "0.1"}
 	vols := sous.Volumes{&sous.Volume{}}
 
-	dr, err := buildDeployRequest(di, env, rez, rID, dID, vols)
+	testKey := "expectedKey"
+	testValue := "expectedValue"
+	md := map[string]string{
+		testKey: testValue,
+	}
+
+	dr, err := buildDeployRequest(di, env, rez, rID, dID, vols, md)
 	require.NoError(err)
 	assert.NotNil(dr)
 	assert.Equal(dr.Deploy.RequestId, rID)
+}
+
+func TestDockerMetadataSet(t *testing.T) {
+	logTempl := "expected:%s got:%s"
+
+	di := "dockerImage"
+	dID := "depID"
+	rID := "reqID"
+	env := sous.Env{"test": "yes"}
+	rez := sous.Resources{"cpus": "0.1"}
+	vols := sous.Volumes{&sous.Volume{}}
+
+	testKey := "expectedKey"
+	testValue := "expectedValue"
+	md := map[string]string{
+		testKey: testValue,
+	}
+
+	dr, err := buildDeployRequest(di, env, rez, rID, dID, vols, md)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if dr.Deploy.Metadata[testKey] == testValue {
+		t.Logf(logTempl, testValue, dr.Deploy.Metadata[testKey])
+	} else {
+		t.Fatalf(logTempl, testValue, dr.Deploy.Metadata[testKey])
+	}
 }
 
 func baseDeployablePair() *sous.DeployablePair {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -118,7 +118,7 @@ func (suite *integrationSuite) BeforeTest(suiteName, testName string) {
 	suite.registry.BecomeFoolishlyTrusting()
 
 	suite.nameCache = suite.newNameCache(testName)
-	suite.client = singularity.NewRectiAgent()
+	suite.client = singularity.NewRectiAgent(suite.nameCache)
 	suite.deployer = singularity.NewDeployer(suite.client)
 }
 
@@ -426,7 +426,7 @@ func (suite *integrationSuite) TestResolve() {
 	// XXX Let's hope this is a temporary solution to a testing issue
 	// The problem is laid out in DCOPS-7625
 	for tries := 0; tries < 3; tries++ {
-		client := singularity.NewRectiAgent()
+		client := singularity.NewRectiAgent(suite.nameCache)
 		deployer := singularity.NewDeployer(client)
 
 		r := sous.NewResolver(deployer, suite.nameCache, &sous.ResolveFilter{})


### PR DESCRIPTION
    singularity.Deploy() adds Docker labels to SingularityDeploy Metadata
    
    TestDockerMetadataSet()
    
    graph.newDockerRegistry() replaces graph.makeDockerRegistry()
    
    singularity.RectiAgent adds labeller member.
