### PR TITLE
ClusterName and Flavor in SingularityDeploy Metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
 after_script:
 - docker ps || true
 - docker logs testregistry_slave_1 || true
+after_success:
 - make coverage
 - bin/codecov -f /tmp/sous-cover/count_merged.txt
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,9 @@ script:
 - make -j2 test
 - make reject_wip
   #- cat doc/shellexamples/*.blended
+after_success:
 - docker ps || true
 - docker logs testregistry_slave_1 || true
-
-after_success:
 - make coverage
 - bin/codecov -f /tmp/sous-cover/count_merged.txt
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
 - make -j2 test
 - make reject_wip
   #- cat doc/shellexamples/*.blended
-after_success:
+after_script:
 - docker ps || true
 - docker logs testregistry_slave_1 || true
 - make coverage

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -37,7 +37,8 @@ type (
 	// rectificationClient abstracts the raw interactions with Singularity.
 	rectificationClient interface {
 		// Deploy creates a new deploy on a particular requeust
-		Deploy(clusterURI, clusterName, depID, reqID, dockerImage string, r sous.Resources, e sous.Env, vols sous.Volumes, flavor string) error
+		//Deploy(clusterURI, clusterName, depID, reqID, dockerImage string, r sous.Resources, e sous.Env, vols sous.Volumes, flavor string) error
+		Deploy(d sous.Deployable, depID, reqID, dockerImage string, r sous.Resources, e sous.Env, vols sous.Volumes) error
 
 		// PostRequest sends a request to a Singularity cluster to initiate
 		PostRequest(cluster, reqID string, instanceCount int, kind sous.ManifestKind, owners sous.OwnerSet) error
@@ -107,8 +108,8 @@ func (r *deployer) RectifySingleCreate(d *sous.Deployable) (err error) {
 		return err
 	}
 	return r.Client.Deploy(
-		d.Cluster.BaseURL, d.ClusterName, computeDeployID(d), reqID, name, d.Resources,
-		d.Env, d.DeployConfig.Volumes, d.Flavor)
+		*d, computeDeployID(d), reqID, name, d.Resources,
+		d.Env, d.DeployConfig.Volumes)
 }
 
 func (r *deployer) RectifyDeletes(dc <-chan *sous.Deployable, errs chan<- sous.DiffResolution) {
@@ -178,15 +179,13 @@ func (r *deployer) RectifySingleModification(pair *sous.DeployablePair) (err err
 		}
 
 		if err := r.Client.Deploy(
-			pair.Post.Cluster.BaseURL,
-			pair.Post.ClusterName,
+			*pair.Post,
 			computeDeployID(pair.Post),
 			computeRequestID(pair.Prior),
 			name,
 			pair.Post.Resources,
 			pair.Post.Env,
 			pair.Post.DeployConfig.Volumes,
-			pair.Post.Flavor,
 		); err != nil {
 			return err
 		}

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -37,7 +37,7 @@ type (
 	// rectificationClient abstracts the raw interactions with Singularity.
 	rectificationClient interface {
 		// Deploy creates a new deploy on a particular requeust
-		Deploy(cluster, depID, reqID, dockerImage string, r sous.Resources, e sous.Env, vols sous.Volumes) error
+		Deploy(clusterURI, clusterName, depID, reqID, dockerImage string, r sous.Resources, e sous.Env, vols sous.Volumes) error
 
 		// PostRequest sends a request to a Singularity cluster to initiate
 		PostRequest(cluster, reqID string, instanceCount int, kind sous.ManifestKind, owners sous.OwnerSet) error
@@ -107,7 +107,7 @@ func (r *deployer) RectifySingleCreate(d *sous.Deployable) (err error) {
 		return err
 	}
 	return r.Client.Deploy(
-		d.Cluster.BaseURL, computeDeployID(d), reqID, name, d.Resources,
+		d.Cluster.BaseURL, d.ClusterName, computeDeployID(d), reqID, name, d.Resources,
 		d.Env, d.DeployConfig.Volumes)
 }
 
@@ -179,6 +179,7 @@ func (r *deployer) RectifySingleModification(pair *sous.DeployablePair) (err err
 
 		if err := r.Client.Deploy(
 			pair.Post.Cluster.BaseURL,
+			pair.Post.ClusterName,
 			computeDeployID(pair.Post),
 			computeRequestID(pair.Prior),
 			name,

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -41,7 +41,7 @@ type (
 		Deploy(d sous.Deployable, reqID string) error
 
 		// PostRequest sends a request to a Singularity cluster to initiate
-		PostRequest(cluster, reqID string, instanceCount int, kind sous.ManifestKind, owners sous.OwnerSet) error
+		PostRequest(d sous.Deployable, reqID string) error
 
 		// DeleteRequest instructs Singularity to delete a particular request
 		DeleteRequest(cluster, reqID, message string) error
@@ -107,7 +107,8 @@ func (r *deployer) RectifySingleCreate(d *sous.Deployable) (err error) {
 		return err
 	}
 	reqID := computeRequestID(d)
-	if err = r.Client.PostRequest(d.Cluster.BaseURL, reqID, d.NumInstances, d.Kind, d.Owners); err != nil {
+	//if err = r.Client.PostRequest(d.Cluster.BaseURL, reqID, d.NumInstances, d.Kind, d.Owners); err != nil {
+	if err = r.Client.PostRequest(*d, reqID); err != nil {
 		return err
 	}
 	return r.Client.Deploy(*d, reqID)
@@ -161,13 +162,7 @@ func (r *deployer) RectifySingleModification(pair *sous.DeployablePair) (err err
 	defer rectifyRecover(pair, "RectifySingleModification", &err)
 	if r.changesReq(pair) {
 		Log.Debug.Printf("Updating Request...")
-		if err := r.Client.PostRequest(
-			pair.Post.Cluster.BaseURL,
-			computeRequestID(pair.Post),
-			pair.Post.NumInstances,
-			pair.Post.Kind,
-			pair.Post.Owners,
-		); err != nil {
+		if err := r.Client.PostRequest(*pair.Post, computeRequestID(pair.Post)); err != nil {
 			return err
 		}
 	}

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -37,7 +37,7 @@ type (
 	// rectificationClient abstracts the raw interactions with Singularity.
 	rectificationClient interface {
 		// Deploy creates a new deploy on a particular requeust
-		Deploy(clusterURI, clusterName, depID, reqID, dockerImage string, r sous.Resources, e sous.Env, vols sous.Volumes) error
+		Deploy(clusterURI, clusterName, depID, reqID, dockerImage string, r sous.Resources, e sous.Env, vols sous.Volumes, flavor string) error
 
 		// PostRequest sends a request to a Singularity cluster to initiate
 		PostRequest(cluster, reqID string, instanceCount int, kind sous.ManifestKind, owners sous.OwnerSet) error
@@ -108,7 +108,7 @@ func (r *deployer) RectifySingleCreate(d *sous.Deployable) (err error) {
 	}
 	return r.Client.Deploy(
 		d.Cluster.BaseURL, d.ClusterName, computeDeployID(d), reqID, name, d.Resources,
-		d.Env, d.DeployConfig.Volumes)
+		d.Env, d.DeployConfig.Volumes, d.Flavor)
 }
 
 func (r *deployer) RectifyDeletes(dc <-chan *sous.Deployable, errs chan<- sous.DiffResolution) {
@@ -186,6 +186,7 @@ func (r *deployer) RectifySingleModification(pair *sous.DeployablePair) (err err
 			pair.Post.Resources,
 			pair.Post.Env,
 			pair.Post.DeployConfig.Volumes,
+			pair.Post.Flavor,
 		); err != nil {
 			return err
 		}

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -37,7 +37,6 @@ type (
 	// rectificationClient abstracts the raw interactions with Singularity.
 	rectificationClient interface {
 		// Deploy creates a new deploy on a particular requeust
-		// Deploy(d sous.Deployable, depID, reqID, dockerImage string, r sous.Resources, e sous.Env, vols sous.Volumes) error
 		Deploy(d sous.Deployable, reqID string) error
 
 		// PostRequest sends a request to a Singularity cluster to initiate
@@ -51,13 +50,10 @@ type (
 	dtoMap map[string]interface{}
 )
 
-// SanitizeDeployID replaces characters forbidden in a Singularity deploy ID
-// with underscores.
 func sanitizeDeployID(in string) string {
 	return illegalDeployIDChars.ReplaceAllString(in, "_")
 }
 
-// StripDeployID removes all characters forbidden in a Singularity deployID.
 func stripDeployID(in string) string {
 	return illegalDeployIDChars.ReplaceAllString(in, "")
 }
@@ -107,7 +103,6 @@ func (r *deployer) RectifySingleCreate(d *sous.Deployable) (err error) {
 		return err
 	}
 	reqID := computeRequestID(d)
-	//if err = r.Client.PostRequest(d.Cluster.BaseURL, reqID, d.NumInstances, d.Kind, d.Owners); err != nil {
 	if err = r.Client.PostRequest(*d, reqID); err != nil {
 		return err
 	}

--- a/ext/singularity/deployer_test.go
+++ b/ext/singularity/deployer_test.go
@@ -172,7 +172,7 @@ func TestShortComputeDeployID(t *testing.T) {
 		},
 	}
 
-	deployID := computeDeployID(d)
+	deployID := d.ComputeDeployID()
 	parsedDeployID := strings.Split(deployID, "_")[0:3]
 	if reflect.DeepEqual(parsedDeployID, strings.Split(verStr, ".")) {
 		t.Logf(logTmpl, verStr, deployID)
@@ -208,7 +208,7 @@ func TestLongComputeDeployID(t *testing.T) {
 		},
 	}
 
-	deployID := computeDeployID(d)
+	deployID := d.ComputeDeployID()
 	parsedDeployID := strings.Split(deployID, "_")[0:3]
 	if reflect.DeepEqual(parsedDeployID, strings.Split("0.0.2", ".")) {
 		t.Logf(logTmpl, verStr, deployID)

--- a/ext/singularity/deployer_test.go
+++ b/ext/singularity/deployer_test.go
@@ -172,7 +172,7 @@ func TestShortComputeDeployID(t *testing.T) {
 		},
 	}
 
-	deployID := d.ComputeDeployID()
+	deployID := computeDeployID(d)
 	parsedDeployID := strings.Split(deployID, "_")[0:3]
 	if reflect.DeepEqual(parsedDeployID, strings.Split(verStr, ".")) {
 		t.Logf(logTmpl, verStr, deployID)
@@ -208,7 +208,7 @@ func TestLongComputeDeployID(t *testing.T) {
 		},
 	}
 
-	deployID := d.ComputeDeployID()
+	deployID := computeDeployID(d)
 	parsedDeployID := strings.Split(deployID, "_")[0:3]
 	if reflect.DeepEqual(parsedDeployID, strings.Split("0.0.2", ".")) {
 		t.Logf(logTmpl, verStr, deployID)

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -56,9 +56,6 @@ func mapResources(r sous.Resources) dtoMap {
 }
 
 // Deploy sends requests to Singularity to make a deployment happen
-// func (ra *RectiAgent) Deploy(clusterURI, clusterName, depID, reqID, dockerImage string,
-//func (ra *RectiAgent) Deploy(d sous.Deployable, depID, reqID, dockerImage string,
-////	r sous.Resources, e sous.Env, vols sous.Volumes) error {
 func (ra *RectiAgent) Deploy(d sous.Deployable, reqID string) error {
 	depID := d.ComputeDeployID()
 	dockerImage := d.BuildArtifact.Name
@@ -73,15 +70,11 @@ func (ra *RectiAgent) Deploy(d sous.Deployable, reqID string) error {
 	if err != nil {
 		return err
 	}
-	Log.Debug.Printf("Collected docker image labels %#v", labels)
 
 	labels[sous.SingularityDeployMetadataClusterName] = clusterName
-	Log.Debug.Printf("Added %s field to labels with value %s", sous.SingularityDeployMetadataClusterName, clusterName)
-
 	labels[sous.SingularityDeployMetadataFlavor] = flavor
-	Log.Debug.Printf("Added %s field to labels with value %s", sous.SingularityDeployMetadataFlavor, flavor)
 
-	Log.Debug.Printf("Deploying instance %s %s %s %s %s %s %v %v", clusterURI, clusterName, depID, reqID, flavor, dockerImage, r, e)
+	Log.Debug.Printf("Deploying instance %#v to request %s", d, reqID)
 	depReq, err := buildDeployRequest(dockerImage, e, r, reqID, depID, vols, labels)
 	if err != nil {
 		return err

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -56,21 +56,25 @@ func mapResources(r sous.Resources) dtoMap {
 }
 
 // Deploy sends requests to Singularity to make a deployment happen
-func (ra *RectiAgent) Deploy(cluster, depID, reqID, dockerImage string,
+func (ra *RectiAgent) Deploy(clusterURI, clusterName, depID, reqID, dockerImage string,
 	r sous.Resources, e sous.Env, vols sous.Volumes) error {
 	labels, err := ra.labeller.ImageLabels(dockerImage)
 	if err != nil {
 		return err
 	}
 	Log.Debug.Printf("Collected docker image labels %#v", labels)
-	Log.Debug.Printf("Deploying instance %s %s %s %s %v %v", cluster, depID, reqID, dockerImage, r, e)
+
+	labels[sous.SingularityDeployMetadataClusterName] = clusterName
+	Log.Debug.Printf("Added %s field to labels with value %s")
+
+	Log.Debug.Printf("Deploying instance %s %s %s %s %s %v %v", clusterURI, clusterName, depID, reqID, dockerImage, r, e)
 	depReq, err := buildDeployRequest(dockerImage, e, r, reqID, depID, vols, labels)
 	if err != nil {
 		return err
 	}
 
 	Log.Debug.Printf("Deploy req: %+ v", depReq)
-	_, err = ra.singularityClient(cluster).Deploy(depReq)
+	_, err = ra.singularityClient(clusterURI).Deploy(depReq)
 	return err
 }
 

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -57,7 +57,7 @@ func mapResources(r sous.Resources) dtoMap {
 
 // Deploy sends requests to Singularity to make a deployment happen
 func (ra *RectiAgent) Deploy(clusterURI, clusterName, depID, reqID, dockerImage string,
-	r sous.Resources, e sous.Env, vols sous.Volumes) error {
+	r sous.Resources, e sous.Env, vols sous.Volumes, flavor string) error {
 	labels, err := ra.labeller.ImageLabels(dockerImage)
 	if err != nil {
 		return err
@@ -65,9 +65,12 @@ func (ra *RectiAgent) Deploy(clusterURI, clusterName, depID, reqID, dockerImage 
 	Log.Debug.Printf("Collected docker image labels %#v", labels)
 
 	labels[sous.SingularityDeployMetadataClusterName] = clusterName
-	Log.Debug.Printf("Added %s field to labels with value %s")
+	Log.Debug.Printf("Added %s field to labels with value %s", sous.SingularityDeployMetadataClusterName, clusterName)
 
-	Log.Debug.Printf("Deploying instance %s %s %s %s %s %v %v", clusterURI, clusterName, depID, reqID, dockerImage, r, e)
+	labels[sous.SingularityDeployMetadataFlavor] = flavor
+	Log.Debug.Printf("Added %s field to labels with value %s", sous.SingularityDeployMetadataFlavor, flavor)
+
+	Log.Debug.Printf("Deploying instance %s %s %s %s %s %s %v %v", clusterURI, clusterName, depID, reqID, flavor, dockerImage, r, e)
 	depReq, err := buildDeployRequest(dockerImage, e, r, reqID, depID, vols, labels)
 	if err != nil {
 		return err
@@ -130,7 +133,6 @@ func buildDeployRequest(dockerImage string, e sous.Env, r sous.Resources, reqID 
 	Log.Debug.Printf("Deploy: %+ v", dep)
 	Log.Debug.Printf("  Container: %+ v", ci)
 	Log.Debug.Printf("  Docker: %+ v", dockerInfo)
-
 	depReq, err = swaggering.LoadMap(&dtos.SingularityDeployRequest{}, dtoMap{"Deploy": dep})
 	if err != nil {
 		return nil, err

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -57,11 +57,7 @@ func mapResources(r sous.Resources) dtoMap {
 
 // Deploy sends requests to Singularity to make a deployment happen
 func (ra *RectiAgent) Deploy(d sous.Deployable, reqID string) error {
-	depID := computeDeployID(&d)
 	dockerImage := d.BuildArtifact.Name
-	r := d.Deployment.DeployConfig.Resources
-	e := d.Deployment.DeployConfig.Env
-	vols := d.Deployment.DeployConfig.Volumes
 	clusterURI := d.Deployment.Cluster.BaseURL
 	clusterName := d.Deployment.ClusterName
 	flavor := d.Deployment.Flavor
@@ -75,7 +71,7 @@ func (ra *RectiAgent) Deploy(d sous.Deployable, reqID string) error {
 	labels[sous.SingularityDeployMetadataFlavor] = flavor
 
 	Log.Debug.Printf("Deploying instance %#v to request %s", d, reqID)
-	depReq, err := buildDeployRequest(dockerImage, e, r, reqID, depID, vols, labels)
+	depReq, err := buildDeployRequest(d, reqID, labels)
 	if err != nil {
 		return err
 	}
@@ -85,8 +81,14 @@ func (ra *RectiAgent) Deploy(d sous.Deployable, reqID string) error {
 	return err
 }
 
-func buildDeployRequest(dockerImage string, e sous.Env, r sous.Resources, reqID string, depID string, vols sous.Volumes, metadata map[string]string) (*dtos.SingularityDeployRequest, error) {
+func buildDeployRequest(d sous.Deployable, reqID string, metadata map[string]string) (*dtos.SingularityDeployRequest, error) {
 	var depReq swaggering.Fielder
+	depID := computeDeployID(&d)
+	dockerImage := d.BuildArtifact.Name
+	r := d.Deployment.DeployConfig.Resources
+	e := d.Deployment.DeployConfig.Env
+	vols := d.Deployment.DeployConfig.Volumes
+
 	dockerInfo, err := swaggering.LoadMap(&dtos.SingularityDockerInfo{}, dtoMap{
 		"Image":   dockerImage,
 		"Network": dtos.SingularityDockerInfoSingularityDockerNetworkTypeBRIDGE, //defaulting to all bridge

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -62,16 +62,10 @@ func (ra *RectiAgent) Deploy(d sous.Deployable, reqID string) error {
 	}
 	dockerImage := d.BuildArtifact.Name
 	clusterURI := d.Deployment.Cluster.BaseURL
-	clusterName := d.Deployment.ClusterName
-	flavor := d.Deployment.Flavor
-
 	labels, err := ra.labeller.ImageLabels(dockerImage)
 	if err != nil {
 		return err
 	}
-
-	labels[sous.SingularityDeployMetadataClusterName] = clusterName
-	labels[sous.SingularityDeployMetadataFlavor] = flavor
 
 	Log.Debug.Printf("Deploying instance %#v to request %s", d, reqID)
 	depReq, err := buildDeployRequest(d, reqID, labels)
@@ -91,6 +85,11 @@ func buildDeployRequest(d sous.Deployable, reqID string, metadata map[string]str
 	r := d.Deployment.DeployConfig.Resources
 	e := d.Deployment.DeployConfig.Env
 	vols := d.Deployment.DeployConfig.Volumes
+	clusterName := d.Deployment.ClusterName
+	flavor := d.Deployment.Flavor
+
+	metadata[sous.SingularityDeployMetadataClusterName] = clusterName
+	metadata[sous.SingularityDeployMetadataFlavor] = flavor
 
 	dockerInfo, err := swaggering.LoadMap(&dtos.SingularityDockerInfo{}, dtoMap{
 		"Image":   dockerImage,

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -57,6 +57,9 @@ func mapResources(r sous.Resources) dtoMap {
 
 // Deploy sends requests to Singularity to make a deployment happen
 func (ra *RectiAgent) Deploy(d sous.Deployable, reqID string) error {
+	if d.BuildArtifact == nil {
+		return &sous.MissingImageNameError{Cause: fmt.Errorf("Missing BuildArtifact on Deployable")}
+	}
 	dockerImage := d.BuildArtifact.Name
 	clusterURI := d.Deployment.Cluster.BaseURL
 	clusterName := d.Deployment.ClusterName

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -147,7 +147,11 @@ func buildDeployRequest(d sous.Deployable, reqID string, metadata map[string]str
 }
 
 // PostRequest sends requests to Singularity to create a new Request
-func (ra *RectiAgent) PostRequest(cluster, reqID string, instanceCount int, kind sous.ManifestKind, owners sous.OwnerSet) error {
+func (ra *RectiAgent) PostRequest(d sous.Deployable, reqID string) error {
+	cluster := d.Deployment.Cluster.BaseURL
+	instanceCount := d.Deployment.DeployConfig.NumInstances
+	kind := d.Deployment.Kind
+	owners := d.Deployment.Owners
 	Log.Debug.Printf("Creating application %s %s %d", cluster, reqID, instanceCount)
 	reqType, err := determineRequestType(kind)
 	if err != nil {

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -57,7 +57,7 @@ func mapResources(r sous.Resources) dtoMap {
 
 // Deploy sends requests to Singularity to make a deployment happen
 func (ra *RectiAgent) Deploy(d sous.Deployable, reqID string) error {
-	depID := d.ComputeDeployID()
+	depID := computeDeployID(&d)
 	dockerImage := d.BuildArtifact.Name
 	r := d.Deployment.DeployConfig.Resources
 	e := d.Deployment.DeployConfig.Env

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -57,11 +57,18 @@ func mapResources(r sous.Resources) dtoMap {
 
 // Deploy sends requests to Singularity to make a deployment happen
 // func (ra *RectiAgent) Deploy(clusterURI, clusterName, depID, reqID, dockerImage string,
-func (ra *RectiAgent) Deploy(d sous.Deployable, depID, reqID, dockerImage string,
-	r sous.Resources, e sous.Env, vols sous.Volumes) error {
+//func (ra *RectiAgent) Deploy(d sous.Deployable, depID, reqID, dockerImage string,
+////	r sous.Resources, e sous.Env, vols sous.Volumes) error {
+func (ra *RectiAgent) Deploy(d sous.Deployable, reqID string) error {
+	depID := d.ComputeDeployID()
+	dockerImage := d.BuildArtifact.Name
+	r := d.Deployment.DeployConfig.Resources
+	e := d.Deployment.DeployConfig.Env
+	vols := d.Deployment.DeployConfig.Volumes
 	clusterURI := d.Deployment.Cluster.BaseURL
 	clusterName := d.Deployment.ClusterName
 	flavor := d.Deployment.Flavor
+
 	labels, err := ra.labeller.ImageLabels(dockerImage)
 	if err != nil {
 		return err

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -56,8 +56,12 @@ func mapResources(r sous.Resources) dtoMap {
 }
 
 // Deploy sends requests to Singularity to make a deployment happen
-func (ra *RectiAgent) Deploy(clusterURI, clusterName, depID, reqID, dockerImage string,
-	r sous.Resources, e sous.Env, vols sous.Volumes, flavor string) error {
+// func (ra *RectiAgent) Deploy(clusterURI, clusterName, depID, reqID, dockerImage string,
+func (ra *RectiAgent) Deploy(d sous.Deployable, depID, reqID, dockerImage string,
+	r sous.Resources, e sous.Env, vols sous.Volumes) error {
+	clusterURI := d.Deployment.Cluster.BaseURL
+	clusterName := d.Deployment.ClusterName
+	flavor := d.Deployment.Flavor
 	labels, err := ra.labeller.ImageLabels(dockerImage)
 	if err != nil {
 		return err

--- a/ext/singularity/recti-agent_test.go
+++ b/ext/singularity/recti-agent_test.go
@@ -86,3 +86,15 @@ func TestDetermineRequestType(t *testing.T) {
 
 	}
 }
+
+func TestFailOnNilBuildArtifact(t *testing.T) {
+	r := sous.NewDummyRegistry()
+	d := sous.Deployable{}
+	ra := NewRectiAgent(r)
+	err := ra.Deploy(d, "testReq")
+	if err != nil {
+		t.Logf("Correctly returned an error upon encountering: %#v", err)
+	} else {
+		t.Fatal("Deploy did not return an error when given a sous.Deployable with an empty BuildArtifact")
+	}
+}

--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -253,7 +253,7 @@ func TestModify(t *testing.T) {
 
 	if assert.Len(client.Deployed, 1) {
 		assert.Regexp("2.3.4", client.Deployed[0].ImageName)
-		t.Log(client.Deployed[0].Vols)
+		t.Logf("VOLUMES:%#v", client.Deployed[0].Vols)
 		assert.Equal("RW", string(client.Deployed[0].Vols[0].Mode))
 	}
 

--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -159,7 +159,7 @@ func TestModifyScale(t *testing.T) {
 
 	assert.Len(client.Deployed, 0)
 	if assert.Len(client.Created, 1) {
-		assert.Equal(24, client.Created[0].Count)
+		assert.Equal(24, client.Created[0].Deployment.DeployConfig.NumInstances)
 	}
 }
 
@@ -269,7 +269,7 @@ func TestModify(t *testing.T) {
 	}
 
 	if assert.Len(client.Created, 1) {
-		assert.Equal(24, client.Created[0].Count)
+		assert.Equal(24, client.Created[0].Deployment.DeployConfig.NumInstances)
 	}
 
 	if assert.Len(client.Deployed, 1) {
@@ -379,8 +379,8 @@ func TestCreates(t *testing.T) {
 
 	if assert.Len(client.Created, 1) {
 		req := client.Created[0]
-		assert.Equal("cluster", req.Cluster)
-		assert.Equal("reqid::nick", req.ID)
-		assert.Equal(12, req.Count)
+		assert.Equal("cluster", req.Deployment.Cluster.BaseURL)
+		assert.Equal("reqid::nick", computeRequestID(&req))
+		assert.Equal(12, req.Deployment.DeployConfig.NumInstances)
 	}
 }

--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -172,7 +172,7 @@ func TestModifyImage(t *testing.T) {
 	assert.Len(client.Created, 0)
 
 	if assert.Len(client.Deployed, 1) {
-		assert.Regexp("2.3.4", client.Deployed[0].ImageName)
+		assert.Regexp("2.3.4", client.Deployed[0].BuildArtifact.Name)
 	}
 }
 
@@ -209,8 +209,8 @@ func TestModifyResources(t *testing.T) {
 	assert.Len(client.Created, 0)
 
 	if assert.Len(client.Deployed, 1) {
-		assert.Regexp("1.2.3", client.Deployed[0].ImageName)
-		assert.Regexp("500", client.Deployed[0].Res["memory"])
+		assert.Regexp("1.2.3", client.Deployed[0].BuildArtifact.Name)
+		assert.Regexp("500", client.Deployed[0].Deployment.DeployConfig.Resources["memory"])
 	}
 }
 
@@ -252,9 +252,9 @@ func TestModify(t *testing.T) {
 	}
 
 	if assert.Len(client.Deployed, 1) {
-		assert.Regexp("2.3.4", client.Deployed[0].ImageName)
-		t.Logf("VOLUMES:%#v", client.Deployed[0].Vols)
-		assert.Equal("RW", string(client.Deployed[0].Vols[0].Mode))
+		assert.Regexp("2.3.4", client.Deployed[0].BuildArtifact.Name)
+		t.Logf("VOLUMES:%#v", client.Deployed[0].Deployment.DeployConfig.Volumes)
+		assert.Equal("RW", string(client.Deployed[0].Deployment.DeployConfig.Volumes[0].Mode))
 	}
 
 }
@@ -352,8 +352,8 @@ func TestCreates(t *testing.T) {
 
 	if assert.Len(client.Deployed, 1) {
 		dep := client.Deployed[0]
-		assert.Equal("cluster", dep.Cluster)
-		assert.Equal("reqid,0.0.0", dep.ImageName)
+		assert.Equal("cluster", dep.Deployment.Cluster.BaseURL)
+		assert.Equal("reqid,0.0.0", dep.BuildArtifact.Name)
 	}
 
 	if assert.Len(client.Created, 1) {

--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -16,20 +16,28 @@ func TestBuildDeployRequest(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	di := "dockerImage"
-	dID := "depID"
-	rID := "reqID"
-	env := sous.Env{"test": "yes"}
-	rez := sous.Resources{"cpus": "0.1"}
-	vols := sous.Volumes{&sous.Volume{}}
-
-	testKey := "expectedKey"
-	testValue := "expectedValue"
-	md := map[string]string{
-		testKey: testValue,
-	}
-
-	dr, err := buildDeployRequest(di, env, rez, rID, dID, vols, md)
+	rID := "expectedRID"
+	dr, err := buildDeployRequest(sous.Deployable{
+		BuildArtifact: &sous.BuildArtifact{
+			Name: "an-image",
+			Type: "docker",
+		},
+		Deployment: &sous.Deployment{
+			SourceID: sous.SourceID{
+				Location: sous.SourceLocation{
+					Repo: "repo",
+				},
+			},
+			DeployConfig: sous.DeployConfig{
+				NumInstances: 1,
+				Resources:    sous.Resources{},
+			},
+			ClusterName: "cluster",
+			Cluster: &sous.Cluster{
+				BaseURL: "http://cluster",
+			},
+		},
+	}, rID, map[string]string{})
 	require.NoError(err)
 	assert.NotNil(dr)
 	assert.Equal(dr.Deploy.RequestId, rID)
@@ -37,25 +45,38 @@ func TestBuildDeployRequest(t *testing.T) {
 
 func TestDockerMetadataSet(t *testing.T) {
 	logTempl := "expected:%s got:%s"
-
-	di := "dockerImage"
-	dID := "depID"
-	rID := "reqID"
-	env := sous.Env{"test": "yes"}
-	rez := sous.Resources{"cpus": "0.1"}
-	vols := sous.Volumes{&sous.Volume{}}
-
 	testKey := "expectedKey"
 	testValue := "expectedValue"
 	md := map[string]string{
 		testKey: testValue,
 	}
 
-	dr, err := buildDeployRequest(di, env, rez, rID, dID, vols, md)
+	rID := "expectedRID"
+	dr, err := buildDeployRequest(sous.Deployable{
+		BuildArtifact: &sous.BuildArtifact{
+			Name: "an-image",
+			Type: "docker",
+		},
+		Deployment: &sous.Deployment{
+			SourceID: sous.SourceID{
+				Location: sous.SourceLocation{
+					Repo: "repo",
+				},
+			},
+			DeployConfig: sous.DeployConfig{
+				NumInstances: 1,
+				Resources:    sous.Resources{},
+			},
+			ClusterName: "cluster",
+			Cluster: &sous.Cluster{
+				BaseURL: "http://cluster",
+			},
+		},
+	}, rID, md)
+
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	if dr.Deploy.Metadata[testKey] == testValue {
 		t.Logf(logTempl, testValue, dr.Deploy.Metadata[testKey])
 	} else {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -409,12 +409,14 @@ func (suite *integrationSuite) TestResolve() {
 	clusters := []string{"test-cluster"}
 	ds, which := suite.deploymentWithRepo(clusters, repoOne)
 	deps := ds.Snapshot()
+	suite.T().Logf("which: %s", which)
 	if suite.NotEqual(which, none, "opentable/one not successfully deployed") {
 		one := deps[which]
 		suite.Equal(1, one.NumInstances)
 	}
 
 	which = suite.findRepo(ds, repoTwo)
+	suite.T().Logf("which: %s", which)
 	if suite.NotEqual(none, which, "opentable/two not successfully deployed") {
 		two := deps[which]
 		suite.Equal(1, two.NumInstances)

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -1,4 +1,7 @@
 package sous
 
+// SingularityDeployMetadataClusterName defines the namespace for storing a Sous ClusterName in SingularityDeploy metadata.
 const SingularityDeployMetadataClusterName = "com.opentable.sous.clustername"
+
+// SingularityDeployMetadataFlavor defines the namespace for storing a Sous Flavor in SingularityDeploy metadata.
 const SingularityDeployMetadataFlavor = "com.opentable.sous.flavor"

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -1,0 +1,3 @@
+package sous
+
+const SingularityDeployMetadataClusterName = "com.opentable.sous.clustername"

--- a/lib/constants.go
+++ b/lib/constants.go
@@ -1,3 +1,4 @@
 package sous
 
 const SingularityDeployMetadataClusterName = "com.opentable.sous.clustername"
+const SingularityDeployMetadataFlavor = "com.opentable.sous.flavor"

--- a/lib/deployable.go
+++ b/lib/deployable.go
@@ -1,9 +1,68 @@
 package sous
 
+import (
+	"github.com/satori/go.uuid"
+	"regexp"
+	"strings"
+)
+
+var illegalDeployIDChars = regexp.MustCompile(`[^a-z|^A-Z|^0-9|^_]`)
+
+// Singularity DeployID must be <50
+const maxDeployIDLen = 49
+
+// maxVersionLen needs to account for the separator character
+// between the version string and the UUID string.
+const maxVersionLen = 31
+
 // A Deployable is the pairing of a Deployment and the resolved image that can
 // (or has) be used to deploy it.
 type Deployable struct {
 	Status DeployStatus
 	*Deployment
 	*BuildArtifact
+}
+
+func (d *Deployable) ComputeDeployID() string {
+	var uuidTrunc, versionTrunc string
+	uuidEntire := stripDeployID(uuid.NewV4().String())
+	versionSansMeta := stripMetadata(d.Deployment.SourceID.Version.String())
+	versionEntire := sanitizeDeployID(versionSansMeta)
+
+	if len(versionEntire) > maxVersionLen {
+		versionTrunc = versionEntire[0:maxVersionLen]
+	} else {
+		versionTrunc = versionEntire
+	}
+
+	// naiveLen is the length of the truncated Version plus
+	// the length of an entire UUID plus the length of a separator
+	// character.
+	naiveLen := len(versionTrunc) + len(uuidEntire) + 1
+
+	if naiveLen > maxDeployIDLen {
+		uuidTrunc = uuidEntire[:maxDeployIDLen-len(versionTrunc)-1]
+	} else {
+		uuidTrunc = uuidEntire
+	}
+
+	return strings.Join([]string{
+		versionTrunc,
+		uuidTrunc,
+	}, "_")
+}
+
+// SanitizeDeployID replaces characters forbidden in a Singularity deploy ID
+// with underscores.
+func sanitizeDeployID(in string) string {
+	return illegalDeployIDChars.ReplaceAllString(in, "_")
+}
+
+// StripDeployID removes all characters forbidden in a Singularity deployID.
+func stripDeployID(in string) string {
+	return illegalDeployIDChars.ReplaceAllString(in, "")
+}
+
+func stripMetadata(in string) string {
+	return strings.Split(in, "+")[0]
 }

--- a/lib/deployable.go
+++ b/lib/deployable.go
@@ -1,68 +1,9 @@
 package sous
 
-import (
-	"github.com/satori/go.uuid"
-	"regexp"
-	"strings"
-)
-
-var illegalDeployIDChars = regexp.MustCompile(`[^a-z|^A-Z|^0-9|^_]`)
-
-// Singularity DeployID must be <50
-const maxDeployIDLen = 49
-
-// maxVersionLen needs to account for the separator character
-// between the version string and the UUID string.
-const maxVersionLen = 31
-
 // A Deployable is the pairing of a Deployment and the resolved image that can
 // (or has) be used to deploy it.
 type Deployable struct {
 	Status DeployStatus
 	*Deployment
 	*BuildArtifact
-}
-
-func (d *Deployable) ComputeDeployID() string {
-	var uuidTrunc, versionTrunc string
-	uuidEntire := stripDeployID(uuid.NewV4().String())
-	versionSansMeta := stripMetadata(d.Deployment.SourceID.Version.String())
-	versionEntire := sanitizeDeployID(versionSansMeta)
-
-	if len(versionEntire) > maxVersionLen {
-		versionTrunc = versionEntire[0:maxVersionLen]
-	} else {
-		versionTrunc = versionEntire
-	}
-
-	// naiveLen is the length of the truncated Version plus
-	// the length of an entire UUID plus the length of a separator
-	// character.
-	naiveLen := len(versionTrunc) + len(uuidEntire) + 1
-
-	if naiveLen > maxDeployIDLen {
-		uuidTrunc = uuidEntire[:maxDeployIDLen-len(versionTrunc)-1]
-	} else {
-		uuidTrunc = uuidEntire
-	}
-
-	return strings.Join([]string{
-		versionTrunc,
-		uuidTrunc,
-	}, "_")
-}
-
-// SanitizeDeployID replaces characters forbidden in a Singularity deploy ID
-// with underscores.
-func sanitizeDeployID(in string) string {
-	return illegalDeployIDChars.ReplaceAllString(in, "_")
-}
-
-// StripDeployID removes all characters forbidden in a Singularity deployID.
-func stripDeployID(in string) string {
-	return illegalDeployIDChars.ReplaceAllString(in, "")
-}
-
-func stripMetadata(in string) string {
-	return strings.Split(in, "+")[0]
 }

--- a/lib/dummy_rectification_client.go
+++ b/lib/dummy_rectification_client.go
@@ -60,8 +60,12 @@ func (t *DummyRectificationClient) logf(f string, v ...interface{}) {
 
 // Deploy implements part of the RectificationClient interface
 func (t *DummyRectificationClient) Deploy(
-	clusterURI, clusterName, depID, reqID, imageName string, res Resources, e Env, vols Volumes, flavor string) error {
-	t.logf("Deploying instance %s %s %s %s %s %v %v %v", clusterURI, clusterName, depID, reqID, imageName, res, e, vols)
+	//	clusterURI, clusterName, depID, reqID, imageName string, res Resources, e Env, vols Volumes, flavor string) error {
+	deployable Deployable, depID, reqID, imageName string, res Resources, e Env, vols Volumes) error {
+	clusterURI := deployable.Deployment.Cluster.BaseURL
+	clusterName := deployable.Deployment.ClusterName
+	flavor := deployable.Deployment.Flavor
+	t.logf("Deploying instance %s %s %s %s %s %s %v %v %v", clusterURI, clusterName, flavor, depID, reqID, imageName, res, e, vols)
 	t.Deployed = append(t.Deployed, dummyDeploy{clusterURI, depID, reqID, imageName, res, e, vols})
 	return nil
 }

--- a/lib/dummy_rectification_client.go
+++ b/lib/dummy_rectification_client.go
@@ -10,17 +10,9 @@ type (
 	// instead it collects the changes that would be performed and options
 	DummyRectificationClient struct {
 		logger   *log.Logger
-		Created  []dummyRequest
+		Created  []Deployable
 		Deployed []Deployable
 		Deleted  []dummyDelete
-	}
-
-	dummyRequest struct {
-		Cluster string
-		ID      string
-		Count   int
-		Kind    ManifestKind
-		Owners  OwnerSet
 	}
 
 	dummyDelete struct {
@@ -52,21 +44,16 @@ func (t *DummyRectificationClient) logf(f string, v ...interface{}) {
 }
 
 // Deploy implements part of the RectificationClient interface
-func (drc *DummyRectificationClient) Deploy(
-	deployable Deployable, reqID string) error {
-	drc.logf("Deploying instance %#v", deployable)
-	drc.Deployed = append(drc.Deployed, deployable)
+func (drc *DummyRectificationClient) Deploy(d Deployable, reqID string) error {
+	drc.logf("Deploying instance %#v", d)
+	drc.Deployed = append(drc.Deployed, d)
 	return nil
 }
 
 // PostRequest (cluster, request id, instance count)
-func (t *DummyRectificationClient) PostRequest(
-	cluster, id string, count int,
-	kind ManifestKind,
-	owners OwnerSet,
-) error {
-	t.logf("Creating application %s %s %d %v %v", cluster, id, count, kind, owners)
-	t.Created = append(t.Created, dummyRequest{cluster, id, count, kind, owners})
+func (drc *DummyRectificationClient) PostRequest(d Deployable, id string) error {
+	drc.logf("Creating application %#v", d, id)
+	drc.Created = append(drc.Created, d)
 	return nil
 }
 

--- a/lib/dummy_rectification_client.go
+++ b/lib/dummy_rectification_client.go
@@ -60,7 +60,7 @@ func (t *DummyRectificationClient) logf(f string, v ...interface{}) {
 
 // Deploy implements part of the RectificationClient interface
 func (t *DummyRectificationClient) Deploy(
-	clusterURI, clusterName, depID, reqID, imageName string, res Resources, e Env, vols Volumes) error {
+	clusterURI, clusterName, depID, reqID, imageName string, res Resources, e Env, vols Volumes, flavor string) error {
 	t.logf("Deploying instance %s %s %s %s %s %v %v %v", clusterURI, clusterName, depID, reqID, imageName, res, e, vols)
 	t.Deployed = append(t.Deployed, dummyDeploy{clusterURI, depID, reqID, imageName, res, e, vols})
 	return nil

--- a/lib/dummy_rectification_client.go
+++ b/lib/dummy_rectification_client.go
@@ -60,9 +60,9 @@ func (t *DummyRectificationClient) logf(f string, v ...interface{}) {
 
 // Deploy implements part of the RectificationClient interface
 func (t *DummyRectificationClient) Deploy(
-	cluster, depID, reqID, imageName string, res Resources, e Env, vols Volumes) error {
-	t.logf("Deploying instance %s %s %s %s %v %v %v", cluster, depID, reqID, imageName, res, e, vols)
-	t.Deployed = append(t.Deployed, dummyDeploy{cluster, depID, reqID, imageName, res, e, vols})
+	clusterURI, clusterName, depID, reqID, imageName string, res Resources, e Env, vols Volumes) error {
+	t.logf("Deploying instance %s %s %s %s %s %v %v %v", clusterURI, clusterName, depID, reqID, imageName, res, e, vols)
+	t.Deployed = append(t.Deployed, dummyDeploy{clusterURI, depID, reqID, imageName, res, e, vols})
 	return nil
 }
 

--- a/lib/dummy_rectification_client.go
+++ b/lib/dummy_rectification_client.go
@@ -1,6 +1,9 @@
 package sous
 
-import "log"
+import (
+	//	"github.com/opentable/sous/ext/singularity"
+	"log"
+)
 
 type (
 	// DummyRectificationClient implements RectificationClient but doesn't act on the Mesos scheduler;
@@ -61,10 +64,17 @@ func (t *DummyRectificationClient) logf(f string, v ...interface{}) {
 // Deploy implements part of the RectificationClient interface
 func (t *DummyRectificationClient) Deploy(
 	//	clusterURI, clusterName, depID, reqID, imageName string, res Resources, e Env, vols Volumes, flavor string) error {
-	deployable Deployable, depID, reqID, imageName string, res Resources, e Env, vols Volumes) error {
+	//	deployable Deployable, depID, reqID, imageName string, res Resources, e Env, vols Volumes) error {
+	deployable Deployable, reqID string) error {
 	clusterURI := deployable.Deployment.Cluster.BaseURL
 	clusterName := deployable.Deployment.ClusterName
 	flavor := deployable.Deployment.Flavor
+	depID := deployable.ComputeDeployID()
+	imageName := deployable.BuildArtifact.Name
+	res := deployable.Deployment.DeployConfig.Resources
+	e := deployable.Deployment.DeployConfig.Env
+	vols := deployable.Deployment.DeployConfig.Volumes
+
 	t.logf("Deploying instance %s %s %s %s %s %s %v %v %v", clusterURI, clusterName, flavor, depID, reqID, imageName, res, e, vols)
 	t.Deployed = append(t.Deployed, dummyDeploy{clusterURI, depID, reqID, imageName, res, e, vols})
 	return nil

--- a/lib/dummy_rectification_client.go
+++ b/lib/dummy_rectification_client.go
@@ -26,20 +26,20 @@ func NewDummyRectificationClient() *DummyRectificationClient {
 }
 
 // SetLogger sets the logger for the client
-func (t *DummyRectificationClient) SetLogger(l *log.Logger) {
+func (drc *DummyRectificationClient) SetLogger(l *log.Logger) {
 	l.Println("dummy begin")
-	t.logger = l
+	drc.logger = l
 }
 
-func (t *DummyRectificationClient) log(v ...interface{}) {
-	if t.logger != nil {
-		t.logger.Print(v...)
+func (drc *DummyRectificationClient) log(v ...interface{}) {
+	if drc.logger != nil {
+		drc.logger.Print(v...)
 	}
 }
 
-func (t *DummyRectificationClient) logf(f string, v ...interface{}) {
-	if t.logger != nil {
-		t.logger.Printf(f, v...)
+func (drc *DummyRectificationClient) logf(f string, v ...interface{}) {
+	if drc.logger != nil {
+		drc.logger.Printf(f, v...)
 	}
 }
 
@@ -58,9 +58,9 @@ func (drc *DummyRectificationClient) PostRequest(d Deployable, id string) error 
 }
 
 // DeleteRequest (cluster url, request id, instance count, message)
-func (t *DummyRectificationClient) DeleteRequest(
+func (drc *DummyRectificationClient) DeleteRequest(
 	cluster, reqid, message string) error {
-	t.logf("Deleting application %s %s %s", cluster, reqid, message)
-	t.Deleted = append(t.Deleted, dummyDelete{cluster, reqid, message})
+	drc.logf("Deleting application %s %s %s", cluster, reqid, message)
+	drc.Deleted = append(drc.Deleted, dummyDelete{cluster, reqid, message})
 	return nil
 }

--- a/lib/dummy_rectification_client.go
+++ b/lib/dummy_rectification_client.go
@@ -1,7 +1,6 @@
 package sous
 
 import (
-	//	"github.com/opentable/sous/ext/singularity"
 	"log"
 )
 

--- a/lib/dummy_rectification_client.go
+++ b/lib/dummy_rectification_client.go
@@ -11,18 +11,8 @@ type (
 	DummyRectificationClient struct {
 		logger   *log.Logger
 		Created  []dummyRequest
-		Deployed []dummyDeploy
+		Deployed []Deployable
 		Deleted  []dummyDelete
-	}
-
-	dummyDeploy struct {
-		Cluster   string
-		DepID     string
-		ReqID     string
-		ImageName string
-		Res       Resources
-		E         Env
-		Vols      Volumes
 	}
 
 	dummyRequest struct {
@@ -62,21 +52,10 @@ func (t *DummyRectificationClient) logf(f string, v ...interface{}) {
 }
 
 // Deploy implements part of the RectificationClient interface
-func (t *DummyRectificationClient) Deploy(
-	//	clusterURI, clusterName, depID, reqID, imageName string, res Resources, e Env, vols Volumes, flavor string) error {
-	//	deployable Deployable, depID, reqID, imageName string, res Resources, e Env, vols Volumes) error {
+func (drc *DummyRectificationClient) Deploy(
 	deployable Deployable, reqID string) error {
-	clusterURI := deployable.Deployment.Cluster.BaseURL
-	clusterName := deployable.Deployment.ClusterName
-	flavor := deployable.Deployment.Flavor
-	depID := deployable.ComputeDeployID()
-	imageName := deployable.BuildArtifact.Name
-	res := deployable.Deployment.DeployConfig.Resources
-	e := deployable.Deployment.DeployConfig.Env
-	vols := deployable.Deployment.DeployConfig.Volumes
-
-	t.logf("Deploying instance %s %s %s %s %s %s %v %v %v", clusterURI, clusterName, flavor, depID, reqID, imageName, res, e, vols)
-	t.Deployed = append(t.Deployed, dummyDeploy{clusterURI, depID, reqID, imageName, res, e, vols})
+	drc.logf("Deploying instance %#v", deployable)
+	drc.Deployed = append(drc.Deployed, deployable)
 	return nil
 }
 


### PR DESCRIPTION
I've refactored the Deploy() and PostRequest() functions on the singularity rectificationClient interface, making their method signatures markedly shorter. I removed an unused "Volumes" member from the sous.Deployment struct. I've simplified the DummyRectifcationClient to use lists of Deployables instead of a custom type. ClusterName and Flavor variables have been added to the SIngularityDeploy Metadata field, and constants that determine which key they use are set as constants in the sous package.