### PR TITLE
Install dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
 ## Unreleased
+### Added
+- For developers only, there are 2 new build targets: `install-dev` and
+  `install-brew`. These allow developers on a Mac to quickly switch between having
+  a personal dev build, or the latest release from homebrew installed locally.
 
 ## [0.5.12](//github.com/opentable/sous/compare/0.5.11...0.5.12)
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ else
 GIT_TAG := $(shell $(TAG_TEST))
 endif
 
+# install-dev uses DESC and DATE to make a git described, timestamped dev build.
+DESC := $(shell git describe)
+DATE := $(shell date +%Y-%m-%dT%H-%M-%S)
+DEV_VERSION := "$(DESC)-devbuild-$(DATE)"
+
 # Sous releases are tagged with format v0.0.0. semv library
 # does not understand the v prefix, so this lops it off.
 SOUS_VERSION := $(shell echo $(GIT_TAG) | sed 's/^v//')
@@ -75,6 +80,10 @@ clean-running-containers:
 
 gitlog:
 	git log `git describe --abbrev=0`..HEAD
+
+install-dev:
+	rm "$$(which sous)" || true
+	go install -ldflags "-X main.VersionString=$(DEV_VERSION)"
 
 install-ggen:
 	cd bin/ggen && go install ./

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,16 @@ gitlog:
 	git log `git describe --abbrev=0`..HEAD
 
 install-dev:
+	brew uninstall opentable/public/sous || true
 	rm "$$(which sous)" || true
 	go install -ldflags "-X main.VersionString=$(DEV_VERSION)"
+	echo "Now run 'hash -r && sous version' to make sure you are using the dev version of sous."
+
+install-brew:
+	rm "$$(which sous)" || true
+	brew uninstall opentable/public/sous || true
+	brew install opentable/public/sous
+	echo "Now run 'hash -r && sous version' to make sure you are using the homebrew-installed sous."
 
 install-ggen:
 	cd bin/ggen && go install ./


### PR DESCRIPTION
I frequently want to switch between running a personal dev build of Sous and the latest official release from Homebrew. This PR adds two complementary make targets: `install-dev` and `install-brew`. They are complementary because running either of these commands will remove the version of sous installed by the other.

- `install-dev` adds a timestamp to the build as well, so you can be sure you're using a fresh one.
- `install-brew` and `install-dev` are both too rough for non-sous-developers to use, as they just indiscriminately delete `$(which sous)`.
- You should run `hash -r` manually after running either of these to make sure you're running the version you expect.

You can see it spits out errors in normal operation. This could be refined, but I'm happy with it for now as it's only for our convenience.

```shell
face:sous ssalisbury$ make install-dev
brew uninstall opentable/public/sous || true
Uninstalling /usr/local/Cellar/sous/0.5.8... (5 files, 16MB)
rm "$(which sous)" || true
rm: : No such file or directory
go install -ldflags "-X main.VersionString="0.5.12-2-g8647b3e-devbuild-2017-06-06T11-25-16""
echo "Now run 'hash -r && sous version' to make sure you are using the dev version of sous."
Now run 'hash -r && sous version' to make sure you are using the dev version of sous.
face:sous ssalisbury$ hash -r && sous version
sous version 0.5.12-2-g8647b3e-devbuild-2017-06-06T11-25-16 (go1.8.3 darwin/amd64)
face:sous ssalisbury$ make install-brew
rm "$(which sous)" || true
brew uninstall opentable/public/sous || true
Error: No such keg: /usr/local/Cellar/sous
brew install opentable/public/sous
==> Installing sous from opentable/public
==> Downloading https://github.com/opentable/sous/releases/download/0.5.8/sous-darwin-amd64_
Already downloaded: /Users/ssalisbury/Library/Caches/Homebrew/sous-0.5.8.tar.gz
🍺  /usr/local/Cellar/sous/0.5.8: 5 files, 16MB, built in 1 second
echo "Now run 'hash -r && sous version' to make sure you are using the homebrew-installed sous."
Now run 'hash -r && sous version' to make sure you are using the homebrew-installed sous.
face:sous ssalisbury$ hash -r && sous version
sous version 0.5.8+77f4121e37c1775a25210275305eaaa854ede581 (go1.7.3 darwin/amd64)
```

See the commit comments for more details.

