### PR TITLE
Binding the "intended deploytments" to the phase is statuses.

### DIFF
--- a/ext/docker/image_mapping.go
+++ b/ext/docker/image_mapping.go
@@ -239,12 +239,12 @@ func (nc *NameCache) getImageName(sid sous.SourceID) (string, strpairs, error) {
 	if _, ok := errors.Cause(err).(NoImageNameFound); !ok {
 		// We got a probable database error, give up.
 		Log.Info.Printf("Cache error: %s", err)
-		return "", nil, errors.Wrap(err, "getting name from cache")
+		return "", nil, errors.Wrapf(err, "getting name from cache of %s", nc.DockerRegistryHost)
 	}
 	// The error was a NoImageNameFound.
 	if name, qualities, err = nc.getImageNameAfterHarvest(sid); err != nil {
 		// Failed even after a harvest, give up.
-		return "", nil, errors.Wrapf(err, "getting image from cache after harvest")
+		return "", nil, errors.Wrapf(err, "getting image from cache after harvest from %s", nc.DockerRegistryHost)
 	}
 	return name, qualities, nil
 }

--- a/graph/local_config.go
+++ b/graph/local_config.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,8 +32,6 @@ type (
 )
 
 func newSousConfig(lsc LocalSousConfig) *config.Config {
-	log.Printf("%#v", lsc)
-	log.Printf("%#v %[1]p", lsc.Config)
 	return lsc.Config
 }
 

--- a/integration/sh_test.go
+++ b/integration/sh_test.go
@@ -320,7 +320,7 @@ func TestShellLevelIntegration(t *testing.T) {
 	git tag -am 'Updated!' 0.0.24
 	git push --tags
 	sous build
-	sous deploy -cluster left
+	time sous deploy -d -v -cluster left
 	`, defaultCheck)
 
 	//check :=
@@ -329,13 +329,12 @@ func TestShellLevelIntegration(t *testing.T) {
 	cat {{.Workdir}}/updated_services.txt
 	URL=$(cat {{.Workdir}}/updated_services.txt| grep "sous-demo.*left" | awk '{ print $3 ":" $4 }' | tail -n 1)
 	echo $URL
-	curl "$URL"
 	`, func(name string, res shelltest.Result, t *testing.T) {
 		defaultCheck(name, res, t)
 		if !res.Matches("sous-demo") {
 			t.Error("No sous-demo request running!")
 		}
-		if !res.Matches("0.0.24") {
+		if !res.Matches("0_0_24") {
 			t.Error("Updates sous doesn't reflect intended version")
 		}
 	})

--- a/lib/deployable_chans_test.go
+++ b/lib/deployable_chans_test.go
@@ -14,7 +14,7 @@ type NameResolveTestSuite struct {
 	testCluster *Cluster
 	depChans    *DeployableChans
 	diffChans   *DeployableChans
-	errChan     chan error
+	errChan     chan *DiffResolution
 }
 
 func (nrs *NameResolveTestSuite) makeTestDep() *Deployable {
@@ -71,7 +71,7 @@ func (nrs *NameResolveTestSuite) SetupTest() {
 	nrs.depChans = NewDeployableChans(10)
 	dc := NewDeployableChans(10)
 	nrs.diffChans = dc
-	nrs.errChan = make(chan error, 10)
+	nrs.errChan = make(chan *DiffResolution, 10)
 }
 
 func (nrs *NameResolveTestSuite) TearDownTest() {
@@ -81,7 +81,7 @@ func (nrs *NameResolveTestSuite) TearDownTest() {
 func (nrs *NameResolveTestSuite) TestResolveNameGood() {
 	da, err := resolveName(nrs.reg, nrs.makeTestDep())
 	nrs.NotNil(da)
-	nrs.NoError(err)
+	nrs.Nil(err)
 }
 
 func (nrs *NameResolveTestSuite) TestResolveNameBad() {
@@ -89,7 +89,7 @@ func (nrs *NameResolveTestSuite) TestResolveNameBad() {
 
 	da, err := resolveName(nrs.reg, nrs.makeTestDep())
 	nrs.Nil(da.BuildArtifact)
-	nrs.Error(err)
+	nrs.Error(err.Error)
 }
 
 func (nrs *NameResolveTestSuite) TestResolveNameSkipped() {
@@ -98,7 +98,7 @@ func (nrs *NameResolveTestSuite) TestResolveNameSkipped() {
 
 	da, err := resolveName(nrs.reg, noInstances)
 	nrs.Nil(da.BuildArtifact)
-	nrs.NoError(err)
+	nrs.Nil(err)
 }
 
 func (nrs *NameResolveTestSuite) TestResolveNameStartChannel() {
@@ -144,7 +144,7 @@ func (nrs *NameResolveTestSuite) TestResolveNameStartChannelUnresolved() {
 	case <-nrs.depChans.Start:
 		nrs.Fail("Shouldn't process a starting deployment")
 	case err := <-nrs.errChan:
-		nrs.Error(err)
+		nrs.Error(err.Error)
 	case <-time.After(time.Second / 2):
 		nrs.Fail("Timeout waiting for depChans to resolve")
 	}

--- a/lib/map_state_to_deployments_test.go
+++ b/lib/map_state_to_deployments_test.go
@@ -347,7 +347,6 @@ func compareManifests(t *testing.T, expectedManifests, actualManifests Manifests
 		t.Fatalf("got %d manifests; want %d", actualLen, expectedLen)
 	}
 	for _, mid := range expectedManifests.Keys() {
-		t.Log(mid, "READING")
 		expected, ok := expectedManifests.Get(mid)
 		if !ok {
 			t.Errorf("missing expected manifest %q", mid)
@@ -369,8 +368,6 @@ func compareManifests(t *testing.T, expectedManifests, actualManifests Manifests
 			_, ok := actual.Deployments[clusterName]
 			if !ok {
 				t.Errorf("deployment %q missing", did)
-			} else {
-				t.Logf("GOT DEPLOYMENT %q", did)
 			}
 		}
 		// Check actual contains only the expected DeploySpecs.
@@ -381,7 +378,6 @@ func compareManifests(t *testing.T, expectedManifests, actualManifests Manifests
 				t.Errorf("extra deployment %q", did)
 			}
 		}
-		t.Log(mid, "OK")
 	}
 }
 

--- a/lib/resolvestatus_test.go
+++ b/lib/resolvestatus_test.go
@@ -71,7 +71,7 @@ func TestResolveRecorder(t *testing.T) {
 		block := make(chan struct{})
 
 		// Run all the phases in the test in order.
-		rs := NewResolveRecorder(func(rs *ResolveRecorder) {
+		rs := NewResolveRecorder(NewDeployments(), func(rs *ResolveRecorder) {
 			for phaseNum, phase := range test.Phases {
 				// Note 1: 1-indexed phase naming.
 				phaseName := fmt.Sprintf("test %d; phase %d", testNum+1, phaseNum+1)

--- a/lib/status_poller.go
+++ b/lib/status_poller.go
@@ -20,7 +20,6 @@ type (
 	subPoller struct {
 		HTTPClient
 		ClusterName, URL         string
-		Deployments              *Deployments
 		locationFilter, idFilter *ResolveFilter
 		User                     User
 		httpErrorCount           int
@@ -44,7 +43,9 @@ type (
 
 	// copied from server - avoiding coupling to server implemention
 	statusData struct {
-		Deployments           []*Deployment
+		// Deployments is deprecated - there's not a list of intended deployments
+		// on each resolve status
+		// Deployments           []*Deployment
 		Completed, InProgress *ResolveStatus
 	}
 
@@ -331,33 +332,31 @@ func (sub *subPoller) pollOnce() ResolveState {
 		return ResolveErredHTTP
 	}
 	sub.httpErrorCount = 0
-	deps := NewDeployments(data.Deployments...)
-	sub.Deployments = &deps
 
-	return sub.computeState(
-		// The serverIntent is the deployment in the GDM when the server started
-		// its current resolve sweep.  Note that this might be different from the
-		// /gdm query the parent poller collected if, for instance, the resolution
-		// started before the most recent update to the GDM.
-		sub.serverIntent(),
+	currentState := sub.computeState(sub.stateFeatures("in-progress", data.InProgress))
 
-		// The stable/current statuses are the complete status log collected in
-		// the most recent completed resolution, and the live status log being
-		// collected by a still-running resolution, if any. We filter the
-		// deployment we care about out of those logs.
-		data.stableFor(sub.locationFilter),
-		data.currentFor(sub.locationFilter),
-	)
+	if currentState == ResolveNotStarted ||
+		currentState == ResolveNotVersion ||
+		currentState == ResolvePendingRequest {
+		return sub.computeState(sub.stateFeatures("completed", data.Completed))
+	}
+
+	return currentState
+}
+
+func (sub *subPoller) stateFeatures(kind string, rezState *ResolveStatus) (*Deployment, *DiffResolution) {
+	current := diffResolutionFor(rezState, sub.locationFilter)
+	srvIntent := serverIntent(rezState, sub.locationFilter)
+	Log.Debug.Printf("%s reports %s intent to resolve [%v]", sub.URL, kind, srvIntent)
+	Log.Debug.Printf("%s reports %s rez: %v", sub.URL, kind, current)
+
+	return srvIntent, current
 }
 
 // computeState takes the servers intended deployment, and the stable and
 // current DiffResolutions and computes the state of resolution for the
 // deployment based on that data.
-func (sub *subPoller) computeState(srvIntent *Deployment, stable, current *DiffResolution) ResolveState {
-	Log.Debug.Printf("%s reports intent to resolve [%v]", sub.URL, srvIntent)
-	Log.Debug.Printf("%s reports stable rez: %v", sub.URL, stable)
-	Log.Debug.Printf("%s reports in-progress rez: %v", sub.URL, current)
-
+func (sub *subPoller) computeState(srvIntent *Deployment, current *DiffResolution) ResolveState {
 	// In there's no intent for the deployment in the current resolution, we
 	// haven't started on it yet. Remember that we've already determined that the
 	// most-recent GDM does have the deployment scheduled for this cluster, so it
@@ -373,13 +372,6 @@ func (sub *subPoller) computeState(srvIntent *Deployment, stable, current *DiffR
 	// times before that cycle starts.)
 	if !sub.idFilter.FilterDeployment(srvIntent) {
 		return ResolveNotVersion
-	}
-
-	// We prefer the "current" DiffResolution, but the cluster may not have
-	// gotten to it yet to put in its log. In that case, we'll consider the most
-	// recent stable log.
-	if current == nil {
-		current = stable
 	}
 
 	// If there's no DiffResolution yet for our Deployment, then we're still
@@ -434,15 +426,21 @@ func (sub *subPoller) computeState(srvIntent *Deployment, stable, current *DiffR
 	return ResolveInProgress
 }
 
-func (sub *subPoller) serverIntent() *Deployment {
-	Log.Vomit.Printf("Filtering %#v", sub.Deployments)
-	Log.Debug.Printf("Filtering with %q", sub.locationFilter)
-	dep, exactlyOne := sub.Deployments.Single(sub.locationFilter.FilterDeployment)
-	if !exactlyOne {
-		Log.Debug.Printf("With %s we didn't match exactly one deployment.", sub.locationFilter)
-		return nil
+func serverIntent(rstat *ResolveStatus, rf *ResolveFilter) *Deployment {
+	Log.Vomit.Printf("Filtering %#v", rstat.Intended)
+	Log.Debug.Printf("Filtering with %q", rf)
+	var dep *Deployment
+
+	for _, d := range rstat.Intended {
+		if rf.FilterDeployment(d) {
+			if dep != nil {
+				Log.Debug.Printf("With %s we didn't match exactly one deployment.", rf)
+				return nil
+			}
+			dep = d
+		}
 	}
-	Log.Vomit.Printf("Matching deployment: %#v", dep)
+
 	return dep
 }
 

--- a/lib/status_poller_test.go
+++ b/lib/status_poller_test.go
@@ -194,6 +194,110 @@ func TestStatusPoller(t *testing.T) {
 			}
 		],
 		"completed": {
+			"intended": [ {
+				"sourceid": {
+					"location": "` + repoName + `",
+					"version": "1.0.1+1234"
+				}
+			} ],
+			"log":[ {
+					"manifestid": "` + repoName + `",
+					"desc": "unchanged"
+				} ]
+		},
+		"inprogress": {"log":[]}
+	}`)
+
+	rf := &ResolveFilter{
+		Repo: repoName,
+	}
+
+	cl, err := NewClient(mainSrv.URL)
+	if err != nil {
+		t.Fatalf("Error building HTTP client: %#v", err)
+	}
+	poller := NewStatusPoller(cl, rf, User{Name: "Test User"})
+
+	testCh := make(chan ResolveState)
+	go func() {
+		rState, err := poller.Wait(context.Background())
+		if err != nil {
+			t.Errorf("Error starting poller: %#v", err)
+		}
+		testCh <- rState
+	}()
+
+	timeout := 100 * time.Millisecond
+	select {
+	case <-time.After(timeout):
+		t.Errorf("Happy path polling took more than %s", timeout)
+	case rState := <-testCh:
+		if rState != ResolveComplete {
+			t.Errorf("Resolve state was %s not %s", rState, ResolveComplete)
+		}
+	}
+}
+
+func TestStatusPoller_OldServer2(t *testing.T) {
+	serversRE := regexp.MustCompile(`/servers$`)
+	statusRE := regexp.MustCompile(`/status$`)
+	gdmRE := regexp.MustCompile(`/gdm$`)
+	var gdmJSON, serversJSON, statusJSON []byte
+
+	h := func(rw http.ResponseWriter, r *http.Request) {
+		url := r.URL.String()
+		if serversRE.MatchString(url) {
+			rw.Write(serversJSON)
+		} else if statusRE.MatchString(url) {
+			rw.Write(statusJSON)
+		} else if gdmRE.MatchString(url) {
+			rw.Write(gdmJSON)
+		} else {
+			t.Errorf("Bad request: %#v", r)
+			rw.WriteHeader(500)
+			rw.Write([]byte{})
+		}
+	}
+
+	mainSrv := httptest.NewServer(http.HandlerFunc(h))
+	otherSrv := httptest.NewServer(http.HandlerFunc(h))
+
+	repoName := "github.com/opentable/example"
+
+	serversJSON = []byte(`{
+		"servers": [
+			{"clustername": "main", "url":"` + mainSrv.URL + `"},
+			{"clustername": "other", "url":"` + otherSrv.URL + `"}
+		]
+	}`)
+	gdmJSON = []byte(`{
+		"deployments": [
+			{
+				"clustername": "other",
+				"sourceid": {
+					"location": "` + repoName + `",
+					"version": "1.0.1+1234"
+				}
+			},
+			{
+				"clustername": "main",
+				"sourceid": {
+					"location": "` + repoName + `",
+					"version": "1.0.1+1234"
+				}
+			}
+		]
+	}`)
+	statusJSON = []byte(`{
+		"deployments": [
+			{
+				"sourceid": {
+					"location": "` + repoName + `",
+					"version": "1.0.1+1234"
+				}
+			}
+		],
+		"completed": {
 			"log":[ {
 					"manifestid": "` + repoName + `",
 					"desc": "unchanged"
@@ -292,6 +396,12 @@ func TestStatusPoller_MesosFailed(t *testing.T) {
 			}
 		],
 		"completed": {
+			"intended": [ {
+					"sourceid": {
+						"location": "` + repoName + `",
+						"version": "1.0.1+1234"
+					}
+				} ],
 			"log":[ {
 					"manifestid": "` + repoName + `",
 					"desc": "unchanged",

--- a/lib/status_poller_test.go
+++ b/lib/status_poller_test.go
@@ -71,41 +71,29 @@ func TestSubPoller_ComputeState(t *testing.T) {
 		}
 	}
 
-	testCompute := func(version string, intent *Deployment, stable, current *DiffResolution, expected ResolveState) {
+	testCompute := func(version string, intent *Deployment, current *DiffResolution, expected ResolveState) {
 		sub := subPoller{
 			idFilter: &ResolveFilter{
 				Tag: version,
 			},
 		}
-		if actual := sub.computeState(intent, stable, current); expected != actual {
-			t.Errorf("sub.computeState(%v, %v, %v) -> %v != %v", intent, stable, current, actual, expected)
+		if actual := sub.computeState(intent, current); expected != actual {
+			t.Errorf("sub.computeState(%v, %v) -> %v != %v", intent, current, actual, expected)
 		}
 	}
 
-	testCompute("1.0", nil, nil, nil, ResolveNotStarted)
-	testCompute("1.0", deployment("0.9", DeployStatusAny), nil, nil, ResolveNotVersion)
-	testCompute("1.0", deployment("1.0", DeployStatusAny), nil, nil, ResolvePendingRequest)
+	testCompute("1.0", nil, nil, ResolveNotStarted)
+	testCompute("1.0", deployment("0.9", DeployStatusAny), nil, ResolveNotVersion)
+	testCompute("1.0", deployment("1.0", DeployStatusAny), nil, ResolvePendingRequest)
 
-	testCompute("1.0", deployment("1.0", DeployStatusAny), diffRez("update", nil), nil, ResolveInProgress) //known update , no outcome yet
-	testCompute("1.0", deployment("1.0", DeployStatusAny), nil, diffRez("update", nil), ResolveInProgress) //new update   , now in progress
-	testCompute("1.0", deployment("1.0", DeployStatusAny), diffRez("unchanged", nil), diffRez("update", nil), ResolveInProgress)
-	testCompute("1.0", deployment("1.0", DeployStatusAny), diffRez("create", rezErr), diffRez("update", nil), ResolveInProgress)
-	testCompute("1.0", deployment("1.0", DeployStatusAny), diffRez("create", permErr), diffRez("update", nil), ResolveInProgress)
+	testCompute("1.0", deployment("1.0", DeployStatusAny), diffRez("update", nil), ResolveInProgress) //known update , no outcome yet
 
-	testCompute("1.0", deployment("1.0", DeployStatusAny), diffRez("unchanged", rezErr), nil, ResolveErredRez)
-	testCompute("1.0", deployment("1.0", DeployStatusAny), nil, diffRez("unchanged", rezErr), ResolveErredRez)
-	testCompute("1.0", deployment("1.0", DeployStatusAny), diffRez("unchanged", nil), diffRez("unchanged", rezErr), ResolveErredRez)
-	testCompute("1.0", deployment("1.0", DeployStatusAny), diffRez("create", rezErr), diffRez("unchanged", rezErr), ResolveErredRez)
-	testCompute("1.0", deployment("1.0", DeployStatusAny), diffRez("unchanged", nil), diffRez("unchanged", permErr), ResolveFailed)
-	testCompute("1.0", deployment("1.0", DeployStatusAny), diffRez("create", rezErr), diffRez("unchanged", permErr), ResolveFailed)
+	testCompute("1.0", deployment("1.0", DeployStatusAny), diffRez("unchanged", rezErr), ResolveErredRez)
+	testCompute("1.0", deployment("1.0", DeployStatusAny), diffRez("unchanged", permErr), ResolveFailed)
 
-	testCompute("1.0", deployment("1.0", DeployStatusAny), diffRez("unchanged", nil), nil, ResolveComplete)
-	testCompute("1.0", deployment("1.0", DeployStatusAny), nil, diffRez("unchanged", nil), ResolveComplete)
-	testCompute("1.0", deployment("1.0", DeployStatusAny), diffRez("create", rezErr), diffRez("unchanged", nil), ResolveComplete)
-	testCompute("1.0", deployment("1.0", DeployStatusAny), diffRez("create", permErr), diffRez("unchanged", nil), ResolveComplete)
+	testCompute("1.0", deployment("1.0", DeployStatusAny), diffRez("unchanged", nil), ResolveComplete)
 
-	testCompute("1.0", deployment("1.0", DeployStatusPending), diffRez("unchanged", nil), diffRez("coming", nil), ResolveTasksStarting)
-	testCompute("1.0", deployment("1.0", DeployStatusPending), diffRez("coming", nil), nil, ResolveTasksStarting)
+	testCompute("1.0", deployment("1.0", DeployStatusPending), diffRez("coming", nil), ResolveTasksStarting)
 }
 
 func TestStatusPoller_updateState(t *testing.T) {


### PR DESCRIPTION
Here's the problem: the /status endpoint reports two things: the list of
deployments when the current resolution cycle started, and the resolutions that
have been completed so far. From those two things, the client can figure out
what's up with the deployment it cares about, effectively by answering two
questions: first, is the server working on my deployment? Second, has it
resolved yet?

Because this is polling an ongoing process, we in fact keep two status lists:
the most recent "complete" status, and the current live one. The in progress
list is fresher, but the stable one has a resolution for everything.

Trouble was, we were sharing a single list of deployments between both, which
meant for updates (i.e. not the first successful deployment) the list would
include the new update, and the stable list would include "it's settled", so it
looked like a stable status.

This is fixed by attaching a copy of the intended deployments to each of the
two status reports, so that resolutions tie to their intentions. Obvious when
you think about it, I suppose.

The server continues to serve the buggy common depenedencies so that old
clients won't freak out, and the client will use the common list if the server
doesn't provide the new ones - otherwise it would never see the intention to
deploy the service it was waiting on. Those concessions to backwards
compatibility will need to be torn out at some point, maybe even soon.