### PR TITLE
MakeRequestID Digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## [Unreleased]
+### Fixed
+- Singularity RequestIDs are generated with a suffix of the MD5 sum of
+  pre-slug data instead of a random UUID.
+
 ## [0.5.1](//github.com/opentable/sous/compare/0.5.0...0.5.1)
 
 ### Fixed

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -244,8 +244,11 @@ func MakeRequestID(depID sous.DeploymentID) string {
 	cl := illegalDeployIDChars.ReplaceAllString(depID.Cluster, "_")
 
 	h := md5.New()
+	sep := []byte{0}
 	io.WriteString(h, depID.ManifestID.Source.String())
+	h.Write(sep)
 	io.WriteString(h, depID.ManifestID.Flavor)
+	h.Write(sep)
 	io.WriteString(h, depID.Cluster)
 
 	reqBase := fmt.Sprintf("%s-%s-%s-%x", sl, fl, cl, h.Sum(nil))

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -140,7 +140,7 @@ func (suite *integrationSuite) BeforeTest(suiteName, testName string) {
 	suite.deployer = singularity.NewDeployer(suite.client)
 }
 
-func (suite *integrationSuite) TeardownTest() {
+func (suite *integrationSuite) TearDownTest() {
 	ResetSingularity()
 }
 


### PR DESCRIPTION
The algorithm used to create a SingularityRequestID needs to be idempotent.