### PR TITLE
Fixing output for missing config. #trivial

### DIFF
--- a/lib/http_state_manager.go
+++ b/lib/http_state_manager.go
@@ -20,12 +20,12 @@ type (
 	}
 )
 
-func (g *gdmWrapper) manifests(defs Defs, base Manifests) (Manifests, error) {
+func (g *gdmWrapper) manifests(defs Defs) (Manifests, error) {
 	ds := NewDeployments()
 	for _, d := range g.Deployments {
 		ds.Add(d)
 	}
-	return ds.PutbackManifests(defs, base)
+	return ds.Manifests(defs)
 }
 
 // NewHTTPStateManager creates a new HTTPStateManager.
@@ -74,7 +74,7 @@ func (hsm *HTTPStateManager) WriteState(s *State, u User) error {
 		return err
 	}
 	diff := cds.Diff(wds)
-	cchs := diff.Concentrate(s.Defs, hsm.cached.Manifests)
+	cchs := diff.Concentrate(s.Defs)
 	Log.Debug.Printf("Processing diffs...")
 	return hsm.process(cchs)
 }
@@ -208,7 +208,6 @@ func (hsm *HTTPStateManager) getManifests(defs Defs) (Manifests, error) {
 	if err := hsm.Retrieve("./gdm", nil, &gdm, hsm.User); err != nil {
 		return Manifests{}, errors.Wrapf(err, "getting manifests")
 	}
-
 	return gdm.manifests(defs)
 }
 

--- a/lib/http_state_manager.go
+++ b/lib/http_state_manager.go
@@ -20,12 +20,12 @@ type (
 	}
 )
 
-func (g *gdmWrapper) manifests(defs Defs) (Manifests, error) {
+func (g *gdmWrapper) manifests(defs Defs, base Manifests) (Manifests, error) {
 	ds := NewDeployments()
 	for _, d := range g.Deployments {
 		ds.Add(d)
 	}
-	return ds.Manifests(defs)
+	return ds.PutbackManifests(defs, base)
 }
 
 // NewHTTPStateManager creates a new HTTPStateManager.
@@ -74,7 +74,7 @@ func (hsm *HTTPStateManager) WriteState(s *State, u User) error {
 		return err
 	}
 	diff := cds.Diff(wds)
-	cchs := diff.Concentrate(s.Defs)
+	cchs := diff.Concentrate(s.Defs, hsm.cached.Manifests)
 	Log.Debug.Printf("Processing diffs...")
 	return hsm.process(cchs)
 }
@@ -208,6 +208,7 @@ func (hsm *HTTPStateManager) getManifests(defs Defs) (Manifests, error) {
 	if err := hsm.Retrieve("./gdm", nil, &gdm, hsm.User); err != nil {
 		return Manifests{}, errors.Wrapf(err, "getting manifests")
 	}
+
 	return gdm.manifests(defs)
 }
 

--- a/util/configloader/configloader.go
+++ b/util/configloader/configloader.go
@@ -57,7 +57,9 @@ func (cl *configLoader) Load(target interface{}, filePath string) error {
 		if !os.IsNotExist(err) {
 			return err
 		}
-		sous.Log.Info.Printf("Missing config file, using defaults", map[string]interface{}{"path": filePath})
+		// I'd like to say "override with e.g. SOUS_CONFIG_FILE", but the
+		// construction of the path happens elsewhere.
+		sous.Log.Info.Printf("No config file found at %q, using defaults.", filePath)
 	} else {
 		if err := cl.loadYAMLFile(target, filePath); err != nil {
 			return err


### PR DESCRIPTION
The output looked like

"warn: Missing config file, using defaults%!(EXTRA map[string]interface {}=map[path:/home/teamcity/.config/sous/config.yaml])"

because of a mismatch between Printf and no template. Simple update to output more nicely.
Better still would be to give hints about what to do if that's the wrong path
(e.g. the SOUS_CONFIG_FILE env) but this is a general config loader function.