### PR TITLE
Nicer pinning labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.6...HEAD)
+### Changed
+- Images built with Sous get a pinning tag that now includes the timestamp of
+  the build, so that multiple builds on a single revision won't clobber labesls
+  and make images inaccessible.
 
 ## [0.5.6](//github.com/opentable/sous/compare/0.5.5...0.5.6)
 ### Fixed

--- a/ext/docker/builder.go
+++ b/ext/docker/builder.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/nyarly/inlinefiles/templatestore"
 	"github.com/opentable/sous/lib"
@@ -76,7 +77,7 @@ func (b *Builder) ApplyMetadata(br *sous.BuildResult, bc *sous.BuildContext) err
 
 func (b *Builder) applyMetadata(br *sous.BuildResult, kind string, bc *sous.BuildContext) error {
 	br.VersionName = b.VersionTag(bc.Version(), kind)
-	br.RevisionName = b.RevisionTag(bc.Version(), kind)
+	br.RevisionName = b.RevisionTag(bc.Version(), kind, time.Now())
 
 	c := b.SourceShell.Cmd("docker", "build", "-t", br.VersionName, "-t", br.RevisionName, "-")
 	bf := b.metadataDockerfile(br, bc)
@@ -147,6 +148,6 @@ func (b *Builder) VersionTag(v sous.SourceID, kind string) string {
 }
 
 // RevisionTag computes an image tag from a SourceVersion's revision id
-func (b *Builder) RevisionTag(v sous.SourceID, kind string) string {
-	return revisionTag(b.DockerRegistryHost, v, kind)
+func (b *Builder) RevisionTag(v sous.SourceID, kind string, time time.Time) string {
+	return revisionTag(b.DockerRegistryHost, v, kind, time)
 }

--- a/ext/docker/builder_test.go
+++ b/ext/docker/builder_test.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"io/ioutil"
 	"testing"
+	"time"
 
 	"github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/shell"
@@ -51,9 +52,8 @@ func TestTagStrings(t *testing.T) {
 
 	assert.Equal("/sous/docker:1.2.3", versionName(sid, ""))
 	assert.Equal("/sous/docker-builder:1.2.3", versionName(sid, "builder"))
-	assert.Equal("/sous/docker:deadbeef", revisionName(sid, ""))
-	assert.Equal("/sous/docker-builder:deadbeef", revisionName(sid, "builder"))
-
+	assert.Equal("/sous/docker:zdeadbeef-1976-09-28T00.00.00-07.00", revisionName(sid, "", time.Unix(212742000, 0)))
+	assert.Equal("/sous/docker-builder:zdeadbeef-1976-09-28T00.00.00-07.00", revisionName(sid, "builder", time.Unix(212742000, 0)))
 }
 
 func TestBuilderApplyMetadata(t *testing.T) {

--- a/ext/docker/builder_test.go
+++ b/ext/docker/builder_test.go
@@ -52,8 +52,8 @@ func TestTagStrings(t *testing.T) {
 
 	assert.Equal("/sous/docker:1.2.3", versionName(sid, ""))
 	assert.Equal("/sous/docker-builder:1.2.3", versionName(sid, "builder"))
-	assert.Equal("/sous/docker:zdeadbeef-1976-09-28T00.00.00-07.00", revisionName(sid, "", time.Unix(212742000, 0)))
-	assert.Equal("/sous/docker-builder:zdeadbeef-1976-09-28T00.00.00-07.00", revisionName(sid, "builder", time.Unix(212742000, 0)))
+	assert.Equal("/sous/docker:zdeadbeef-1976-09-28T07.00.00", revisionName(sid, "", time.Unix(212742000, 0)))
+	assert.Equal("/sous/docker-builder:zdeadbeef-1976-09-28T07.00.00", revisionName(sid, "builder", time.Unix(212742000, 0)))
 }
 
 func TestBuilderApplyMetadata(t *testing.T) {

--- a/ext/docker/names.go
+++ b/ext/docker/names.go
@@ -93,7 +93,7 @@ func revisionName(sid sous.SourceID, kind string, time time.Time) string {
 
 	// z prefix sorts "pinning" labels to the bottom
 	// Format is the RFC3339 format, with . instead of : so that it's a legal docker tag
-	labelStr := fmt.Sprintf("z%v-%v", sid.RevID(), time.Format("2006-01-02T15.04.05Z07.00"))
+	labelStr := fmt.Sprintf("z%v-%v", sid.RevID(), time.UTC().Format("2006-01-02T15.04.05"))
 	return strings.Join([]string{imageRepoName(sid.Location, kind), labelStr}, ":")
 }
 


### PR DESCRIPTION
Adds a timestamp to the "pinning" label used to keep manifests in the registry.

Also prefixes the label with the character "z" so that they'll all sort together (and last) in lists of labels.