### PR TITLE
singularity: Ensure DeployID < 50 chars.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## [0.5.9](//github.com/opentable/sous/compare/0.5.8...0.5.9)
+### Fixed
+- Long version strings resulted in Singularity deploy IDs longer than the max
+  allowed length of 49 characters. Now they are always limited to 49.
+
 ## [0.5.8](//github.com/opentable/sous/compare/0.5.7...0.5.8)
 ### Fixed
 - Now builds and runs on Go 1.8 (one small change to URL parsing broke Sous for go 1.8).

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -19,7 +19,7 @@ import (
 // c.f. https://github.com/HubSpot/Singularity/blob/master/Docs/reference/configuration.md#limits
 
 // Singularity DeployID must be <50
-const maxDeployIDLen = 50
+const maxDeployIDLen = 49
 
 // Singularity RequestID must be <100
 const maxRequestIDLen = 100
@@ -270,7 +270,7 @@ func computeDeployID(d *sous.Deployable) string {
 		uuidEntire,
 	}, "_")
 
-	if len(depBase) < maxDeployIDLen {
+	if len(depBase) <= maxDeployIDLen {
 		return depBase
 	}
 


### PR DESCRIPTION
 singularity: Ensure DeployID < 50 chars.                                
                                                                         
 - Previously the tests passed because of an off by one error in         
   comparison (checking not greater than rather than strictly less than).
 - Singularity spec is strictly less than 50, i.e. max = 49.             
                                                                         