### PR TITLE
Requests limited to only legal characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ with respect to its command line interface and HTTP interface.
 * Split image build strategy: support for using a build image to produce artifacts to be run
   in a separate deploy image.
 
+### Changed
+* Sous detects the tasks in its purview based on metadata it sets when the task
+  is created, rather than inspecting request or deploy ids.
+
+### Fixed
+* Consequent to detecting tasks based on metadata,
+  Sous's requests are now compatible
+  with Singularity 0.14,
+  and the resulting Mesos Task IDs are suitable to use as Kafka client ids.
+
 ## [0.4.1](//github.com/opentable/sous/compare/0.4.0...0.4.1)
 
 ### Fixed

--- a/doc/legal_characters.md
+++ b/doc/legal_characters.md
@@ -35,3 +35,10 @@ static bool isInvalid(int c)
   }
 ```
 which appears more liberal than both Singularity and Mesos.
+
+# Current Conclusion
+
+The current restriction seems to be that:
+
+`A-Za-z0-9_` is legal for DeployIDs, and
+`A-Za-z0-9_-` (note the `-`) is legal for RequestIDs.

--- a/doc/legal_characters.md
+++ b/doc/legal_characters.md
@@ -1,0 +1,37 @@
+# Legal Characters
+
+Sous needs to interact with many different systems,
+and as a result must respect their restrictions on their data values.
+
+## Kafka
+
+It's common practice to use Mesos task IDs or Singularity Deploy IDs as Kafka identifiers.
+
+Per the [Kafka codebase](http://www.mouser.com/ProductDetail/NXP-Freescale/MK66FX1M0VMD18/?qs=zEQ6BYqA5vFpb82mBvv7rg%3D%3D)
+the pattern for Kafka client and group IDs is:
+```scala
+"[a-zA-Z0-9\\._\\-]*"
+```
+
+## Singularity
+
+As of [Singularity 0.14](https://github.com/HubSpot/Singularity/blob/86d524cfa656907637b150a341760bb7ce518746/SingularityService/src/main/java/com/hubspot/singularity/data/SingularityValidator.java)
+the restriction on Request and Deploy IDs is like
+```java
+  private static final Pattern DEPLOY_ID_ILLEGAL_PATTERN = Pattern.compile("[^a-zA-Z0-9_]");
+  private static final Pattern REQUEST_ID_ILLEGAL_PATTERN = Pattern.compile("[^a-zA-Z0-9_-]");
+```
+The [PR](https://github.com/HubSpot/Singularity/pull/1407) that introduced this pattern
+refers to Docker as the influence on Singularity's choice of pattern.
+
+## Mesos
+
+Mesos TaskIDs have this restriction:
+
+```c++
+static bool isInvalid(int c)
+  {
+    return iscntrl(c) || c == '/' || c == '\\';
+  }
+```
+which appears more liberal than both Singularity and Mesos.

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -13,7 +13,8 @@ import (
 	"github.com/satori/go.uuid"
 )
 
-var illegalDeployIDChars = regexp.MustCompile(`[^a-z|^A-Z|^0-9|^_]`)
+var illegalDeployIDChars = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+var illegalRequestIDChars = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
 
 // SanitizeDeployID replaces characters forbidden in a Singularity deploy ID
 // with underscores.

--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -385,7 +385,7 @@ func TestCreates(t *testing.T) {
 	if assert.Len(client.Created, 1) {
 		req := client.Created[0]
 		assert.Equal("cluster", req.Deployment.Cluster.BaseURL)
-		assert.Equal("reqid::nick", computeRequestID(&req))
+		assert.Regexp("^reqid--nick-[0-9a-f]*$", computeRequestID(&req))
 		assert.Equal(12, req.Deployment.DeployConfig.NumInstances)
 	}
 }


### PR DESCRIPTION
As restricted by Kafka, Singularity and Mesos. Docker is implied by
Singularity, afaict, but probably worth checking that as well.

Note that there's a disambiguation suffix added (ala deploy ids), but I
think that'll be minimal impact because request IDs get cut off in the web
UI as it is.