### PR TITLE
ext/git: Fix CanonicalRepoURL for go1.8.

### DIFF
--- a/ext/git/remote.go
+++ b/ext/git/remote.go
@@ -44,6 +44,9 @@ func (rs Remotes) ensureExists(name string) Remote {
 // credentials, and possibly ending with ".git", and returns a clean path of the
 // form: <hostname>/<repo-path>.
 func CanonicalRepoURL(repoURL string) (string, error) {
+	if strings.HasPrefix(repoURL, "git@") {
+		repoURL = "ssh://" + repoURL
+	}
 	u, err := url.Parse(repoURL)
 	if err != nil {
 		return "", fmt.Errorf("only valid URLs can be canonicalised: %s", err)


### PR DESCRIPTION
- Go 1.8 introduced changes to url.Parse, making it reject
  urls of the format git@github.com:user/project.
- Fix is to prefix these with ssh://.
- See go 1.8 release notes: https://golang.org/doc/go1.8#net_url