### PR TITLE
Fixed the wrong test; fixed the wrong code

### DIFF
--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -193,10 +193,12 @@ func (r deployer) changesReq(pair *sous.DeployablePair) bool {
 }
 
 func changesDep(pair *sous.DeployablePair) bool {
-	return !(pair.Prior.SourceID.Equal(pair.Post.SourceID) &&
-		pair.Prior.Resources.Equal(pair.Post.Resources) &&
-		pair.Prior.Env.Equal(pair.Post.Env) &&
-		pair.Prior.DeployConfig.Volumes.Equal(pair.Post.DeployConfig.Volumes))
+	return pair.Post.Status == sous.DeployStatusFailed ||
+		pair.Prior.Status == sous.DeployStatusFailed ||
+		!(pair.Prior.SourceID.Equal(pair.Post.SourceID) &&
+			pair.Prior.Resources.Equal(pair.Post.Resources) &&
+			pair.Prior.Env.Equal(pair.Post.Env) &&
+			pair.Prior.DeployConfig.Volumes.Equal(pair.Post.DeployConfig.Volumes))
 }
 
 func computeRequestID(d *sous.Deployable) string {

--- a/ext/singularity/deployer_test.go
+++ b/ext/singularity/deployer_test.go
@@ -336,7 +336,7 @@ func TestModificationOfFailed(t *testing.T) {
 	assert.Equal(t, rez.Desc, sous.ModifyDiff)
 	assert.Error(t, rez.Error)
 	assert.False(t, sous.IsTransientResolveError(rez.Error))
-	assert.Len(t, drc.Deployed, 0)
+	assert.Len(t, drc.Deployed, 1)
 	assert.Len(t, drc.Created, 0)
 	assert.Len(t, drc.Deleted, 0)
 


### PR DESCRIPTION
There was a test for "if the deployments are the same, but one is
failed" which specified "do nothing" when in fact, Sous should be
whamming new deploys after failed ones until someone pulls it offa the
jerk.

Test now specifies a change, and the code complies.