### PR TITLE
Adding `make staticcheck`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 - "./bin/vendor-check"
 script:
 - make -j2 test
-- make reject_wip
+- make reject-wip
   #- cat doc/shellexamples/*.blended
 after_script:
 - docker ps || true

--- a/staticcheck.ignore
+++ b/staticcheck.ignore
@@ -1,0 +1,1 @@
+github.com/opentable/sous/lib/source_context_test.go:SA4006


### PR DESCRIPTION
This finds (but I haven't corrected yet) errors like 'err' being
assigned and then ignored.

I'd like to add this to our CI routine, in an effort to end-run certain simple
problems.