### PR TITLE
Treat the configured docker registry as canonical

### DIFF
--- a/ext/docker/image_mapping.go
+++ b/ext/docker/image_mapping.go
@@ -186,7 +186,7 @@ func (nc *NameCache) GetSourceID(a *sous.BuildArtifact) (sous.SourceID, error) {
 
 	qualities := qualitiesFromLabels(md.Labels)
 
-	err = nc.dbInsert(newSID, md.Registry+"/"+md.CanonicalName, md.Etag, qualities)
+	err = nc.dbInsert(newSID, nc.DockerRegistryHost+"/"+md.CanonicalName, md.Etag, qualities)
 	if err != nil {
 		return sid, err
 	}
@@ -194,9 +194,12 @@ func (nc *NameCache) GetSourceID(a *sous.BuildArtifact) (sous.SourceID, error) {
 	Log.Vomit.Printf("cn: %v all: %v", md.CanonicalName, md.AllNames)
 	names := []string{}
 	for _, n := range md.AllNames {
-		names = append(names, md.Registry+"/"+n)
+		names = append(names, nc.DockerRegistryHost+"/"+n)
 	}
-	err = nc.dbAddNames(md.Registry+"/"+md.CanonicalName, names)
+	err = nc.dbAddNames(nc.DockerRegistryHost+"/"+md.CanonicalName, names)
+	if err != nil && md.Registry != nc.DockerRegistryHost {
+		err = nc.dbAddNames(md.Registry+"/"+md.CanonicalName, names)
+	}
 
 	Log.Debug.Printf("Image name: %s -> (updated) Source ID: %v", in, newSID)
 	return newSID, err

--- a/ext/docker/image_mapping.go
+++ b/ext/docker/image_mapping.go
@@ -186,19 +186,22 @@ func (nc *NameCache) GetSourceID(a *sous.BuildArtifact) (sous.SourceID, error) {
 
 	qualities := qualitiesFromLabels(md.Labels)
 
-	err = nc.dbInsert(newSID, nc.DockerRegistryHost+"/"+md.CanonicalName, md.Etag, qualities)
+	fullCanon := nc.DockerRegistryHost + "/" + md.CanonicalName
+	Log.Vomit.Printf("Recording %q (with etag: %s) as canonical for %v", fullCanon, md.Etag, newSID)
+	err = nc.dbInsert(newSID, fullCanon, md.Etag, qualities)
 	if err != nil {
 		return sid, err
 	}
 
-	Log.Vomit.Printf("cn: %v all: %v", md.CanonicalName, md.AllNames)
 	names := []string{}
 	for _, n := range md.AllNames {
 		names = append(names, nc.DockerRegistryHost+"/"+n)
 	}
 	err = nc.dbAddNames(nc.DockerRegistryHost+"/"+md.CanonicalName, names)
+	Log.Vomit.Printf("Recorded additional names: %v for %q at registry %s (err: %v)", md.AllNames, fullCanon, nc.DockerRegistryHost, err)
 	if err != nil && md.Registry != nc.DockerRegistryHost {
 		err = nc.dbAddNames(md.Registry+"/"+md.CanonicalName, names)
+		Log.Vomit.Printf("Recorded additional names: %v for %q at registry %s (err: %v)", md.AllNames, md.Registry+"/"+md.CanonicalName, md.Registry, err)
 	}
 
 	Log.Debug.Printf("Image name: %s -> (updated) Source ID: %v", in, newSID)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -91,7 +91,7 @@ func (suite *integrationSuite) newNameCache(name string) *docker.NameCache {
 
 	suite.Require().NoError(err)
 
-	return docker.NewNameCache("", suite.registry, db)
+	return docker.NewNameCache(registryName, suite.registry, db)
 }
 
 func (suite *integrationSuite) BeforeTest(suiteName, testName string) {


### PR DESCRIPTION
Updates the NameCache to record the canonical name of images as being on the
registry host it was configured with as opposed to the registry name returned
in the metadata.

Consequence of this change was that integration tests needed to be updated to
configure the registry.

The returned registry name, if it differs for some reason, is recorded as well,
to minimize unneeded redeploys.