### PR TITLE
singularity: Fix regression with Singularity DeployIDs len > 49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## Unreleased
+### Fixed
+- Off-by-one error with Singularity deploy IDs, fixed in 0.5.9, re-introduced in
+  0.5.10. 
+
 ## [0.5.10](//github.com/opentable/sous/compare/0.5.9...0.5.10)
 ### Fixed
 - Off-by-one error with long request IDs.

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -19,7 +19,7 @@ import (
 // c.f. https://github.com/HubSpot/Singularity/blob/master/Docs/reference/configuration.md#limits
 
 // Singularity DeployID must be <50
-const maxDeployIDLen = 50
+const maxDeployIDLen = 49
 
 // Singularity RequestID must be <100
 const maxRequestIDLen = 100
@@ -274,5 +274,5 @@ func computeDeployID(d *sous.Deployable) string {
 		return depBase
 	}
 
-	return depBase[:(maxDeployIDLen - 1)]
+	return depBase[:(maxDeployIDLen)]
 }

--- a/ext/singularity/deployer_test.go
+++ b/ext/singularity/deployer_test.go
@@ -235,7 +235,8 @@ func TestLongComputeDeployID(t *testing.T) {
 
 	idLen := len(deployID)
 	logLenTmpl := "Got length:%d Max length:%d"
-	if len(deployID) >= 50 { // 50 is how our Singularity is configured
+	// Assert that we have been truncated to exactly the maximum length.
+	if len(deployID) != 49 { // 49 is the maximum deployID length.
 		t.Fatalf(logLenTmpl, idLen, maxDeployIDLen)
 	} else {
 		t.Logf(logLenTmpl, idLen, maxDeployIDLen)
@@ -278,7 +279,7 @@ func TestComputeDeployID_exactly50(t *testing.T) {
 
 	idLen := len(deployID)
 	logLenTmpl := "Got length:%d Max length:%d"
-	if len(deployID) >= 50 { // 50 is how our Singularity is configured
+	if len(deployID) != 49 { // 49 is the maximum deploy id length.
 		t.Fatalf(logLenTmpl, idLen, maxDeployIDLen)
 	} else {
 		t.Logf(logLenTmpl, idLen, maxDeployIDLen)

--- a/ext/singularity/deployer_test.go
+++ b/ext/singularity/deployer_test.go
@@ -242,6 +242,49 @@ func TestLongComputeDeployID(t *testing.T) {
 	}
 }
 
+func TestComputeDeployID_exactly50(t *testing.T) {
+	verStr := "0.0.2-c-seventeen" // This version string is exactly 17 chars.
+	logTmpl := "Provided version string:%s DeployID:%#v"
+	d := &sous.Deployable{
+		BuildArtifact: &sous.BuildArtifact{
+			Name: "build-artifact",
+			Type: "docker",
+		},
+		Deployment: &sous.Deployment{
+			SourceID: sous.SourceID{
+				Location: sous.SourceLocation{
+					Repo: "fake.tld/org/project",
+				},
+				Version: semv.MustParse(verStr),
+			},
+			DeployConfig: sous.DeployConfig{
+				NumInstances: 1,
+				Resources:    sous.Resources{},
+			},
+			ClusterName: "cluster",
+			Cluster: &sous.Cluster{
+				BaseURL: "cluster",
+			},
+		},
+	}
+
+	deployID := computeDeployID(d)
+	parsedDeployID := strings.Split(deployID, "_")[0:3]
+	if reflect.DeepEqual(parsedDeployID, strings.Split("0.0.2", ".")) {
+		t.Logf(logTmpl, verStr, deployID)
+	} else {
+		t.Fatalf(logTmpl, verStr, deployID)
+	}
+
+	idLen := len(deployID)
+	logLenTmpl := "Got length:%d Max length:%d"
+	if len(deployID) >= 50 { // 50 is how our Singularity is configured
+		t.Fatalf(logLenTmpl, idLen, maxDeployIDLen)
+	} else {
+		t.Logf(logLenTmpl, idLen, maxDeployIDLen)
+	}
+}
+
 func TestPendingModification(t *testing.T) {
 	drc := sous.NewDummyRectificationClient()
 	deployer := NewDeployer(drc)


### PR DESCRIPTION
Failing test for ComputeDeployID
- When the version string is exactly 17 chars long, we get a DeployID
  50 chars long, which is too long.