### PR TITLE
Startup options recognised by Singularity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## Unreleased
+### Fixed
+- Singularity now accepts changes to Startup options in manifest.
+
+
 ## [0.5.10](//github.com/opentable/sous/compare/0.5.9...0.5.10)
 ### Fixed
 - Off-by-one error with long request IDs.

--- a/cli/sous_plumbing_status.go
+++ b/cli/sous_plumbing_status.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"flag"
-	"fmt"
 	"time"
 
 	"github.com/opentable/sous/config"
@@ -48,7 +47,7 @@ func (sps *SousPlumbingStatus) Execute(args []string) cmdr.Result {
 		return cmdr.EnsureErrorResult(err)
 	}
 	if state != sous.ResolveComplete {
-		return cmdr.EnsureErrorResult(fmt.Errorf("failed"))
+		return cmdr.UsageErrorf("failed (state is %s)", state)
 	}
 
 	return cmdr.Success()

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -186,32 +186,49 @@ func (r *deployer) RectifyModifies(
 }
 
 func (r *deployer) RectifySingleModification(pair *sous.DeployablePair) (err error) {
-	Log.Debug.Printf("Rectifying modified %q: \n  %# v \n    =>  \n  %# v", pair.ID(), pair.Prior.Deployment, pair.Post.Deployment)
+	different, diffs := pair.Post.Deployment.Diff(pair.Prior.Deployment)
+	if !different {
+		Log.Warn.Printf("Attempting to rectify empty diff for %q", pair.ID())
+	}
+
+	Log.Notice.Printf("Rectifying modified %q; Diffs: %s", pair.ID(), strings.Join(diffs, "\n"))
+	Log.Debug.Printf("Full prior and post deployments: %q: \n  %# v \n    =>  \n  %# v", pair.ID(), pair.Prior.Deployment, pair.Post.Deployment)
 	defer rectifyRecover(pair, "RectifySingleModification", &err)
 
 	data, ok := pair.ExecutorData.(*singularityTaskData)
 	if !ok {
-		return errors.Errorf("Modification record %#v doesn't contain Singularity compatible data: was %T\n\t%#v", pair.ID(), data, pair)
+		err := errors.Errorf("Modification record %#v doesn't contain Singularity compatible data: was %T\n\t%#v", pair.ID(), data, pair)
+		Log.Warn.Println(err)
+		return err
 	}
 	reqID := data.requestID
 
+	changesApplied := false
 	Log.Vomit.Printf("Operating on request %q", reqID)
 	if r.changesReq(pair) {
 		Log.Debug.Printf("Updating Request...")
 		if err := r.Client.PostRequest(*pair.Post, reqID); err != nil {
+			Log.Warn.Println(err)
 			return err
 		}
+		changesApplied = true
 	} else {
-		Log.Vomit.Printf("Request %q does not require changes", reqID)
+		Log.Debug.Printf("Request %q does not require changes", reqID)
 	}
 
 	if changesDep(pair) {
 		Log.Debug.Printf("Deploying...")
 		if err := r.Client.Deploy(*pair.Post, reqID); err != nil {
+			Log.Warn.Println(err)
 			return err
 		}
+		changesApplied = true
 	} else {
-		Log.Vomit.Printf("Deploy on %q does not require change", reqID)
+		Log.Debug.Printf("Deploy at %q does not require changes", reqID)
+	}
+
+	if !changesApplied {
+		Log.Warn.Printf("No changes applied to Singularity for %q", pair.ID())
 	}
 
 	return nil

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -244,7 +244,8 @@ func changesDep(pair *sous.DeployablePair) bool {
 		!(pair.Prior.SourceID.Equal(pair.Post.SourceID) &&
 			pair.Prior.Resources.Equal(pair.Post.Resources) &&
 			pair.Prior.Env.Equal(pair.Post.Env) &&
-			pair.Prior.DeployConfig.Volumes.Equal(pair.Post.DeployConfig.Volumes))
+			pair.Prior.DeployConfig.Volumes.Equal(pair.Post.DeployConfig.Volumes) &&
+			pair.Prior.Startup.Equal(pair.Post.Startup))
 }
 
 func computeRequestID(d *sous.Deployable) (string, error) {

--- a/lib/deploy_config.go
+++ b/lib/deploy_config.go
@@ -155,6 +155,11 @@ func (dc *DeployConfig) Diff(o DeployConfig) (bool, []string) {
 	return len(diffs) == 0, diffs
 }
 
+// Equal returns true if s == o.
+func (s Startup) Equal(o Startup) bool {
+	return len(s.diff(o)) == 0
+}
+
 func (s Startup) diff(o Startup) []string {
 	diffs := []string{}
 	diff := func(format string, a ...interface{}) { diffs = append(diffs, fmt.Sprintf(format, a...)) }


### PR DESCRIPTION
Includes #403 

Our singularity code includes a filter for changes to be applied to requests or deploys. This is to allow some changes to the GDM (e.g. sous-only metadata) to be ignored for the purpose of Singularity.   This change adds Startup as a field that needs to be reflected in Singularity.