### PR TITLE
Sous server explicitly sets wildcard for offset and flavor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.5...HEAD)
+### Fixed
+- Sous server was unintentionally filtering out manifests with non-empty offsets or flavors.
+
 ## [0.5.5](//github.com/opentable/sous/compare/0.5.4...0.5.5)
 
 ### Fixed

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -252,6 +252,8 @@ func TestInvokeServer(t *testing.T) {
 	server, good := exe.Cmd.(*SousServer)
 	require.True(t, good)
 	assert.NotNil(t, server.SousGraph)
+	assert.True(t, server.AutoResolver.ResolveFilter.Offset.All, "server.AutoResolver.ResolveFilter.Offset.All")
+	assert.True(t, server.AutoResolver.ResolveFilter.Flavor.All, "server.AutoResolver.ResolveFilter.Flavor.All")
 }
 
 /*

--- a/cli/sous_server.go
+++ b/cli/sous_server.go
@@ -22,6 +22,7 @@ type SousServer struct {
 
 	*config.Config
 	*graph.SousGraph
+	*sous.AutoResolver
 
 	flags struct {
 		dryrun,
@@ -61,6 +62,8 @@ func (ss *SousServer) AddFlags(fs *flag.FlagSet) {
 // labeller and registrar.
 func (ss *SousServer) RegisterOn(psy Addable) {
 	psy.Add(graph.DryrunOption(ss.flags.dryrun))
+	ss.DeployFilterFlags.Offset = "*"
+	ss.DeployFilterFlags.Flavor = "*"
 	psy.Add(&ss.DeployFilterFlags)
 }
 
@@ -70,12 +73,9 @@ func (ss *SousServer) Execute(args []string) cmdr.Result {
 		return EnsureErrorResult(err)
 	}
 	ss.Log.Info.Println("Starting scheduled GDM resolution.")
+	ss.Log.Debug.Print("Filtering the GDM to resolve on this server to: %v", ss.DeployFilterFlags)
 
-	var arWrapper struct {
-		*sous.AutoResolver
-	}
-	ss.SousGraph.MustInject(&arWrapper)
-	arWrapper.AutoResolver.Kickoff()
+	ss.AutoResolver.Kickoff()
 
 	ss.Log.Info.Printf("Sous Server v%s running at %s for %s", ss.Sous.Version, ss.flags.laddr, ss.DeployFilterFlags.Cluster)
 


### PR DESCRIPTION
Otherwise it was using the zero value of "" which meant "no offset" or "no flavor" - and ignoring those deployments entirely.