### PR TITLE
Singularity deployId tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## Unreleased
+### Fixed
+- Off-by-one error with Singularity deploy IDs, fixed in 0.5.9, re-introduced in
+  0.5.10. 
+
 ## [0.5.10](//github.com/opentable/sous/compare/0.5.9...0.5.10)
 ### Fixed
 - Off-by-one error with long request IDs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ with respect to its command line interface and HTTP interface.
 ## Unreleased
 ### Fixed
 - Off-by-one error with Singularity deploy IDs, fixed in 0.5.9, re-introduced in
-  0.5.10. 
+  0.5.10. Now includes better tests surrounding edge cases.
 
 ## [0.5.10](//github.com/opentable/sous/compare/0.5.9...0.5.10)
 ### Fixed

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -19,7 +19,7 @@ import (
 // c.f. https://github.com/HubSpot/Singularity/blob/master/Docs/reference/configuration.md#limits
 
 // Singularity DeployID must be <50
-const maxDeployIDLen = 50
+const maxDeployIDLen = 49
 
 // Singularity RequestID must be <100
 const maxRequestIDLen = 100
@@ -274,5 +274,5 @@ func computeDeployID(d *sous.Deployable) string {
 		return depBase
 	}
 
-	return depBase[:(maxDeployIDLen - 1)]
+	return depBase[:(maxDeployIDLen)]
 }

--- a/ext/singularity/deployer_test.go
+++ b/ext/singularity/deployer_test.go
@@ -235,7 +235,8 @@ func TestLongComputeDeployID(t *testing.T) {
 
 	idLen := len(deployID)
 	logLenTmpl := "Got length:%d Max length:%d"
-	if len(deployID) >= 50 { // 50 is how our Singularity is configured
+	// Assert that we have been truncated to exactly the maximum length.
+	if len(deployID) != 49 { // 49 is the maximum deployID length.
 		t.Fatalf(logLenTmpl, idLen, maxDeployIDLen)
 	} else {
 		t.Logf(logLenTmpl, idLen, maxDeployIDLen)
@@ -278,7 +279,7 @@ func TestComputeDeployID_exactly50(t *testing.T) {
 
 	idLen := len(deployID)
 	logLenTmpl := "Got length:%d Max length:%d"
-	if len(deployID) >= 50 { // 50 is how our Singularity is configured
+	if len(deployID) != 49 { // 49 is the maximum deploy id length.
 		t.Fatalf(logLenTmpl, idLen, maxDeployIDLen)
 	} else {
 		t.Logf(logLenTmpl, idLen, maxDeployIDLen)

--- a/ext/singularity/deployer_test.go
+++ b/ext/singularity/deployer_test.go
@@ -168,6 +168,9 @@ func TestRectifyRecover(t *testing.T) {
 //
 // Notably, it tests for off-by-one edge cases, by testing 16 and 17 character
 // version strings which caused confusion in earlier implementations.
+//
+// It also tests for the 32/33 version string length boundary, at which we
+// expect to begin truncating the version string itself.
 func TestComputeDeployID(t *testing.T) {
 	tests := []struct {
 		VersionString, DeployIDPrefix string
@@ -192,7 +195,14 @@ func TestComputeDeployID(t *testing.T) {
 		// Greater than 17 characters long, expect max deployId length.
 		{"0.0.2-chr-eighteen", "0_0_2_", 49},
 		{"0.0.2-thisversionissolongthatonewouldexpectittobetruncated", "0_0_2_", 49},
-		{"10.12.5-thisversionissolongthatonewouldexpectittobetruncated", "10_12_5_", 49}}
+		{"10.12.5-thisversionissolongthatonewouldexpectittobetruncated", "10_12_5_", 49},
+
+		// Exactly 32 chars long, expect full sanitised version string as prefix.
+		{"10.12.5-32-chars-version-string", "10_12_5_32_chars_version_string_", 49},
+
+		// Exactly 33 chars long, expect truncated sanitised version string as prefix.
+		{"10.12.5-33-chars-version-stringX", "10_12_5_33_chars_version_string_", 49},
+	}
 	for _, test := range tests {
 		inputVersion := test.VersionString
 		expectedPrefix := test.DeployIDPrefix

--- a/ext/singularity/deployer_test.go
+++ b/ext/singularity/deployer_test.go
@@ -242,6 +242,49 @@ func TestLongComputeDeployID(t *testing.T) {
 	}
 }
 
+func TestComputeDeployID_exactly50(t *testing.T) {
+	verStr := "0.0.2-c-seventeen" // This version string is exactly 17 chars.
+	logTmpl := "Provided version string:%s DeployID:%#v"
+	d := &sous.Deployable{
+		BuildArtifact: &sous.BuildArtifact{
+			Name: "build-artifact",
+			Type: "docker",
+		},
+		Deployment: &sous.Deployment{
+			SourceID: sous.SourceID{
+				Location: sous.SourceLocation{
+					Repo: "fake.tld/org/project",
+				},
+				Version: semv.MustParse(verStr),
+			},
+			DeployConfig: sous.DeployConfig{
+				NumInstances: 1,
+				Resources:    sous.Resources{},
+			},
+			ClusterName: "cluster",
+			Cluster: &sous.Cluster{
+				BaseURL: "cluster",
+			},
+		},
+	}
+
+	deployID := computeDeployID(d)
+	parsedDeployID := strings.Split(deployID, "_")[0:3]
+	if reflect.DeepEqual(parsedDeployID, strings.Split("0.0.2", ".")) {
+		t.Logf(logTmpl, verStr, deployID)
+	} else {
+		t.Fatalf(logTmpl, verStr, deployID)
+	}
+
+	idLen := len(deployID)
+	logLenTmpl := "Got length:%d Max length:%d"
+	if len(deployID) >= 50 { // 50 is how our Singularity is configured
+		t.Fatalf(logLenTmpl, idLen, maxDeployIDLen)
+	} else {
+		t.Logf(logLenTmpl, idLen, maxDeployIDLen)
+	}
+}
+
 func TestPendingModification(t *testing.T) {
 	drc := sous.NewDummyRectificationClient()
 	deployer := NewDeployer(drc)

--- a/ext/singularity/deployer_test.go
+++ b/ext/singularity/deployer_test.go
@@ -167,24 +167,9 @@ func TestShortComputeDeployID(t *testing.T) {
 	verStr := "0.0.1"
 	logTmpl := "Provided version string:%s DeployID:%#v"
 	d := &sous.Deployable{
-		BuildArtifact: &sous.BuildArtifact{
-			Name: "build-artifact",
-			Type: "docker",
-		},
 		Deployment: &sous.Deployment{
 			SourceID: sous.SourceID{
-				Location: sous.SourceLocation{
-					Repo: "fake.tld/org/project",
-				},
 				Version: semv.MustParse(verStr),
-			},
-			DeployConfig: sous.DeployConfig{
-				NumInstances: 1,
-				Resources:    sous.Resources{},
-			},
-			ClusterName: "cluster",
-			Cluster: &sous.Cluster{
-				BaseURL: "cluster",
 			},
 		},
 	}
@@ -203,24 +188,9 @@ func TestLongComputeDeployID(t *testing.T) {
 	verStr := "0.0.2-thisversionissolongthatonewouldexpectittobetruncated"
 	logTmpl := "Provided version string:%s DeployID:%#v"
 	d := &sous.Deployable{
-		BuildArtifact: &sous.BuildArtifact{
-			Name: "build-artifact",
-			Type: "docker",
-		},
 		Deployment: &sous.Deployment{
 			SourceID: sous.SourceID{
-				Location: sous.SourceLocation{
-					Repo: "fake.tld/org/project",
-				},
 				Version: semv.MustParse(verStr),
-			},
-			DeployConfig: sous.DeployConfig{
-				NumInstances: 1,
-				Resources:    sous.Resources{},
-			},
-			ClusterName: "cluster",
-			Cluster: &sous.Cluster{
-				BaseURL: "cluster",
 			},
 		},
 	}
@@ -247,24 +217,9 @@ func TestComputeDeployID_exactly50(t *testing.T) {
 	verStr := "0.0.2-c-seventeen" // This version string is exactly 17 chars.
 	logTmpl := "Provided version string:%s DeployID:%#v"
 	d := &sous.Deployable{
-		BuildArtifact: &sous.BuildArtifact{
-			Name: "build-artifact",
-			Type: "docker",
-		},
 		Deployment: &sous.Deployment{
 			SourceID: sous.SourceID{
-				Location: sous.SourceLocation{
-					Repo: "fake.tld/org/project",
-				},
 				Version: semv.MustParse(verStr),
-			},
-			DeployConfig: sous.DeployConfig{
-				NumInstances: 1,
-				Resources:    sous.Resources{},
-			},
-			ClusterName: "cluster",
-			Cluster: &sous.Cluster{
-				BaseURL: "cluster",
 			},
 		},
 	}


### PR DESCRIPTION
Includes #400 

Adds table-driven tests that document edge cases in Singularity deployId generation, to help us avoid introducing regressions in future.
