### PR TITLE
Adds an opaque "ExecutorData" field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.0...HEAD)
+
+### Fixed
+- Singularity RequestIDs retrieved from Singularity are reused when updating deploys,
+  instead of recomputing fresh unique ones each time.
+
 ## [0.5.0](//github.com/opentable/sous/compare/0.4.1...0.5.0)
 
 ### Added

--- a/dev_support/sous_qa_setup/certificates.go
+++ b/dev_support/sous_qa_setup/certificates.go
@@ -76,6 +76,9 @@ func getCertIPSans(certPath string) ([]net.IP, error) {
 	}
 
 	block, _ := pem.Decode(certBuf.Bytes())
+	if block == nil {
+		return nil, fmt.Errorf("Error decoding PEM from %q", certPath)
+	}
 
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {

--- a/ext/docker/image_mapping.go
+++ b/ext/docker/image_mapping.go
@@ -110,7 +110,7 @@ func (nc *NameCache) Warmup(r string) error {
 	}
 	ts, err := nc.RegistryClient.AllTags(r)
 	if err != nil {
-		return errors.Wrap(err, "warming up")
+		return errors.Wrapf(err, "warming up %q", r)
 	}
 	for _, t := range ts {
 		Log.Debug.Printf("Harvested tag: %v for repo: %v", t, r)

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -180,16 +180,17 @@ func (r *deployer) RectifyModifies(
 func (r *deployer) RectifySingleModification(pair *sous.DeployablePair) (err error) {
 	Log.Debug.Printf("Rectifying modified %q: \n  %# v \n    =>  \n  %# v", pair.ID(), pair.Prior.Deployment, pair.Post.Deployment)
 	defer rectifyRecover(pair, "RectifySingleModification", &err)
+	reqID := computeRequestID(pair.Prior)
 	if r.changesReq(pair) {
 		Log.Debug.Printf("Updating Request...")
-		if err := r.Client.PostRequest(*pair.Post, computeRequestID(pair.Post)); err != nil {
+		if err := r.Client.PostRequest(*pair.Post, reqID); err != nil {
 			return err
 		}
 	}
 
 	if changesDep(pair) {
 		Log.Debug.Printf("Deploying...")
-		if err := r.Client.Deploy(*pair.Post, computeRequestID(pair.Prior)); err != nil {
+		if err := r.Client.Deploy(*pair.Post, reqID); err != nil {
 			return err
 		}
 

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -181,11 +181,14 @@ func (r *deployer) RectifySingleModification(pair *sous.DeployablePair) (err err
 	Log.Debug.Printf("Rectifying modified %q: \n  %# v \n    =>  \n  %# v", pair.ID(), pair.Prior.Deployment, pair.Post.Deployment)
 	defer rectifyRecover(pair, "RectifySingleModification", &err)
 	reqID := computeRequestID(pair.Prior)
+	Log.Vomit.Printf("Operating on request %q", reqID)
 	if r.changesReq(pair) {
 		Log.Debug.Printf("Updating Request...")
 		if err := r.Client.PostRequest(*pair.Post, reqID); err != nil {
 			return err
 		}
+	} else {
+		Log.Vomit.Printf("Request %q does not require changes", reqID)
 	}
 
 	if changesDep(pair) {
@@ -193,8 +196,10 @@ func (r *deployer) RectifySingleModification(pair *sous.DeployablePair) (err err
 		if err := r.Client.Deploy(*pair.Post, reqID); err != nil {
 			return err
 		}
-
+	} else {
+		Log.Vomit.Printf("Deploy on %q does not require change", reqID)
 	}
+
 	return nil
 }
 

--- a/ext/singularity/deployer_test.go
+++ b/ext/singularity/deployer_test.go
@@ -236,6 +236,7 @@ func TestPendingModification(t *testing.T) {
 	}
 
 	dp := &sous.DeployablePair{
+		ExecutorData: &singularityTaskData{requestID: "reqid"},
 		Post: &sous.Deployable{
 			BuildArtifact: &sous.BuildArtifact{
 				Name: "build-artifact",
@@ -263,7 +264,7 @@ func TestPendingModification(t *testing.T) {
 
 	rez := <-rezCh
 
-	assert.Equal(t, rez.Desc, sous.ModifyDiff)
+	assert.Equal(t, sous.ModifyDiff, rez.Desc)
 	assert.Zero(t, rez.Error)
 	assert.Len(t, drc.Deployed, 0)
 	assert.Len(t, drc.Created, 0)
@@ -293,6 +294,7 @@ func TestModificationOfFailed(t *testing.T) {
 	}
 
 	dp := &sous.DeployablePair{
+		ExecutorData: &singularityTaskData{requestID: "reqid"},
 		Post: &sous.Deployable{
 			BuildArtifact: &sous.BuildArtifact{
 				Name: "build-artifact",

--- a/ext/singularity/deployment_builder.go
+++ b/ext/singularity/deployment_builder.go
@@ -100,6 +100,8 @@ func BuildDeployment(reg sous.ImageLabeller, clusters sous.Clusters, req SingReq
 	db := deploymentBuilder{registry: reg, clusters: clusters, req: req}
 
 	db.Target.Cluster = &sous.Cluster{BaseURL: req.SourceURL}
+	db.Target.ExecutorData = &singularityTaskData{requestID: reqID(req.ReqParent)}
+	Log.Vomit.Printf("Recording %v as requestID for instance.", db.Target.ExecutorData)
 	db.request = req.ReqParent.Request
 
 	return db.Target, db.canRetry(db.completeConstruction())

--- a/ext/singularity/deployment_builder.go
+++ b/ext/singularity/deployment_builder.go
@@ -2,6 +2,7 @@ package singularity
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/opentable/go-singularity/dtos"
 	"github.com/opentable/sous/ext/docker"
@@ -258,6 +259,21 @@ func (db *deploymentBuilder) determineStatus() error {
 	if db.history.DeployResult.DeployState == dtos.SingularityDeployResultDeployStateSUCCEEDED {
 		db.Target.Status = sous.DeployStatusActive
 	} else {
+		msg := db.history.DeployResult.Message
+		if len(db.history.DeployResult.DeployFailures) > 0 {
+			msgs := []string{}
+			for _, df := range db.history.DeployResult.DeployFailures {
+				msgs = append(msgs, df.Message)
+			}
+			msg = strings.Join(msgs, ", ")
+		}
+
+		db.Target.ExecutorMessage = fmt.Sprintf("Deploy faulure: %q %s/request/%s/deploy/%s",
+			msg,
+			db.req.SourceURL,
+			db.history.Deploy.RequestId,
+			db.history.Deploy.Id,
+		)
 		db.Target.Status = sous.DeployStatusFailed
 	}
 

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -31,12 +31,18 @@ func stripMetadata(in string) string {
 	return strings.Split(in, "+")[0]
 }
 
-// RectiAgent is an implementation of the RectificationClient interface
-type RectiAgent struct {
-	singClients map[string]*singularity.Client
-	sync.RWMutex
-	labeller sous.ImageLabeller
-}
+type (
+	// RectiAgent is an implementation of the RectificationClient interface
+	RectiAgent struct {
+		singClients map[string]*singularity.Client
+		sync.RWMutex
+		labeller sous.ImageLabeller
+	}
+
+	singularityTaskData struct {
+		requestID string
+	}
+)
 
 // NewRectiAgent returns a set-up RectiAgent
 func NewRectiAgent(l sous.ImageLabeller) *RectiAgent {

--- a/ext/singularity/rectifier_test.go
+++ b/ext/singularity/rectifier_test.go
@@ -86,6 +86,7 @@ func TestDockerMetadataSet(t *testing.T) {
 
 func baseDeployablePair() *sous.DeployablePair {
 	return &sous.DeployablePair{
+		ExecutorData: &singularityTaskData{requestID: "reqid"},
 		Prior: &sous.Deployable{
 			BuildArtifact: &sous.BuildArtifact{
 				Name: "the-prior-image",
@@ -284,6 +285,7 @@ func TestDeletes(t *testing.T) {
 	assert := assert.New(t)
 
 	deleted := &sous.DeployablePair{
+		ExecutorData: &singularityTaskData{requestID: "reqid"},
 		Prior: &sous.Deployable{
 			Deployment: &sous.Deployment{
 				SourceID: sous.SourceID{

--- a/integration/hello-server-labels/nginx.conf
+++ b/integration/hello-server-labels/nginx.conf
@@ -22,7 +22,7 @@ http {
         }
 
         location ~ \.php$ {
-            fastcgi_pass   127.0.0.1:9000;
+            fastcgi_pass   127.0.0.1:9100;
             fastcgi_index  index.php;
             include         fastcgi_params;
             fastcgi_param   SCRIPT_FILENAME    $document_root$fastcgi_script_name;

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -110,7 +110,7 @@ func (suite *integrationSuite) waitUntilNotPending(clusters []string, sourceRepo
 
 func (suite *integrationSuite) statusIs(ds *sous.DeployState, expected sous.DeployStatus) {
 	actual := ds.Status
-	suite.Equal(actual, expected, "deploy status is %q; want %q\nIn: %#v", actual, expected, ds)
+	suite.Equal(actual, expected, "deploy status is %q; want %q\n%s\nIn: %#v", actual, expected, ds.ExecutorMessage, ds)
 }
 
 func (suite *integrationSuite) BeforeTest(suiteName, testName string) {
@@ -141,7 +141,7 @@ func (suite *integrationSuite) BeforeTest(suiteName, testName string) {
 }
 
 func (suite *integrationSuite) TeardownTest() {
-	ResetSingularity()
+	// XXX UNCOMMENT ME: ResetSingularity()
 }
 
 func (suite *integrationSuite) TestGetLabels() {
@@ -236,6 +236,8 @@ func (suite *integrationSuite) TestFailedService() {
 }
 
 func (suite *integrationSuite) TestSuccessfulService() {
+	sous.Log.BeChatty()
+	defer sous.Log.BeQuiet()
 	if os.Getenv("TRAVIS") == "true" {
 		suite.T().Skip()
 	}
@@ -311,8 +313,6 @@ func (suite *integrationSuite) TestMissingImage() {
 }
 
 func (suite *integrationSuite) TestResolve() {
-	sous.Log.BeChatty()
-	defer sous.Log.BeQuiet()
 	clusterDefs := sous.Defs{
 		Clusters: sous.Clusters{
 			"test-cluster": &sous.Cluster{
@@ -375,7 +375,7 @@ func (suite *integrationSuite) TestResolve() {
 
 	// XXX Let's hope this is a temporary solution to a testing issue
 	// The problem is laid out in DCOPS-7625
-	for tries := 20; tries > 0; tries-- {
+	for tries := 50; tries > 0; tries-- {
 		client := singularity.NewRectiAgent(suite.nameCache)
 		deployer := singularity.NewDeployer(client)
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -214,8 +214,8 @@ func (suite *integrationSuite) TestFailedService() {
 
 	var fails *sous.DeployState
 	sleepTime := time.Duration(500) * time.Millisecond
+	suite.T().Log("About to capture snapshot - this may take some time")
 	for counter := 1; ; counter++ {
-		log.Printf("deployment state snapshot attempt:%d", counter)
 		ds, which := suite.deploymentWithRepo(clusters, "github.com/opentable/homer-says-doh")
 		deps := ds.Snapshot()
 		fails = deps[which]
@@ -223,7 +223,6 @@ func (suite *integrationSuite) TestFailedService() {
 		if fails.Status != sous.DeployStatusPending {
 			break
 		}
-		log.Printf("sleeping for %s", sleepTime)
 		time.Sleep(sleepTime)
 	}
 	suite.statusIs(fails, sous.DeployStatusFailed)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"testing"
 	"time"
@@ -92,6 +91,26 @@ func (suite *integrationSuite) newNameCache(name string) *docker.NameCache {
 	suite.Require().NoError(err)
 
 	return docker.NewNameCache(registryName, suite.registry, db)
+}
+
+func (suite *integrationSuite) waitUntilNotPending(clusters []string, sourceRepo string) *sous.DeployState {
+	sleepTime := time.Duration(500) * time.Millisecond
+	suite.T().Log("About to snapshot the state - it may take some time.")
+	for counter := 1; ; counter++ {
+		ds, which := suite.deploymentWithRepo(clusters, sourceRepo)
+		deps := ds.Snapshot()
+		deployState := deps[which]
+		suite.Require().NotNil(deployState)
+		if deployState.Status != sous.DeployStatusPending {
+			return deployState
+		}
+		time.Sleep(sleepTime)
+	}
+}
+
+func (suite *integrationSuite) statusIs(ds *sous.DeployState, expected sous.DeployStatus) {
+	actual := ds.Status
+	suite.Equal(actual, expected, "deploy status is %q; want %q\nIn: %#v", actual, expected, ds)
 }
 
 func (suite *integrationSuite) BeforeTest(suiteName, testName string) {
@@ -212,113 +231,44 @@ func (suite *integrationSuite) TestGetRunningDeploymentSet_all() {
 func (suite *integrationSuite) TestFailedService() {
 	clusters := []string{"test-cluster"}
 
-	var fails *sous.DeployState
-	sleepTime := time.Duration(500) * time.Millisecond
-	suite.T().Log("About to capture snapshot - this may take some time")
-	for counter := 1; ; counter++ {
-		ds, which := suite.deploymentWithRepo(clusters, "github.com/opentable/homer-says-doh")
-		deps := ds.Snapshot()
-		fails = deps[which]
-		suite.Require().NotNil(fails)
-		if fails.Status != sous.DeployStatusPending {
-			break
-		}
-		time.Sleep(sleepTime)
-	}
+	fails := suite.waitUntilNotPending(clusters, "github.com/opentable/homer-says-doh")
 	suite.statusIs(fails, sous.DeployStatusFailed)
 }
 
 func (suite *integrationSuite) TestSuccessfulService() {
 	if os.Getenv("TRAVIS") == "true" {
-		// Note: I would normally use t.Skipf() for this, but it isn't part of suite.
-		log.Println("SKIPPING TestSuccessfulService() in Travis")
-		return
+		suite.T().Skip()
 	}
 	clusters := []string{"test-cluster"}
 
-	var succeeds *sous.DeployState
-	sleepTime := time.Duration(500) * time.Millisecond
-	for counter := 1; ; counter++ {
-		log.Printf("deployment state snapshot attempt:%d", counter)
-		ds, which := suite.deploymentWithRepo(clusters, "github.com/docker/dockercloud-hello-world")
-		deps := ds.Snapshot()
-		succeeds = deps[which]
-		suite.Require().NotNil(succeeds)
-		if succeeds.Status != sous.DeployStatusPending {
-			break
-		}
-		log.Printf("sleeping for %s", sleepTime)
-		time.Sleep(sleepTime)
-	}
+	succeeds := suite.waitUntilNotPending(clusters, "github.com/docker/dockercloud-hello-world")
 	suite.statusIs(succeeds, sous.DeployStatusActive)
 }
 
 func (suite *integrationSuite) TestFailedDeployFollowingSuccessfulDeploy() {
 	if os.Getenv("TRAVIS") == "true" {
-		suite.T().Skipf("SKIPPING TestFailedDeployFollowingSuccessfulDeploy() in Travis")
+		suite.T().Skip("TestFailedDeployFollowingSuccessfulDeploy() in Travis")
 	}
 	clusters := []string{"test-cluster"}
 
 	const sourceRepo = "github.com/user/succeedthenfail" // Part of request ID.
 	const clusterName = "test-cluster"                   // Part of request ID.
 
-	{
-		// Create an assert on a successful deployment.
-		var ports []int32
-		const repoName = "succeedthenfail"
-		const dir = "succeedthenfail-succeed"
-		const tag = "1.0.0-succeed"
+	// Create an assert on a successful deployment.
+	var ports []int32
+	const repoName = "succeedthenfail"
 
-		registerAndDeploy(ip, clusterName, repoName, sourceRepo, dir, tag, ports)
+	registerAndDeploy(ip, clusterName, repoName, sourceRepo, "succeedthenfail-succeed", "1.0.0-succeed", ports)
 
-		var deployState *sous.DeployState
-		sleepTime := time.Duration(500) * time.Millisecond
-		for counter := 1; ; counter++ {
-			ds, which := suite.deploymentWithRepo(clusters, sourceRepo)
-			log.Printf("deployment state snapshot attempt:%d", counter)
-			log.Printf("GOT DEPLOY ID: %q", which)
-			deps := ds.Snapshot()
-			deployState = deps[which]
-			suite.Require().NotNil(deployState)
-			if deployState.Status != sous.DeployStatusPending {
-				break
-			}
-			log.Printf("sleeping for %s", sleepTime)
-			time.Sleep(sleepTime)
-		}
-		suite.statusIs(deployState, sous.DeployStatusActive)
-	}
+	deployState := suite.waitUntilNotPending(clusters, sourceRepo)
+	suite.statusIs(deployState, sous.DeployStatusActive)
 
-	{
-		// Create an assert on a failed deployment.
-		var ports []int32
-		const repoName = "succeedthenfail"
-		const dir = "succeedthenfail-fail"
-		const tag = "2.0.0-fail"
+	// Create an assert on a failed deployment.
 
-		registerAndDeploy(ip, clusterName, repoName, sourceRepo, dir, tag, ports)
+	registerAndDeploy(ip, clusterName, repoName, sourceRepo, "succeedthenfail-fail", "2.0.0-fail", ports)
 
-		var deployState *sous.DeployState
-		sleepTime := time.Duration(500) * time.Millisecond
-		for counter := 1; ; counter++ {
-			log.Printf("deployment state snapshot attempt:%d", counter)
-			ds, which := suite.deploymentWithRepo(clusters, sourceRepo)
-			deps := ds.Snapshot()
-			deployState = deps[which]
-			suite.Require().NotNil(deployState)
-			if deployState.Status != sous.DeployStatusPending {
-				break
-			}
-			log.Printf("sleeping for %s", sleepTime)
-			time.Sleep(sleepTime)
-		}
-		suite.statusIs(deployState, sous.DeployStatusFailed)
-	}
-}
-
-func (suite *integrationSuite) statusIs(ds *sous.DeployState, expected sous.DeployStatus) {
-	actual := ds.Status
-	suite.Equal(actual, expected, "deploy status is %q; want %q", actual, expected)
+	deployState = suite.waitUntilNotPending(clusters, sourceRepo)
+	suite.statusIs(deployState, sous.DeployStatusFailed)
 }
 
 func (suite *integrationSuite) TestMissingImage() {
@@ -361,6 +311,8 @@ func (suite *integrationSuite) TestMissingImage() {
 }
 
 func (suite *integrationSuite) TestResolve() {
+	sous.Log.BeChatty()
+	defer sous.Log.BeQuiet()
 	clusterDefs := sous.Defs{
 		Clusters: sous.Clusters{
 			"test-cluster": &sous.Cluster{
@@ -385,7 +337,7 @@ func (suite *integrationSuite) TestResolve() {
 	stateTwoThree := sous.State{
 		Defs: clusterDefs,
 		Manifests: sous.NewManifests(
-			suite.manifest(suite.nameCache, "opentable/two", "test-two", repoTwo, "1.1.1"),
+			suite.manifest(suite.nameCache, "opentable/two", "test-two-updated", repoTwo, "1.1.2"),
 			suite.manifest(suite.nameCache, "opentable/three", "test-three", repoThree, "1.1.1"),
 		),
 	}
@@ -429,7 +381,7 @@ func (suite *integrationSuite) TestResolve() {
 
 		r := sous.NewResolver(deployer, suite.nameCache, &sous.ResolveFilter{})
 
-		err := r.Begin(deploymentsTwoThree, clusterDefs.Clusters).Wait()
+		err = r.Begin(deploymentsTwoThree, clusterDefs.Clusters).Wait()
 		if err != nil {
 			suite.Require().NotRegexp(`Pending deploy already in progress`, err.Error())
 
@@ -444,7 +396,9 @@ func (suite *integrationSuite) TestResolve() {
 	ds, which = suite.deploymentWithRepo(clusters, repoTwo)
 	deps = ds.Snapshot()
 	if suite.NotEqual(none, which, "opentable/two no longer deployed after resolve") {
-		suite.Equal(1, deps[which].NumInstances)
+		dep := deps[which]
+		suite.Equal(1, dep.NumInstances)
+		suite.Equal("1.1.2", dep.Deployment.SourceID.Version.String())
 	}
 
 	which = suite.findRepo(ds, repoThree)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -375,7 +375,7 @@ func (suite *integrationSuite) TestResolve() {
 
 	// XXX Let's hope this is a temporary solution to a testing issue
 	// The problem is laid out in DCOPS-7625
-	for tries := 0; tries < 3; tries++ {
+	for tries := 20; tries > 0; tries-- {
 		client := singularity.NewRectiAgent(suite.nameCache)
 		deployer := singularity.NewDeployer(client)
 
@@ -383,10 +383,10 @@ func (suite *integrationSuite) TestResolve() {
 
 		err = r.Begin(deploymentsTwoThree, clusterDefs.Clusters).Wait()
 		if err != nil {
-			suite.Require().NotRegexp(`Pending deploy already in progress`, err.Error())
+			//suite.Require().NotRegexp(`Pending deploy already in progress`, err.Error())
 
-			suite.T().Logf("Singularity conflict - waiting for previous deploy to complete - try #%d", tries+1)
-			time.Sleep(1 * time.Second)
+			suite.T().Logf("Singularity conflict - waiting for previous deploy to complete - will try %d more times", tries)
+			time.Sleep(2 * time.Second)
 		}
 	}
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -141,7 +141,7 @@ func (suite *integrationSuite) BeforeTest(suiteName, testName string) {
 }
 
 func (suite *integrationSuite) TeardownTest() {
-	// XXX UNCOMMENT ME: ResetSingularity()
+	ResetSingularity()
 }
 
 func (suite *integrationSuite) TestGetLabels() {

--- a/integration/test-two-updated/.docker-repo
+++ b/integration/test-two-updated/.docker-repo
@@ -1,0 +1,1 @@
+grafana

--- a/integration/test-two-updated/Dockerfile
+++ b/integration/test-two-updated/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:latest
+
+ENV package grafana-1.9.1
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl mini-httpd uuid-runtime
+
+RUN curl -s http://grafanarel.s3.amazonaws.com/$package.tar.gz | tar -xz --strip-components=1 -C /srv
+COPY config.js /srv/
+RUN rm /srv/config.sample.js
+
+WORKDIR /
+
+LABEL \
+  com.opentable.sous.repo_url=github.com/opentable/two \
+  com.opentable.sous.repo_offset= \
+  com.opentable.sous.version=1.1.2 \
+  com.opentable.sous.revision=91495f1b1630084e301241100ecf2e775f6b672c
+
+CMD mini-httpd -d /srv -p $PORT0 -D

--- a/integration/test-two-updated/config.js
+++ b/integration/test-two-updated/config.js
@@ -1,0 +1,122 @@
+// == Configuration
+// config.js is where you will find the core Grafana configuration. This file contains parameter that
+// must be set before Grafana is run for the first time.
+
+define(['settings'],
+function (Settings) {
+
+
+  return new Settings({
+
+    /* Data sources
+    * ========================================================
+    * Datasources are used to fetch metrics, annotations, and serve as dashboard storage
+    *  - You can have multiple of the same type.
+    *  - grafanaDB: true    marks it for use for dashboard storage
+    *  - default: true      marks the datasource as the default metric source (if you have multiple)
+    *  - basic authentication: use url syntax http://username:password@domain:port
+    */
+
+    // InfluxDB example setup (the InfluxDB databases specified need to exist)
+    /*
+    datasources: {
+      influxdb: {
+        type: 'influxdb',
+        url: "http://my_influxdb_server:8086/db/database_name",
+        username: 'admin',
+        password: 'admin',
+      },
+      grafana: {
+        type: 'influxdb',
+        url: "http://my_influxdb_server:8086/db/grafana",
+        username: 'admin',
+        password: 'admin',
+        grafanaDB: true
+      },
+    },
+    */
+
+    // Graphite & Elasticsearch example setup
+    /*
+    datasources: {
+      graphite: {
+        type: 'graphite',
+        url: "http://my.graphite.server.com:8080",
+      },
+      elasticsearch: {
+        type: 'elasticsearch',
+        url: "http://my.elastic.server.com:9200",
+        index: 'grafana-dash',
+        grafanaDB: true,
+      }
+    },
+    */
+
+    datasources: {
+        graphite: {
+            type: 'graphite',
+            url: "https://www.hostedgraphite.com/f935da19/944374b8-f348-4dfa-b799-4e25a01d1292/graphite/",
+        },
+        elasticsearch: {
+            type: 'elasticsearch',
+            url: "http://grafana-es-qa-uswest2.otenv.com:9200",
+            index: 'grafana-dash',
+            grafanaDB: true,
+        }
+    },
+
+    // OpenTSDB & Elasticsearch example setup
+    /*
+    datasources: {
+      opentsdb: {
+        type: 'opentsdb',
+        url: "http://opentsdb.server:4242",
+      },
+      elasticsearch: {
+        type: 'elasticsearch',
+        url: "http://my.elastic.server.com:9200",
+        index: 'grafana-dash',
+        grafanaDB: true,
+      }
+    },
+    */
+
+    /* Global configuration options
+    * ========================================================
+    */
+
+    // specify the limit for dashboard search results
+    search: {
+      max_results: 20
+    },
+
+    // default home dashboard
+    default_route: '/dashboard/file/default.json',
+
+    // set to false to disable unsaved changes warning
+    unsaved_changes_warning: true,
+
+    // set the default timespan for the playlist feature
+    // Example: "1m", "1h"
+    playlist_timespan: "1m",
+
+    // If you want to specify password before saving, please specify it bellow
+    // The purpose of this password is not security, but to stop some users from accidentally changing dashboards
+    admin: {
+      password: ''
+    },
+
+    // Change window title prefix from 'Grafana - <dashboard title>'
+    window_title_prefix: 'Grafana - ',
+
+    // Add your own custom panels
+    plugins: {
+      // list of plugin panels
+      panels: [],
+      // requirejs modules in plugins folder that should be loaded
+      // for example custom datasources
+      dependencies: [],
+    }
+
+  });
+});

--- a/lib/deployable_chans.go
+++ b/lib/deployable_chans.go
@@ -17,8 +17,9 @@ type (
 	// situation, where the Prior Deployable is the known state and the Post
 	// Deployable is the desired state.
 	DeployablePair struct {
-		Prior, Post *Deployable
-		name        DeploymentID
+		Prior, Post  *Deployable
+		name         DeploymentID
+		ExecutorData interface{}
 	}
 
 	diffSet struct {
@@ -136,7 +137,7 @@ func resolveCreates(r Registry, from chan *DeployablePair, to chan *DeployablePa
 			Log.Debug.Printf("Failed create deployment %q: % #v", dep.ID(), dep)
 			continue
 		}
-		to <- &DeployablePair{name: dp.name, Prior: nil, Post: da}
+		to <- &DeployablePair{ExecutorData: dp.ExecutorData, name: dp.name, Prior: nil, Post: da}
 	}
 	close(to)
 }
@@ -146,7 +147,7 @@ func resolveCreates(r Registry, from chan *DeployablePair, to chan *DeployablePa
 func maybeResolveRetains(r Registry, from chan *DeployablePair, to chan *DeployablePair, errs chan *DiffResolution) {
 	for dp := range from {
 		da := maybeResolveSingle(r, dp.Post)
-		to <- &DeployablePair{name: dp.name, Prior: da, Post: da}
+		to <- &DeployablePair{ExecutorData: dp.ExecutorData, name: dp.name, Prior: da, Post: da}
 	}
 	close(to)
 }
@@ -154,7 +155,7 @@ func maybeResolveRetains(r Registry, from chan *DeployablePair, to chan *Deploya
 func maybeResolveDeletes(r Registry, from chan *DeployablePair, to chan *DeployablePair, errs chan *DiffResolution) {
 	for dp := range from {
 		da := maybeResolveSingle(r, dp.Prior)
-		to <- &DeployablePair{name: dp.name, Prior: da, Post: nil}
+		to <- &DeployablePair{ExecutorData: dp.ExecutorData, name: dp.name, Prior: da, Post: nil}
 	}
 	close(to)
 }
@@ -204,5 +205,5 @@ func resolvePair(r Registry, depPair *DeployablePair) (*DeployablePair, *DiffRes
 	prior, _ := resolveName(r, depPair.Prior)
 	post, err := resolveName(r, depPair.Post)
 
-	return &DeployablePair{name: depPair.name, Prior: prior, Post: post}, err
+	return &DeployablePair{ExecutorData: depPair.ExecutorData, name: depPair.name, Prior: prior, Post: post}, err
 }

--- a/lib/deployment_diff.go
+++ b/lib/deployment_diff.go
@@ -138,7 +138,8 @@ func (d *stateDiffer) diff(existing DeployStates) {
 			Log.Debug.Printf("Modified deployment: %q (% #v)", id, differences)
 
 			d.Update <- &DeployablePair{
-				name: id,
+				name:         id,
+				ExecutorData: intendDS.ExecutorData,
 				Prior: &Deployable{
 					Deployment: &intendDS.Deployment,
 					Status:     intendDS.Status,
@@ -153,7 +154,8 @@ func (d *stateDiffer) diff(existing DeployStates) {
 
 		Log.Debug.Printf("Retained deployment: %q (% #v)", id, differences)
 		d.Stable <- &DeployablePair{
-			name: id,
+			name:         id,
+			ExecutorData: intendDS.ExecutorData,
 			Prior: &Deployable{
 				Deployment: &intendDS.Deployment,
 				Status:     intendDS.Status,
@@ -170,7 +172,8 @@ func (d *stateDiffer) diff(existing DeployStates) {
 		Log.Debug.Printf("Deleted deployment: %q", deletedDS.ID())
 
 		d.Stop <- &DeployablePair{
-			name: deletedDS.ID(),
+			name:         deletedDS.ID(),
+			ExecutorData: deletedDS.ExecutorData,
 			Prior: &Deployable{
 				Deployment: &deletedDS.Deployment,
 				Status:     deletedDS.Status,

--- a/lib/deploystate.go
+++ b/lib/deploystate.go
@@ -9,7 +9,8 @@ import "fmt"
 // It wraps Deployment and adds Status.
 type DeployState struct {
 	Deployment
-	Status DeployStatus
+	Status       DeployStatus
+	ExecutorData interface{}
 }
 
 // DeployStatus represents the status of a deployment in an external cluster.
@@ -26,6 +27,10 @@ const (
 	// DeployStatusFailed means the deployment has failed.
 	DeployStatusFailed
 )
+
+func (ds DeployState) String() string {
+	return fmt.Sprintf("%s %s %v", ds.Deployment.String(), ds.Status, ds.ExecutorData)
+}
 
 // Clone returns an independent clone of this DeployState.
 func (ds DeployState) Clone() *DeployState {

--- a/lib/deploystate.go
+++ b/lib/deploystate.go
@@ -9,8 +9,9 @@ import "fmt"
 // It wraps Deployment and adds Status.
 type DeployState struct {
 	Deployment
-	Status       DeployStatus
-	ExecutorData interface{}
+	Status          DeployStatus
+	ExecutorMessage string
+	ExecutorData    interface{}
 }
 
 // DeployStatus represents the status of a deployment in an external cluster.


### PR DESCRIPTION
Singularity stashes its requestID there, and picks it back up to do modify actions.

There's also sundry improved logging, and I've started the idea od
ExecutorMessage for failures - the idea, eventually, is to thread that back
through /status so that `sous deploy` can report details from Singularity - so
that when your task dies on launch, you can at least follow a link to determine
the cause.