### PR TITLE
Integration Singularity Reset poll loop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ with respect to its command line interface and HTTP interface.
   pre-slug data instead of a random UUID.
 - Singularity RequestIDs are shortened to no longer include FQDN or
   organization of Git repo URL.
+- Integration test enhancements.
 
 ### Fixed
 - Calls to `docker build` now have a `--pull` flag so that stale cached FROM

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ test-unit:
 	go test $(EXTRA_GO_FLAGS) $(TEST_VERBOSE) -timeout 2m ./...
 
 test-integration: setup-containers
-	SOUS_QA_DESC=$(QA_DESC) go test $(EXTRA_GO_FLAGS)  $(TEST_VERBOSE) ./integration --tags=integration
+	SOUS_QA_DESC=$(QA_DESC) go test -timeout 15m $(EXTRA_GO_FLAGS)  $(TEST_VERBOSE) ./integration --tags=integration
 
 $(QA_DESC): sous-qa-setup
 	./sous_qa_setup --compose-dir ./integration/test-registry/ --out-path=$(QA_DESC)

--- a/integration/docker_helpers.go
+++ b/integration/docker_helpers.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"regexp"
 	"testing"
+	"time"
 
 	sing "github.com/opentable/go-singularity"
 	"github.com/opentable/go-singularity/dtos"
@@ -92,7 +93,18 @@ func ResetSingularity() {
 			panic(err)
 		}
 	}
-	log.Print("Singularity reset.")
+
+	for i := 100; i > 0; i-- {
+		verifyReqList, err := singClient.GetRequests()
+		if err != nil {
+			panic(err)
+		}
+		log.Printf("Singularity reset. Remaining requests:%d", len(verifyReqList))
+		if len(verifyReqList) == 0 {
+			break
+		}
+		time.Sleep(time.Second)
+	}
 }
 
 // BuildImageName constructs a simple image name rooted at the SingularityURL

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/opentable/sous/ext/docker"
 	"github.com/opentable/sous/ext/singularity"
 	"github.com/opentable/sous/lib"
@@ -385,7 +386,7 @@ func (suite *integrationSuite) TestResolve() {
 		if err != nil {
 			//suite.Require().NotRegexp(`Pending deploy already in progress`, err.Error())
 
-			suite.T().Logf("Singularity conflict - waiting for previous deploy to complete - will try %d more times", tries)
+			suite.T().Logf("Singularity error:%s - will try %d more times", spew.Sdump(err), tries)
 			time.Sleep(2 * time.Second)
 		}
 	}


### PR DESCRIPTION
It is hoped that this will fix some sporadic test failures by not considering Singularity completely reset until its api returns a zero-length list of active requests.

Extended timeout for integration tests.

Spew in integration tests to pretty-print errors.