### PR TITLE
Deployment.Diff static analysis checking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
-## Unreleased
+## [Unreleased](//github.com/opentable/sous/compare/0.5.11...HEAD)
+
+### Added
+- Static analysis of important core data model calculations to ensure that all the components of those structures are at least "touched" during diff calculation.
+
 
 ## [0.5.11](//github.com/opentable/sous/compare/0.5.10...0.5.11)
 ### Fixed

--- a/ext/otpl/otpl_test.go
+++ b/ext/otpl/otpl_test.go
@@ -104,7 +104,6 @@ func TestManifestParser_ParseManifest(t *testing.T) {
 							"ports":  "1",
 						},
 						Metadata: sous.Metadata(nil),
-						Args:     []string(nil),
 						Env: sous.Env{
 							"SOME_VAR": "22",
 						},

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -79,7 +79,6 @@ func (suite *integrationSuite) manifest(nc *docker.NameCache, drepo, containerDi
 						Timeout:              &checkReadyTimeout,
 					},
 					Resources:    sous.Resources{"cpus": "0.1", "memory": "100", "ports": "1"},
-					Args:         []string{},
 					Env:          sous.Env{"repo": drepo}, //map[s]s
 					NumInstances: 1,
 					Volumes:      sous.Volumes{{"/tmp", "/tmp", sous.VolumeMode("RO")}},

--- a/lib/deploy_config.go
+++ b/lib/deploy_config.go
@@ -21,8 +21,10 @@ type (
 		// of this deployment. It will be checked for conflict with the
 		// definitions found in State.Defs.EnvVars, and if not in conflict
 		// assumes the greatest priority.
-		Args []string `yaml:",omitempty" validate:"values=nonempty"`
-		Env  `yaml:",omitempty" validate:"keys=nonempty,values=nonempty"`
+		Env `yaml:",omitempty" validate:"keys=nonempty,values=nonempty"`
+
+		// No manifest uses this, it doesn't get sent to Singularity. If we want it we should bring it back.
+		//Args []string `yaml:",omitempty" validate:"values=nonempty"`
 		// NumInstances is a guide to the number of instances that should be
 		// deployed in this cluster, note that the actual number may differ due
 		// to decisions made by Sous. If set to zero, Sous will decide how many
@@ -206,8 +208,6 @@ func (s Startup) diff(o Startup) []string {
 // Clone returns a deep copy of this DeployConfig.
 func (dc DeployConfig) Clone() (c DeployConfig) {
 	c.NumInstances = dc.NumInstances
-	c.Args = make([]string, len(dc.Args))
-	copy(dc.Args, c.Args)
 	c.Env = make(Env)
 	for k, v := range dc.Env {
 		c.Env[k] = v
@@ -305,12 +305,6 @@ func flattenDeployConfigs(dcs []DeployConfig) DeployConfig {
 	for _, c := range dcs {
 		if len(c.Volumes) != 0 {
 			dc.Volumes = c.Volumes
-			break
-		}
-	}
-	for _, c := range dcs {
-		if len(c.Args) != 0 {
-			dc.Args = c.Args
 			break
 		}
 	}

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -189,18 +189,15 @@ func (d *Deployment) Diff(o *Deployment) (bool, []string) {
 		diff("kind; this: %q; other: %q", d.Kind, o.Kind)
 	}
 
-	// TODO: Make sure owners get written to Singularity, then uncomment next line.
-	/*
-		if len(d.Owners) != len(o.Owners) {
-			//diff("number of owners; this: %+v; other: %+v", len(d.Owners), len(o.Owners))
-		}
+	if len(d.Owners) != len(o.Owners) {
+		diff("number of owners; this: %+v; other: %+v", len(d.Owners), len(o.Owners))
+	}
 
-		for owner := range d.Owners {
-			if _, has := o.Owners[owner]; !has {
-				//diff("owner %s", owner)
-			}
+	for owner := range d.Owners {
+		if _, has := o.Owners[owner]; !has {
+			diff("owner %s", owner)
 		}
-	*/
+	}
 	_, configDiffs := d.DeployConfig.Diff(o.DeployConfig)
 	diffs = append(diffs, configDiffs...)
 	return len(diffs) != 0, diffs

--- a/lib/deployment_test.go
+++ b/lib/deployment_test.go
@@ -48,7 +48,6 @@ func TestDeploymentClone(t *testing.T) {
 	original := &Deployment{
 		DeployConfig: DeployConfig{
 			Resources:    Resources{},
-			Args:         []string{},
 			Env:          Env{},
 			NumInstances: 3,
 			Volumes:      vols,
@@ -100,7 +99,6 @@ func TestBuildDeployment(t *testing.T) {
 	sp := DeploySpec{
 		DeployConfig: DeployConfig{
 			Resources:    Resources{},
-			Args:         []string{},
 			Env:          Env{},
 			NumInstances: 3,
 			Volumes: Volumes{

--- a/lib/deployment_test.go
+++ b/lib/deployment_test.go
@@ -25,7 +25,6 @@ func TestDeploymentDiffAnalysis(t *testing.T) {
 		// is is compared directly - Repo and Dir are compared implicitly thereby
 		"Deployment.SourceID.Location.Repo",
 		"Deployment.SourceID.Location.Dir",
-
 		/*
 			"Deployment.Owners",
 			"Deployment.DeployConfig.Args",

--- a/lib/deployment_test.go
+++ b/lib/deployment_test.go
@@ -5,9 +5,40 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/opentable/sous/util/allfields"
 	"github.com/samsalisbury/semv"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestDeploymentDiffAnalysis(t *testing.T) {
+	exemptions := []string{
+		// we depend on ClusterName to uniquely identify clusters,
+		// so we don't compare the cluster itself
+		"Deployment.Cluster",
+		"Deployment.Cluster.Name",
+		"Deployment.Cluster.Kind",
+		"Deployment.Cluster.BaseURL",
+		"Deployment.Cluster.Env",
+		"Deployment.Cluster.AllowedAdvisories",
+
+		// SourceID.Location is incorporated into the value of ID(),
+		// is is compared directly - Repo and Dir are compared implicitly thereby
+		"Deployment.SourceID.Location.Repo",
+		"Deployment.SourceID.Location.Dir",
+
+		/*
+			"Deployment.Owners",
+			"Deployment.DeployConfig.Args",
+			"Deployment.Args",
+		*/
+	}
+
+	ast := allfields.ParseDir(".")
+	tree := allfields.ExtractTree(ast, "Deployment")
+	untouched := allfields.ConfirmTree(tree, ast, "Diff").Exempt(exemptions)
+
+	assert.Empty(t, untouched)
+}
 
 func TestDeploymentClone(t *testing.T) {
 	vers := semv.MustParse("1.2.3-test+thing")

--- a/util/allfields/allfields.go
+++ b/util/allfields/allfields.go
@@ -1,0 +1,205 @@
+package allfields
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+type (
+	confTreeVisitor struct {
+		structs map[string]*structNode
+		aliases map[string]struct{}
+		needs   []fieldNeed
+	}
+
+	typeVisitor struct {
+		ctv *confTreeVisitor
+	}
+
+	typeSpecVisitor struct {
+		ctv   *confTreeVisitor
+		tName string
+	}
+
+	fieldNeed struct {
+		typeName, fieldName string
+		node                *structNode
+	}
+
+	packageMap map[string]*ast.Package
+)
+
+func (ctv *confTreeVisitor) Visit(n ast.Node) ast.Visitor {
+	switch rn := n.(type) {
+	default:
+		fmt.Printf("Not GenDecl: %T\n", rn)
+	case *ast.FuncDecl:
+	case *ast.GenDecl:
+		switch rn.Tok {
+		default:
+			spew.Printf("Not TYPE: %v\n", rn.Tok)
+		case token.IMPORT, token.CONST, token.VAR:
+		case token.TYPE:
+			return &typeVisitor{ctv: ctv}
+		}
+	}
+	return nil
+}
+
+func (v *typeVisitor) Visit(n ast.Node) ast.Visitor {
+	switch ts := n.(type) {
+	case *ast.TypeSpec:
+		return &typeSpecVisitor{ctv: v.ctv, tName: ts.Name.Name}
+	}
+	return nil
+}
+
+func (tv *typeSpecVisitor) Visit(n ast.Node) ast.Visitor {
+	ctv := tv.ctv
+
+	switch ts := n.(type) {
+	default:
+		ctv.aliases[tv.tName] = struct{}{}
+	case *ast.StructType:
+		sName := tv.tName
+		snode, has := ctv.structs[sName]
+		if !has {
+			snode = newStructNode(sName)
+			ctv.structs[sName] = snode
+		}
+
+		for _, f := range ts.Fields.List {
+			for _, n := range f.Names {
+				if simpleType(f.Type) {
+					snode.kids[n.Name] = &confirmation{typeName: typeName(f.Type)}
+				} else {
+					snode.needs = append(snode.needs, fieldNeed{typeName: typeName(f.Type), fieldName: n.Name})
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (ctv *confTreeVisitor) treeFor(name string) confNode {
+	first, has := ctv.structs[name]
+	if !has {
+		panic(fmt.Errorf("no struct type named %q", name))
+	}
+	must := []*structNode{first}
+
+	for len(must) > 0 {
+		var thumb *structNode
+		thumb, must = must[0], must[1:]
+
+		for len(thumb.needs) > 0 {
+			var nd fieldNeed
+			nd, thumb.needs = thumb.needs[0], thumb.needs[1:]
+
+			if s, has := ctv.structs[nd.typeName]; has {
+				thumb.kids[nd.fieldName] = s
+				must = append(must, s)
+			} else if _, has := ctv.aliases[nd.typeName]; has {
+				thumb.kids[nd.fieldName] = &confirmation{typeName: nd.typeName}
+			} else {
+				panic(fmt.Errorf("unfulfilled need: %v", nd))
+			}
+		}
+	}
+
+	return first
+}
+
+func typeName(fType ast.Expr) string {
+	switch tx := fType.(type) {
+	default:
+		spew.Printf("default %+#v\n", tx)
+	case *ast.Ident:
+		return tx.Name
+	case *ast.ArrayType:
+		switch ex := tx.Elt.(type) {
+		default:
+			spew.Println("array default", tx, ex)
+		case *ast.Ident:
+			return ex.Name
+		}
+	case *ast.SelectorExpr:
+		return typeName(tx.X) + "." + tx.Sel.Name
+	case *ast.StarExpr:
+		switch sx := tx.X.(type) {
+		default:
+			spew.Println("star default", tx, sx)
+		case *ast.Ident:
+			return sx.Name
+		}
+	}
+	return "dunno!"
+}
+
+// This is kind of misnomer, and means more like "followable": is the type a struct in this package?
+// Either this behavior is wrong and should change, or it's right and the name should be "local struct"
+func simpleType(fType ast.Expr) bool {
+	switch tx := fType.(type) {
+	default:
+		spew.Printf("default case, simpleType: %+#v\n", tx)
+		return false
+	case *ast.Ident:
+		switch tx.Name {
+		default:
+			return false
+		case "bool", "byte", "complex64", "complex128", "error", "float32",
+			"float64", "int", "int8", "int16", "int32", "int64", "rune", "string",
+			"uint", "uint8", "uint16", "uint32", "uint64", "uintptr":
+			return true
+		}
+
+	// This and ArrayType maybe should deplend on the kind of their element types,
+	// but can't really be sure that each element is confirmed anyway...
+	case *ast.MapType:
+		return true
+	case *ast.ArrayType:
+		//return simpleType(tx.Elt)
+		return true
+	case *ast.SelectorExpr:
+		return true
+	case *ast.ChanType:
+		return true
+	case *ast.FuncType:
+		return true
+	case *ast.StarExpr:
+		return simpleType(tx.X)
+	}
+}
+
+func ParseDir(dir string) packageMap {
+	fset := &token.FileSet{}
+	inclAll := func(os.FileInfo) bool { return true }
+
+	pkgs, err := parser.ParseDir(fset, dir, inclAll, parser.DeclarationErrors)
+	if err != nil {
+		panic(err)
+	}
+
+	return pkgs
+}
+
+func ExtractTree(pkgs packageMap, structName string) confNode {
+	ctv := &confTreeVisitor{structs: map[string]*structNode{}, aliases: map[string]struct{}{}}
+
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				ast.Walk(ctv, decl)
+			}
+		}
+	}
+	spew.Dump("done visiting")
+
+	return ctv.treeFor(structName)
+}

--- a/util/allfields/allfields.go
+++ b/util/allfields/allfields.go
@@ -12,9 +12,7 @@ import (
 
 type (
 	confTreeVisitor struct {
-		structs map[string]*structNode
-		aliases map[string]struct{}
-		needs   []fieldNeed
+		structs map[string]*structReq
 	}
 
 	typeVisitor struct {
@@ -26,13 +24,51 @@ type (
 		tName string
 	}
 
-	fieldNeed struct {
-		typeName, fieldName string
-		node                *structNode
+	fieldVisitor struct {
+		ctv   *confTreeVisitor
+		snode *structDef
+	}
+
+	structDef struct {
+		typeName                string
+		simpleFields            map[string]string
+		namedFields, anonFields map[string]*structReq
+	}
+
+	structReq struct {
+		typeName string
+		sat      *structDef
+		alias    bool
 	}
 
 	packageMap map[string]*ast.Package
 )
+
+func ParseDir(dir string) packageMap {
+	fset := &token.FileSet{}
+	inclAll := func(os.FileInfo) bool { return true }
+
+	pkgs, err := parser.ParseDir(fset, dir, inclAll, parser.DeclarationErrors)
+	if err != nil {
+		panic(err)
+	}
+
+	return pkgs
+}
+
+func ExtractTree(pkgs packageMap, structName string) confNode {
+	ctv := &confTreeVisitor{structs: map[string]*structReq{}}
+
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				ast.Walk(ctv, decl)
+			}
+		}
+	}
+
+	return ctv.treeFor(structName)
+}
 
 func (ctv *confTreeVisitor) Visit(n ast.Node) ast.Visitor {
 	switch rn := n.(type) {
@@ -51,8 +87,21 @@ func (ctv *confTreeVisitor) Visit(n ast.Node) ast.Visitor {
 	return nil
 }
 
+func (ctv *confTreeVisitor) getStructReq(name string) *structReq {
+	req, has := ctv.structs[name]
+	if has {
+		return req
+	}
+	req = &structReq{typeName: name}
+	ctv.structs[name] = req
+	return req
+}
+
 func (v *typeVisitor) Visit(n ast.Node) ast.Visitor {
 	switch ts := n.(type) {
+	default:
+		spew.Printf("tV: not typespec: %v\n", ts)
+	case nil:
 	case *ast.TypeSpec:
 		return &typeSpecVisitor{ctv: v.ctv, tName: ts.Name.Name}
 	}
@@ -62,79 +111,136 @@ func (v *typeVisitor) Visit(n ast.Node) ast.Visitor {
 func (tv *typeSpecVisitor) Visit(n ast.Node) ast.Visitor {
 	ctv := tv.ctv
 
-	switch ts := n.(type) {
+	switch rn := n.(type) {
 	default:
-		ctv.aliases[tv.tName] = struct{}{}
+		spew.Printf("typeSpec default (->alias): %+#v\n", n)
+	case nil:
+	case *ast.CommentGroup:
+	case *ast.Ident:
+		if tv.tName == "" {
+			tv.tName = rn.Name
+		} else {
+			alias := ctv.getStructReq(tv.tName)
+			alias.alias = true
+		}
+	case *ast.ArrayType, *ast.MapType, *ast.ChanType:
+		alias := ctv.getStructReq(tv.tName)
+		alias.alias = true
+	case *ast.InterfaceType, *ast.FuncType: // not really, but end of confirmable paths
+		alias := ctv.getStructReq(tv.tName)
+		alias.alias = true
 	case *ast.StructType:
 		sName := tv.tName
-		snode, has := ctv.structs[sName]
-		if !has {
-			snode = newStructNode(sName)
-			ctv.structs[sName] = snode
+		snode := ctv.getStructReq(sName)
+		if snode.sat != nil {
+			panic("redefinition of " + sName)
+		}
+		snode.sat = &structDef{
+			typeName:     tv.tName,
+			namedFields:  map[string]*structReq{},
+			anonFields:   map[string]*structReq{},
+			simpleFields: map[string]string{},
 		}
 
-		for _, f := range ts.Fields.List {
-			for _, n := range f.Names {
-				if simpleType(f.Type) {
-					snode.kids[n.Name] = &confirmation{typeName: typeName(f.Type)}
-				} else {
-					snode.needs = append(snode.needs, fieldNeed{typeName: typeName(f.Type), fieldName: n.Name})
-				}
-			}
-		}
+		return &fieldVisitor{ctv: ctv, snode: snode.sat}
 	}
 
 	return nil
 }
 
-func (ctv *confTreeVisitor) treeFor(name string) confNode {
-	first, has := ctv.structs[name]
-	if !has {
-		panic(fmt.Errorf("no struct type named %q", name))
-	}
-	must := []*structNode{first}
-
-	for len(must) > 0 {
-		var thumb *structNode
-		thumb, must = must[0], must[1:]
-
-		for len(thumb.needs) > 0 {
-			var nd fieldNeed
-			nd, thumb.needs = thumb.needs[0], thumb.needs[1:]
-
-			if s, has := ctv.structs[nd.typeName]; has {
-				thumb.kids[nd.fieldName] = s
-				must = append(must, s)
-			} else if _, has := ctv.aliases[nd.typeName]; has {
-				thumb.kids[nd.fieldName] = &confirmation{typeName: nd.typeName}
-			} else {
-				panic(fmt.Errorf("unfulfilled need: %v", nd))
+func (v *fieldVisitor) Visit(n ast.Node) ast.Visitor {
+	switch f := n.(type) {
+	default:
+		spew.Printf("fieldVisitor default: %v\n", f)
+	case nil:
+	case *ast.FieldList:
+		return v
+	case *ast.Field:
+		switch {
+		default:
+			for _, n := range f.Names {
+				v.snode.namedFields[n.Name] = v.ctv.getStructReq(typeName(f.Type))
+			}
+		case len(f.Names) == 0:
+			tn := typeName(f.Type)
+			v.snode.anonFields[tn] = v.ctv.getStructReq(tn)
+		case simpleType(f.Type):
+			for _, n := range f.Names {
+				v.snode.simpleFields[n.Name] = typeName(f.Type)
 			}
 		}
 	}
-
-	return first
+	return nil
 }
 
-func typeName(fType ast.Expr) string {
+// XXX Cycles in the struct def tree will not be caught!
+// Linked lists are a no go!
+func (ctv *confTreeVisitor) treeFor(name string) confNode {
+	first, has := ctv.structs[name]
+	if !has {
+		panic(fmt.Errorf("no requirement recorded for struct type named %q", name))
+	}
+
+	return first.confNode(name)
+}
+
+func (sr *structReq) confNode(name string) confNode {
+	switch {
+	default:
+		panic(fmt.Errorf("no satisfying def for `%s %s`", name, sr.typeName))
+	case sr.sat != nil:
+		return sr.sat.confNode()
+	case sr.alias:
+		return newConfirmation(sr.typeName)
+	}
+}
+
+func (sd *structDef) confNode() confNode {
+	node := newStructNode(sd.typeName)
+
+	for name, typeName := range sd.simpleFields {
+		node.kids[name] = newConfirmation(typeName)
+	}
+
+	for name, req := range sd.namedFields {
+		node.kids[name] = req.confNode(name)
+	}
+
+	for name, req := range sd.anonFields {
+		field := req.confNode(name)
+		node.kids[name] = field
+		if aStruct, is := field.(*structNode); is {
+			for n, subField := range aStruct.kids {
+				if _, has := node.kids[n]; !has {
+					node.kids[n] = subField
+				}
+			}
+		}
+	}
+	return node
+}
+
+func typeName(fType ast.Node) string {
 	switch tx := fType.(type) {
 	default:
-		spew.Printf("default %+#v\n", tx)
+		//spew.Printf("typeName default %+#v\n", tx)
 	case *ast.Ident:
 		return tx.Name
+	case *ast.MapType:
+		return "map[?]?"
 	case *ast.ArrayType:
 		switch ex := tx.Elt.(type) {
 		default:
-			spew.Println("array default", tx, ex)
+			//spew.Println("array default", tx, ex)
 		case *ast.Ident:
-			return ex.Name
+			return "[]" + ex.Name
 		}
 	case *ast.SelectorExpr:
 		return typeName(tx.X) + "." + tx.Sel.Name
 	case *ast.StarExpr:
 		switch sx := tx.X.(type) {
 		default:
-			spew.Println("star default", tx, sx)
+			//spew.Println("star default", tx, sx)
 		case *ast.Ident:
 			return sx.Name
 		}
@@ -147,7 +253,7 @@ func typeName(fType ast.Expr) string {
 func simpleType(fType ast.Expr) bool {
 	switch tx := fType.(type) {
 	default:
-		spew.Printf("default case, simpleType: %+#v\n", tx)
+		//spew.Printf("default case, simpleType: %+#v\n", tx)
 		return false
 	case *ast.Ident:
 		switch tx.Name {
@@ -175,31 +281,4 @@ func simpleType(fType ast.Expr) bool {
 	case *ast.StarExpr:
 		return simpleType(tx.X)
 	}
-}
-
-func ParseDir(dir string) packageMap {
-	fset := &token.FileSet{}
-	inclAll := func(os.FileInfo) bool { return true }
-
-	pkgs, err := parser.ParseDir(fset, dir, inclAll, parser.DeclarationErrors)
-	if err != nil {
-		panic(err)
-	}
-
-	return pkgs
-}
-
-func ExtractTree(pkgs packageMap, structName string) confNode {
-	ctv := &confTreeVisitor{structs: map[string]*structNode{}, aliases: map[string]struct{}{}}
-
-	for _, pkg := range pkgs {
-		for _, file := range pkg.Files {
-			for _, decl := range file.Decls {
-				ast.Walk(ctv, decl)
-			}
-		}
-	}
-	spew.Dump("done visiting")
-
-	return ctv.treeFor(structName)
 }

--- a/util/allfields/confirmtree.go
+++ b/util/allfields/confirmtree.go
@@ -10,43 +10,59 @@ import (
 
 type (
 	functionFinder struct {
-		pkgs   packageMap
+		found  bool
 		target string
-		tree   confNode
-		scope  *ast.Scope
+		*parentRef
+	}
+
+	parentRef struct {
+		_pkgs  packageMap
+		_tree  confNode
+		_scope *ast.Scope
+	}
+
+	visitor interface {
+		pkgs() packageMap
+		tree() confNode
+		scope() *ast.Scope
+		pRef() *parentRef
 	}
 
 	confirmVisitor struct {
-		pkgs  packageMap
-		tree  confNode
-		scope *ast.Scope
-		recv  *recvVisitor
-		args  *recvVisitor
+		*parentRef
+		name *ast.Ident
+		recv *recvVisitor
+		args *recvVisitor
 	}
 
 	recvVisitor struct {
-		tree      confNode
-		scope     *ast.Scope
+		*parentRef
 		args      []*argVisitor
 		matchRoot bool
 	}
 
 	argVisitor struct {
+		*parentRef
+		lastNode  ast.Node
 		names     []string
 		matchRoot bool
-		tree      confNode
-		scope     *ast.Scope
+	}
+
+	compLitVisitor struct {
+		*parentRef
+	}
+
+	kvVisitor struct {
+		name *ast.Ident
+		*parentRef
 	}
 
 	exprVisitor struct {
-		pkgs  packageMap
-		tree  confNode
-		scope *ast.Scope
+		*parentRef
 	}
 
 	selectorVisitor struct {
-		tree  confNode
-		scope *ast.Scope
+		*parentRef
 
 		on         *selectorVisitor
 		targetName string
@@ -54,29 +70,36 @@ type (
 	}
 
 	bodyVisitor struct {
-		pkgs  packageMap
-		tree  confNode
+		*parentRef
 		scope *ast.Scope
 	}
 
 	bodyDeclVisitor struct {
-		tree  confNode
-		scope *ast.Scope
+		*parentRef
 	}
 
 	ifVisitor struct {
-		pkgs  packageMap
-		tree  confNode
+		*parentRef
+		scope *ast.Scope
+	}
+
+	rangeVisitor struct {
+		*parentRef
+		stmt  *ast.RangeStmt
 		scope *ast.Scope
 	}
 
 	assignVisitor struct {
-		pkgs  packageMap
-		stmt  *ast.AssignStmt
-		tree  confNode
-		scope *ast.Scope
-		lhs   []asgPath
-		rhs   []rhsItem
+		*parentRef
+		stmt *ast.AssignStmt
+		lhs  []asgPath
+		rhs  []rhsItem
+	}
+
+	callVisitor struct {
+		*parentRef
+		fun  *selectorVisitor
+		args []*selectorVisitor
 	}
 
 	asgPath struct {
@@ -87,15 +110,44 @@ type (
 		sel *selectorVisitor
 		fun *ast.FuncLit
 	}
-
-	callVisitor struct {
-		pkgs  packageMap
-		fun   *selectorVisitor
-		args  []*selectorVisitor
-		tree  confNode
-		scope *ast.Scope
-	}
 )
+
+func ConfirmTree(cn confNode, pkgs packageMap, funcName string) []string {
+	for _, pkg := range pkgs {
+		ff := &functionFinder{
+			target:    funcName,
+			parentRef: &parentRef{_pkgs: pkgs, _tree: cn, _scope: ast.NewScope(nil)},
+		}
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				ast.Walk(ff, decl)
+			}
+		}
+		if cn.confirmed() {
+			return []string{}
+		}
+	}
+
+	missed := []string{}
+	tName := cn.name()
+	for _, f := range cn.missed() {
+		missed = append(missed, tName+f)
+	}
+	return missed
+}
+
+func (pr *parentRef) tree() confNode    { return pr._tree }
+func (pr *parentRef) pkgs() packageMap  { return pr._pkgs }
+func (pr *parentRef) scope() *ast.Scope { return pr._scope }
+func (pr *parentRef) pRef() *parentRef  { return pr }
+
+func (pr *parentRef) pRefNewScope() *parentRef {
+	return &parentRef{
+		_pkgs:  pr.pkgs(),
+		_tree:  pr.tree(),
+		_scope: ast.NewScope(pr.scope()),
+	}
+}
 
 func (v *functionFinder) Visit(n ast.Node) ast.Visitor {
 	switch rn := n.(type) {
@@ -105,7 +157,8 @@ func (v *functionFinder) Visit(n ast.Node) ast.Visitor {
 	case *ast.GenDecl:
 	case *ast.FuncDecl:
 		if rn.Name.Name == v.target {
-			return &confirmVisitor{pkgs: v.pkgs, tree: v.tree, scope: ast.NewScope(v.scope)}
+			v.found = true
+			return &confirmVisitor{parentRef: v.pRefNewScope()}
 		}
 	}
 	return nil
@@ -118,17 +171,16 @@ func (v *confirmVisitor) Visit(n ast.Node) ast.Visitor {
 	case nil:
 	case *ast.CommentGroup:
 	case *ast.Ident: //Name
+		v.name = rn
 	case *ast.FieldList: //Recv
-		v.recv = &recvVisitor{tree: v.tree, scope: v.scope}
+		v.recv = &recvVisitor{parentRef: v.pRef()}
 		return v.recv
 	case *ast.FuncType: //Type
-		v.args = &recvVisitor{tree: v.tree, scope: v.scope}
+		v.args = &recvVisitor{parentRef: v.pRef()}
 		ast.Walk(v.args, rn.Params)
 	case *ast.BlockStmt: //body
 		if (v.recv != nil && v.recv.matchRoot) || (v.args != nil && v.args.matchRoot) { // only if the function's receiver or arg is if the type
-			spew.Println("start body")
-			spew.Dump(v.scope)
-			return &bodyVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
+			return &bodyVisitor{parentRef: v.pRefNewScope()}
 		}
 	}
 	return nil
@@ -149,7 +201,7 @@ func (v *recvVisitor) Visit(n ast.Node) ast.Visitor {
 	case *ast.FieldList:
 		return v
 	case *ast.Field:
-		av := &argVisitor{names: []string{}, scope: v.scope, tree: v.tree}
+		av := &argVisitor{names: []string{}, parentRef: v.pRef()}
 		v.args = append(v.args, av)
 		return av
 	}
@@ -157,28 +209,32 @@ func (v *recvVisitor) Visit(n ast.Node) ast.Visitor {
 }
 
 func (v *argVisitor) Visit(n ast.Node) ast.Visitor {
-	switch rn := n.(type) {
+	switch n.(type) {
 	default:
-		spew.Printf("unexpected type to argV: %+#v\n", n)
-	case nil:
-	case *ast.CommentGroup, *ast.BasicLit:
-	case *ast.Ident:
-		v.names = append(v.names, rn.Name)
-	case *ast.StarExpr:
-		tName := typeName(rn)
-		//spew.Printf("arg type: %v (vs. root type %v)\n", tName, v.tree.name())
-		if tName == v.tree.name() {
-			v.matchRoot = true
-			v.tree.confirm()
-			for _, name := range v.names {
-				obj := ast.NewObj(ast.Var, name)
-				obj.Decl = rn
-				obj.Data = v.tree
-				v.scope.Insert(obj)
-			}
+		if ident, is := v.lastNode.(*ast.Ident); is {
+			v.names = append(v.names, ident.Name)
 		}
-	case ast.Expr:
-		spew.Printf("argV Expr: %#v\n", rn)
+		v.lastNode = n
+	case *ast.CommentGroup, *ast.BasicLit:
+	case nil:
+		switch rn := v.lastNode.(type) {
+		default:
+			spew.Printf("unexpected type to argV: %+#v\n", v.lastNode)
+		case *ast.Ident, *ast.StarExpr:
+			tName := typeName(rn)
+			if tName == v.tree().name() {
+				v.matchRoot = true
+				v.tree().confirm()
+				for _, name := range v.names {
+					obj := ast.NewObj(ast.Var, name)
+					obj.Decl = rn
+					obj.Data = v.tree()
+					v.scope().Insert(obj)
+				}
+			}
+		case ast.Expr:
+			spew.Printf("argV Expr: %#v\n", rn)
+		}
 	}
 	return nil
 }
@@ -189,16 +245,35 @@ func (v *bodyVisitor) Visit(n ast.Node) ast.Visitor {
 		spew.Printf("unexpected type to bodyV: %+#v\n", n)
 	case *ast.CommentGroup, *ast.BasicLit:
 	case nil:
+	case *ast.BranchStmt:
 	case *ast.AssignStmt:
-		return &assignVisitor{pkgs: v.pkgs, stmt: rn, tree: v.tree, scope: v.scope}
+		return &assignVisitor{stmt: rn, parentRef: v.pRef()}
 	case *ast.IfStmt:
-		return &ifVisitor{pkgs: v.pkgs, tree: v.tree, scope: ast.NewScope(v.scope)}
+		return &ifVisitor{parentRef: v.pRefNewScope()}
+	case *ast.RangeStmt:
+		return &rangeVisitor{parentRef: v.pRefNewScope(), stmt: rn}
 	case *ast.ExprStmt:
-		return &exprVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
+		return &exprVisitor{parentRef: v.pRef()}
 	case *ast.DeclStmt:
-		return &bodyDeclVisitor{tree: v.tree, scope: v.scope}
+		return &bodyDeclVisitor{parentRef: v.pRef()}
 	case *ast.ReturnStmt:
-		return &exprVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
+		return &exprVisitor{parentRef: v.pRef()}
+	}
+	return nil
+}
+
+func (v *rangeVisitor) Visit(n ast.Node) ast.Visitor {
+	switch rn := n.(type) {
+	default:
+		spew.Printf("unexpected type to rangeV: %+#v\n", n)
+	case nil:
+	case *ast.CommentGroup, *ast.BasicLit:
+	case *ast.BlockStmt:
+		return &bodyVisitor{parentRef: v.pRef()}
+	case ast.Expr:
+		if rn.Pos() > v.stmt.TokPos {
+			return &exprVisitor{parentRef: v.pRef()}
+		}
 	}
 	return nil
 }
@@ -209,7 +284,6 @@ func (v *bodyDeclVisitor) Visit(n ast.Node) ast.Visitor {
 		spew.Printf("unexpected type to bodyDeclV: %+#v\n", n)
 	case *ast.CommentGroup, *ast.BasicLit:
 	case nil:
-		spew.Println("end body")
 	case *ast.GenDecl:
 		switch rn.Tok {
 		default:
@@ -229,15 +303,49 @@ func (v *exprVisitor) Visit(n ast.Node) ast.Visitor {
 	case *ast.CommentGroup, *ast.BasicLit:
 	case nil:
 	case *ast.UnaryExpr, *ast.BinaryExpr:
-		return &exprVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
+		return &exprVisitor{parentRef: v.pRef()}
 	case *ast.ExprStmt:
 		return v
+	case *ast.StarExpr:
+		return v
 	case *ast.SelectorExpr:
-		return &selectorVisitor{tree: v.tree, scope: v.scope}
+		return &selectorVisitor{parentRef: v.pRef()}
 	case *ast.CallExpr:
-		return &callVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
+		return &callVisitor{parentRef: v.pRef()}
 	case *ast.Ident:
 		// in these contexts, not interesting
+	case *ast.CompositeLit:
+		return &compLitVisitor{parentRef: v.pRef()}
+	}
+	return nil
+}
+
+func (v *compLitVisitor) Visit(n ast.Node) ast.Visitor {
+	switch n.(type) {
+	default:
+		spew.Printf("unexpected type to compLitV: %+#v\n", n)
+	case *ast.CommentGroup, *ast.BasicLit:
+	case nil:
+	case *ast.Ident:
+		// just the type of the struct/array
+	case *ast.KeyValueExpr:
+		return &kvVisitor{parentRef: v.pRef()}
+	}
+	return nil
+}
+
+func (v *kvVisitor) Visit(n ast.Node) ast.Visitor {
+	switch n.(type) {
+	default:
+		spew.Printf("unexpected type to kvV: %+#v\n", n)
+	case *ast.CommentGroup, *ast.BasicLit:
+	case nil:
+	case *ast.Ident:
+		return nil //don't care about keys, don't care about `key: localVar`
+	case *ast.CallExpr:
+		return &callVisitor{parentRef: v.pRef()}
+	case *ast.SelectorExpr:
+		return &selectorVisitor{parentRef: v.pRef()}
 	}
 	return nil
 }
@@ -248,19 +356,19 @@ func (v *selectorVisitor) Visit(n ast.Node) ast.Visitor {
 		default:
 			spew.Printf("unexpected type to selectorV: %+#v\n", n)
 		case nil:
+			spew.Printf("selector 'complete' before getting any part\n")
 		//case ast.Expr: //body
-		//		return &exprVisitor{tree: v.tree, scope: v.scope}
+		//		return &exprVisitor{tree: v.tree(), scope: v.scope}
 		case *ast.Ident:
-			c := findVar(v.scope, rn.Name)
+			c := findVar(v.scope(), rn.Name)
 			if c != nil {
 				v.on = &selectorVisitor{targetName: rn.Name, target: c}
 			} else {
-				spew.Printf("selector Couldn't find %q in scope.\n", rn.Name)
 				v.on = &selectorVisitor{targetName: rn.Name, target: c}
 			}
 		case *ast.SelectorExpr:
-			sv := &selectorVisitor{scope: v.scope, tree: v.tree}
-			return sv
+			v.on = &selectorVisitor{parentRef: v.pRef()}
+			return v.on
 		}
 		return nil
 	}
@@ -274,12 +382,9 @@ func (v *selectorVisitor) Visit(n ast.Node) ast.Visitor {
 		v.targetName = rn.Name
 		if stgt, ok := v.on.target.(confTreeNode); ok {
 			v.target = stgt.child(rn.Name)
-			//spew.Printf("Found selector target %q: %#v\n", rn.Name, v.target)
 			if v.target != nil {
 				v.target.confirm()
 			}
-		} else {
-			spew.Printf("selector v.on.target was not a confTreeNode: %#v\n", v.on.target)
 		}
 	}
 	return nil
@@ -296,15 +401,23 @@ func findVar(s *ast.Scope, name string) confNode {
 }
 
 func (v *ifVisitor) Visit(n ast.Node) ast.Visitor {
-	switch n.(type) {
+	switch rn := n.(type) {
 	default:
 		spew.Printf("unexpected type to ifV: %+#v\n", n)
 	case *ast.CommentGroup, *ast.BasicLit:
 	case nil:
+	case *ast.Ident:
+		// not interesting in this context
 	case *ast.BlockStmt: //body
-		return &bodyVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
+		return &bodyVisitor{parentRef: v.pRef()}
 	case *ast.UnaryExpr, *ast.BinaryExpr:
-		return &exprVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
+		return &exprVisitor{parentRef: v.pRef()}
+	case *ast.IfStmt:
+		return &ifVisitor{parentRef: v.pRefNewScope()}
+	case *ast.AssignStmt:
+		return &assignVisitor{stmt: rn, parentRef: v.pRef()}
+	case *ast.CallExpr:
+		return &callVisitor{parentRef: v.pRef()}
 	}
 	return nil
 }
@@ -313,35 +426,31 @@ func (v *assignVisitor) Visit(n ast.Node) ast.Visitor {
 	switch rn := n.(type) {
 	default:
 		if rn.Pos() < v.stmt.TokPos {
-			spew.Printf("LHS assignV: %+#v\n", n)
 			v.lhs = append(v.lhs, asgPath{})
 		} else {
-			spew.Printf("RHS assignV: %+#v\n", n)
 			v.rhs = append(v.rhs, rhsItem{sel: &selectorVisitor{}})
 		}
 	case *ast.CommentGroup, *ast.BasicLit:
 	case nil:
 		//spew.Printf("LHS: %+#v\n", v.lhs)
 		for n, r := range v.rhs {
-			if r.sel != nil {
+			if r.sel != nil && r.sel.target != nil {
 				obj := ast.NewObj(ast.Var, v.lhs[n].name)
 				obj.Decl = rn
 				obj.Data = r.sel.target
-				if obj.Data != nil {
-					r.sel.target.confirm()
-				}
-				v.scope.Insert(obj)
+				r.sel.target.confirm()
+				v.scope().Insert(obj)
 			}
 		}
 	case *ast.FuncLit:
 		v.rhs = append(v.rhs, rhsItem{fun: rn})
 	case *ast.CallExpr:
-		return &callVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
+		return &callVisitor{parentRef: v.pRef()}
 	case *ast.Ident:
 		if rn.Pos() < v.stmt.TokPos {
 			v.lhs = append(v.lhs, asgPath{name: rn.Name})
 		} else {
-			v.rhs = append(v.rhs, rhsItem{sel: &selectorVisitor{target: findVar(v.scope, rn.Name)}})
+			v.rhs = append(v.rhs, rhsItem{sel: &selectorVisitor{target: findVar(v.scope(), rn.Name)}})
 		}
 	}
 	return nil
@@ -358,12 +467,12 @@ func (v *callVisitor) Visit(n ast.Node) ast.Visitor {
 		} else {
 			if v.fun.on != nil {
 				if v.fun.on.target != nil {
-					ConfirmTree(v.fun.on.target, v.pkgs, v.fun.targetName)
+					ConfirmTree(v.fun.on.target, v.pkgs(), v.fun.targetName)
 				}
 
 				for _, a := range v.args {
 					if a.target != nil {
-						ConfirmTree(a.target, v.pkgs, v.fun.targetName)
+						ConfirmTree(a.target, v.pkgs(), v.fun.targetName)
 					}
 				}
 			}
@@ -371,50 +480,27 @@ func (v *callVisitor) Visit(n ast.Node) ast.Visitor {
 		}
 	case *ast.Ident:
 		if v.fun == nil {
-			spew.Printf("Call of %q\n", rn.Name)
-			v.fun = &selectorVisitor{target: findVar(v.scope, rn.Name)}
+			v.fun = &selectorVisitor{target: findVar(v.scope(), rn.Name)}
 		} else {
-			as := &selectorVisitor{target: findVar(v.scope, rn.Name)}
+			as := &selectorVisitor{target: findVar(v.scope(), rn.Name)}
 			v.args = append(v.args, as)
 		}
 	case *ast.SelectorExpr:
 		if v.fun == nil {
-			spew.Printf("Call of %v\n", rn)
-			as := &selectorVisitor{tree: v.tree, scope: v.scope}
+			as := &selectorVisitor{parentRef: v.pRef()}
 			v.fun = as
 			return as
 		}
-		as := &selectorVisitor{tree: v.tree, scope: v.scope}
+		as := &selectorVisitor{parentRef: v.pRef()}
 		v.args = append(v.args, as)
 		return as
 	case *ast.CallExpr:
-		return &callVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
-	case *ast.UnaryExpr, *ast.BinaryExpr:
-		return &exprVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
+		return &callVisitor{parentRef: v.pRef()}
+	case *ast.UnaryExpr, *ast.BinaryExpr, *ast.StarExpr:
+		return &exprVisitor{parentRef: v.pRef()}
+	case *ast.CompositeLit:
+		return &compLitVisitor{parentRef: v.pRef()}
 	}
 
 	return nil
-}
-
-func ConfirmTree(cn confNode, pkgs packageMap, funcName string) []string {
-	spew.Printf("Confirming %q touches fields of %q\n", funcName, cn.name())
-	for _, pkg := range pkgs {
-		ff := &functionFinder{pkgs: pkgs, target: funcName, tree: cn, scope: ast.NewScope(nil)}
-		for _, file := range pkg.Files {
-			for _, decl := range file.Decls {
-				ast.Walk(ff, decl)
-			}
-		}
-		if cn.confirmed() {
-			return []string{}
-		}
-	}
-
-	missed := []string{}
-	tName := cn.name()
-	for _, f := range cn.missed() {
-		missed = append(missed, tName+f)
-	}
-	return missed
-
 }

--- a/util/allfields/confirmtree.go
+++ b/util/allfields/confirmtree.go
@@ -110,9 +110,11 @@ type (
 		sel *selectorVisitor
 		fun *ast.FuncLit
 	}
+
+	missedReport []string
 )
 
-func ConfirmTree(cn confNode, pkgs packageMap, funcName string) []string {
+func ConfirmTree(cn confNode, pkgs packageMap, funcName string) missedReport {
 	for _, pkg := range pkgs {
 		ff := &functionFinder{
 			target:    funcName,
@@ -134,6 +136,23 @@ func ConfirmTree(cn confNode, pkgs packageMap, funcName string) []string {
 		missed = append(missed, tName+f)
 	}
 	return missed
+}
+
+func (rep missedReport) Exempt(forgiven []string) []string {
+	realBad := []string{}
+	for _, miss := range rep {
+		keep := true
+		for _, forgive := range forgiven {
+			if miss == forgive {
+				keep = false
+				break
+			}
+		}
+		if keep {
+			realBad = append(realBad, miss)
+		}
+	}
+	return realBad
 }
 
 func (pr *parentRef) tree() confNode    { return pr._tree }

--- a/util/allfields/confirmtree.go
+++ b/util/allfields/confirmtree.go
@@ -1,0 +1,262 @@
+package allfields
+
+import (
+	"fmt"
+	"go/ast"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+type (
+	functionFinder struct {
+		target string
+		tree   confNode
+		scope  *ast.Scope
+	}
+
+	confirmVisitor struct {
+		tree  confNode
+		scope *ast.Scope
+	}
+
+	recvVisitor struct {
+		tree  confNode
+		scope *ast.Scope
+	}
+
+	argVisitor struct {
+		names []string
+		tree  confNode
+		scope *ast.Scope
+	}
+
+	exprVisitor struct {
+		tree  confNode
+		scope *ast.Scope
+	}
+
+	selectorVisitor struct {
+		tree  confNode
+		scope *ast.Scope
+
+		on     *selectorVisitor
+		target confNode
+	}
+
+	bodyVisitor struct {
+		tree  confNode
+		scope *ast.Scope
+	}
+
+	ifVisitor struct {
+		tree  confNode
+		scope *ast.Scope
+	}
+
+	assignVisitor struct {
+		stmt  *ast.AssignStmt
+		tree  confNode
+		scope *ast.Scope
+	}
+)
+
+func (v *functionFinder) Visit(n ast.Node) ast.Visitor {
+	switch rn := n.(type) {
+	default:
+		fmt.Printf("Not FuncDecl: %T\n", rn)
+	case nil:
+	case *ast.GenDecl:
+	case *ast.FuncDecl:
+		if rn.Name.Name == v.target {
+			return &confirmVisitor{tree: v.tree, scope: ast.NewScope(v.scope)}
+		}
+	}
+	return nil
+}
+
+func (v *confirmVisitor) Visit(n ast.Node) ast.Visitor {
+	switch rn := n.(type) {
+	default:
+		spew.Printf("unexpected type to cV: %+#v\n", n)
+	case nil:
+	case *ast.CommentGroup:
+	case *ast.Ident: //Name
+	case *ast.FieldList: //Recv
+		return &recvVisitor{tree: v.tree, scope: v.scope}
+	case *ast.FuncType: //Type
+		rv := &recvVisitor{tree: v.tree, scope: v.scope}
+		ast.Walk(rv, rn.Params)
+	case *ast.BlockStmt: //body
+		if v.tree.selfConfirmed() { // only if the function's receiver or arg is if the type
+			spew.Dump(v.scope)
+			return &bodyVisitor{tree: v.tree, scope: v.scope}
+		}
+	}
+	return nil
+}
+
+func (v *recvVisitor) Visit(n ast.Node) ast.Visitor {
+	switch n.(type) {
+	default:
+		spew.Printf("unexpected type to recvV: %+#v\n", n)
+	case nil:
+	case *ast.CommentGroup:
+	case *ast.FieldList:
+		return v
+	case *ast.Field:
+		return &argVisitor{names: []string{}, scope: v.scope, tree: v.tree}
+	}
+	return nil
+}
+
+func (v *argVisitor) Visit(n ast.Node) ast.Visitor {
+	switch rn := n.(type) {
+	default:
+		spew.Printf("unexpected type to argV: %+#v\n", n)
+	case nil:
+	case *ast.CommentGroup, *ast.BasicLit:
+	case *ast.Ident:
+		v.names = append(v.names, rn.Name)
+	case ast.Expr:
+		tName := typeName(rn)
+		if tName == v.tree.name() {
+			v.tree.confirm()
+			for _, name := range v.names {
+				obj := ast.NewObj(ast.Var, name)
+				obj.Decl = rn
+				obj.Data = v.tree
+				v.scope.Insert(obj)
+			}
+		}
+	}
+	return nil
+}
+
+func (v *bodyVisitor) Visit(n ast.Node) ast.Visitor {
+	switch rn := n.(type) {
+	default:
+		spew.Printf("unexpected type to bodyV: %+#v\n", n)
+	case *ast.CommentGroup, *ast.BasicLit:
+	case nil:
+	case *ast.AssignStmt:
+		return &assignVisitor{stmt: rn, tree: v.tree, scope: v.scope}
+	case *ast.IfStmt:
+		return &ifVisitor{tree: v.tree, scope: ast.NewScope(v.scope)}
+	case *ast.ExprStmt:
+		return &exprVisitor{tree: v.tree, scope: v.scope}
+	}
+	return nil
+}
+
+func (v *exprVisitor) Visit(n ast.Node) ast.Visitor {
+	switch n.(type) {
+	default:
+		spew.Printf("unexpected type to exprV: %+#v\n", n)
+	case *ast.CommentGroup, *ast.BasicLit:
+	case nil:
+	case *ast.UnaryExpr, *ast.BinaryExpr:
+		return &exprVisitor{tree: v.tree, scope: v.scope}
+	case *ast.ExprStmt:
+		return v
+	case *ast.SelectorExpr:
+		return &selectorVisitor{tree: v.tree, scope: v.scope}
+	}
+	return nil
+}
+
+var dummyOn = &selectorVisitor{target: nil}
+
+func (v *selectorVisitor) Visit(n ast.Node) ast.Visitor {
+	if v.on == nil {
+		switch rn := n.(type) {
+		default:
+			spew.Printf("unexpected type to selectorV: %+#v\n", n)
+		case nil:
+		//case ast.Expr: //body
+		//		return &exprVisitor{tree: v.tree, scope: v.scope}
+		case *ast.Ident:
+			c := findVar(v.scope, rn.Name)
+			if c != nil {
+				v.on = &selectorVisitor{target: c}
+			} else {
+				spew.Printf("selector Couldn't find %q in scope.", rn.Name)
+				v.on = dummyOn
+			}
+		case *ast.SelectorExpr:
+			sv := &selectorVisitor{scope: v.scope, tree: v.tree}
+			return sv
+		}
+		return nil
+	}
+
+	switch rn := n.(type) {
+	default:
+		spew.Printf("unexpected type to selectorV: %+#v\n", n)
+	case nil:
+	case *ast.Ident:
+		if stgt, ok := v.on.target.(confTreeNode); ok {
+			v.target = stgt.child(rn.Name)
+			spew.Printf("Found selector target: %#v\n", v.target)
+			if v.target != nil {
+				v.target.confirm()
+			}
+		} else {
+			spew.Printf("selector v.on.target was not a confTreeNode: %#v", v.on.target)
+		}
+	}
+	return nil
+}
+
+func findVar(s *ast.Scope, name string) confNode {
+	if s == nil {
+		return nil
+	}
+	if obj := s.Lookup(name); obj != nil {
+		return obj.Data.(confNode)
+	}
+	return findVar(s.Outer, name)
+}
+
+func (v *ifVisitor) Visit(n ast.Node) ast.Visitor {
+	switch n.(type) {
+	default:
+		spew.Printf("unexpected type to ifV: %+#v\n", n)
+	case *ast.CommentGroup, *ast.BasicLit:
+	case nil:
+	case *ast.BlockStmt: //body
+		return &bodyVisitor{tree: v.tree, scope: v.scope}
+	case *ast.UnaryExpr, *ast.BinaryExpr:
+		return &exprVisitor{tree: v.tree, scope: v.scope}
+	}
+	return nil
+}
+
+func (v *assignVisitor) Visit(n ast.Node) ast.Visitor {
+	switch rn := n.(type) {
+	default:
+		if rn.Pos() < v.stmt.TokPos {
+			spew.Printf("LHS assignV: %+#v\n", n)
+		} else {
+			spew.Printf("RHS assignV: %+#v\n", n)
+		}
+	case *ast.CommentGroup, *ast.BasicLit:
+	case nil:
+	}
+	return nil
+}
+
+func ConfirmTree(cn confNode, pkgs packageMap, funcName string) bool {
+	for _, pkg := range pkgs {
+		ff := &functionFinder{target: funcName, tree: cn, scope: ast.NewScope(nil)}
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				ast.Walk(ff, decl)
+			}
+		}
+		if cn.confirmed() {
+			return true
+		}
+	}
+
+	return cn.confirmed()
+}

--- a/util/allfields/confirmtree.go
+++ b/util/allfields/confirmtree.go
@@ -3,34 +3,43 @@ package allfields
 import (
 	"fmt"
 	"go/ast"
+	"go/token"
 
 	"github.com/davecgh/go-spew/spew"
 )
 
 type (
 	functionFinder struct {
+		pkgs   packageMap
 		target string
 		tree   confNode
 		scope  *ast.Scope
 	}
 
 	confirmVisitor struct {
+		pkgs  packageMap
 		tree  confNode
 		scope *ast.Scope
+		recv  *recvVisitor
+		args  *recvVisitor
 	}
 
 	recvVisitor struct {
-		tree  confNode
-		scope *ast.Scope
+		tree      confNode
+		scope     *ast.Scope
+		args      []*argVisitor
+		matchRoot bool
 	}
 
 	argVisitor struct {
-		names []string
-		tree  confNode
-		scope *ast.Scope
+		names     []string
+		matchRoot bool
+		tree      confNode
+		scope     *ast.Scope
 	}
 
 	exprVisitor struct {
+		pkgs  packageMap
 		tree  confNode
 		scope *ast.Scope
 	}
@@ -39,22 +48,50 @@ type (
 		tree  confNode
 		scope *ast.Scope
 
-		on     *selectorVisitor
-		target confNode
+		on         *selectorVisitor
+		targetName string
+		target     confNode
 	}
 
 	bodyVisitor struct {
+		pkgs  packageMap
+		tree  confNode
+		scope *ast.Scope
+	}
+
+	bodyDeclVisitor struct {
 		tree  confNode
 		scope *ast.Scope
 	}
 
 	ifVisitor struct {
+		pkgs  packageMap
 		tree  confNode
 		scope *ast.Scope
 	}
 
 	assignVisitor struct {
+		pkgs  packageMap
 		stmt  *ast.AssignStmt
+		tree  confNode
+		scope *ast.Scope
+		lhs   []asgPath
+		rhs   []rhsItem
+	}
+
+	asgPath struct {
+		name string
+	}
+
+	rhsItem struct {
+		sel *selectorVisitor
+		fun *ast.FuncLit
+	}
+
+	callVisitor struct {
+		pkgs  packageMap
+		fun   *selectorVisitor
+		args  []*selectorVisitor
 		tree  confNode
 		scope *ast.Scope
 	}
@@ -68,7 +105,7 @@ func (v *functionFinder) Visit(n ast.Node) ast.Visitor {
 	case *ast.GenDecl:
 	case *ast.FuncDecl:
 		if rn.Name.Name == v.target {
-			return &confirmVisitor{tree: v.tree, scope: ast.NewScope(v.scope)}
+			return &confirmVisitor{pkgs: v.pkgs, tree: v.tree, scope: ast.NewScope(v.scope)}
 		}
 	}
 	return nil
@@ -82,14 +119,16 @@ func (v *confirmVisitor) Visit(n ast.Node) ast.Visitor {
 	case *ast.CommentGroup:
 	case *ast.Ident: //Name
 	case *ast.FieldList: //Recv
-		return &recvVisitor{tree: v.tree, scope: v.scope}
+		v.recv = &recvVisitor{tree: v.tree, scope: v.scope}
+		return v.recv
 	case *ast.FuncType: //Type
-		rv := &recvVisitor{tree: v.tree, scope: v.scope}
-		ast.Walk(rv, rn.Params)
+		v.args = &recvVisitor{tree: v.tree, scope: v.scope}
+		ast.Walk(v.args, rn.Params)
 	case *ast.BlockStmt: //body
-		if v.tree.selfConfirmed() { // only if the function's receiver or arg is if the type
+		if (v.recv != nil && v.recv.matchRoot) || (v.args != nil && v.args.matchRoot) { // only if the function's receiver or arg is if the type
+			spew.Println("start body")
 			spew.Dump(v.scope)
-			return &bodyVisitor{tree: v.tree, scope: v.scope}
+			return &bodyVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
 		}
 	}
 	return nil
@@ -100,11 +139,19 @@ func (v *recvVisitor) Visit(n ast.Node) ast.Visitor {
 	default:
 		spew.Printf("unexpected type to recvV: %+#v\n", n)
 	case nil:
+		for _, a := range v.args {
+			if a.matchRoot {
+				v.matchRoot = true
+				break
+			}
+		}
 	case *ast.CommentGroup:
 	case *ast.FieldList:
 		return v
 	case *ast.Field:
-		return &argVisitor{names: []string{}, scope: v.scope, tree: v.tree}
+		av := &argVisitor{names: []string{}, scope: v.scope, tree: v.tree}
+		v.args = append(v.args, av)
+		return av
 	}
 	return nil
 }
@@ -117,9 +164,11 @@ func (v *argVisitor) Visit(n ast.Node) ast.Visitor {
 	case *ast.CommentGroup, *ast.BasicLit:
 	case *ast.Ident:
 		v.names = append(v.names, rn.Name)
-	case ast.Expr:
+	case *ast.StarExpr:
 		tName := typeName(rn)
+		//spew.Printf("arg type: %v (vs. root type %v)\n", tName, v.tree.name())
 		if tName == v.tree.name() {
+			v.matchRoot = true
 			v.tree.confirm()
 			for _, name := range v.names {
 				obj := ast.NewObj(ast.Var, name)
@@ -128,6 +177,8 @@ func (v *argVisitor) Visit(n ast.Node) ast.Visitor {
 				v.scope.Insert(obj)
 			}
 		}
+	case ast.Expr:
+		spew.Printf("argV Expr: %#v\n", rn)
 	}
 	return nil
 }
@@ -139,11 +190,34 @@ func (v *bodyVisitor) Visit(n ast.Node) ast.Visitor {
 	case *ast.CommentGroup, *ast.BasicLit:
 	case nil:
 	case *ast.AssignStmt:
-		return &assignVisitor{stmt: rn, tree: v.tree, scope: v.scope}
+		return &assignVisitor{pkgs: v.pkgs, stmt: rn, tree: v.tree, scope: v.scope}
 	case *ast.IfStmt:
-		return &ifVisitor{tree: v.tree, scope: ast.NewScope(v.scope)}
+		return &ifVisitor{pkgs: v.pkgs, tree: v.tree, scope: ast.NewScope(v.scope)}
 	case *ast.ExprStmt:
-		return &exprVisitor{tree: v.tree, scope: v.scope}
+		return &exprVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
+	case *ast.DeclStmt:
+		return &bodyDeclVisitor{tree: v.tree, scope: v.scope}
+	case *ast.ReturnStmt:
+		return &exprVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
+	}
+	return nil
+}
+
+func (v *bodyDeclVisitor) Visit(n ast.Node) ast.Visitor {
+	switch rn := n.(type) {
+	default:
+		spew.Printf("unexpected type to bodyDeclV: %+#v\n", n)
+	case *ast.CommentGroup, *ast.BasicLit:
+	case nil:
+		spew.Println("end body")
+	case *ast.GenDecl:
+		switch rn.Tok {
+		default:
+			spew.Printf("unexpected Tok: %+#v\n", n)
+		case token.VAR:
+			//spew.Printf("Variable declaration.\n")
+		}
+
 	}
 	return nil
 }
@@ -155,16 +229,18 @@ func (v *exprVisitor) Visit(n ast.Node) ast.Visitor {
 	case *ast.CommentGroup, *ast.BasicLit:
 	case nil:
 	case *ast.UnaryExpr, *ast.BinaryExpr:
-		return &exprVisitor{tree: v.tree, scope: v.scope}
+		return &exprVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
 	case *ast.ExprStmt:
 		return v
 	case *ast.SelectorExpr:
 		return &selectorVisitor{tree: v.tree, scope: v.scope}
+	case *ast.CallExpr:
+		return &callVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
+	case *ast.Ident:
+		// in these contexts, not interesting
 	}
 	return nil
 }
-
-var dummyOn = &selectorVisitor{target: nil}
 
 func (v *selectorVisitor) Visit(n ast.Node) ast.Visitor {
 	if v.on == nil {
@@ -177,10 +253,10 @@ func (v *selectorVisitor) Visit(n ast.Node) ast.Visitor {
 		case *ast.Ident:
 			c := findVar(v.scope, rn.Name)
 			if c != nil {
-				v.on = &selectorVisitor{target: c}
+				v.on = &selectorVisitor{targetName: rn.Name, target: c}
 			} else {
-				spew.Printf("selector Couldn't find %q in scope.", rn.Name)
-				v.on = dummyOn
+				spew.Printf("selector Couldn't find %q in scope.\n", rn.Name)
+				v.on = &selectorVisitor{targetName: rn.Name, target: c}
 			}
 		case *ast.SelectorExpr:
 			sv := &selectorVisitor{scope: v.scope, tree: v.tree}
@@ -193,15 +269,17 @@ func (v *selectorVisitor) Visit(n ast.Node) ast.Visitor {
 	default:
 		spew.Printf("unexpected type to selectorV: %+#v\n", n)
 	case nil:
+		//spew.Printf("selector complete: %#v\n", v)
 	case *ast.Ident:
+		v.targetName = rn.Name
 		if stgt, ok := v.on.target.(confTreeNode); ok {
 			v.target = stgt.child(rn.Name)
-			spew.Printf("Found selector target: %#v\n", v.target)
+			//spew.Printf("Found selector target %q: %#v\n", rn.Name, v.target)
 			if v.target != nil {
 				v.target.confirm()
 			}
 		} else {
-			spew.Printf("selector v.on.target was not a confTreeNode: %#v", v.on.target)
+			spew.Printf("selector v.on.target was not a confTreeNode: %#v\n", v.on.target)
 		}
 	}
 	return nil
@@ -224,9 +302,9 @@ func (v *ifVisitor) Visit(n ast.Node) ast.Visitor {
 	case *ast.CommentGroup, *ast.BasicLit:
 	case nil:
 	case *ast.BlockStmt: //body
-		return &bodyVisitor{tree: v.tree, scope: v.scope}
+		return &bodyVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
 	case *ast.UnaryExpr, *ast.BinaryExpr:
-		return &exprVisitor{tree: v.tree, scope: v.scope}
+		return &exprVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
 	}
 	return nil
 }
@@ -236,27 +314,107 @@ func (v *assignVisitor) Visit(n ast.Node) ast.Visitor {
 	default:
 		if rn.Pos() < v.stmt.TokPos {
 			spew.Printf("LHS assignV: %+#v\n", n)
+			v.lhs = append(v.lhs, asgPath{})
 		} else {
 			spew.Printf("RHS assignV: %+#v\n", n)
+			v.rhs = append(v.rhs, rhsItem{sel: &selectorVisitor{}})
 		}
 	case *ast.CommentGroup, *ast.BasicLit:
 	case nil:
+		//spew.Printf("LHS: %+#v\n", v.lhs)
+		for n, r := range v.rhs {
+			if r.sel != nil {
+				obj := ast.NewObj(ast.Var, v.lhs[n].name)
+				obj.Decl = rn
+				obj.Data = r.sel.target
+				if obj.Data != nil {
+					r.sel.target.confirm()
+				}
+				v.scope.Insert(obj)
+			}
+		}
+	case *ast.FuncLit:
+		v.rhs = append(v.rhs, rhsItem{fun: rn})
+	case *ast.CallExpr:
+		return &callVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
+	case *ast.Ident:
+		if rn.Pos() < v.stmt.TokPos {
+			v.lhs = append(v.lhs, asgPath{name: rn.Name})
+		} else {
+			v.rhs = append(v.rhs, rhsItem{sel: &selectorVisitor{target: findVar(v.scope, rn.Name)}})
+		}
 	}
 	return nil
 }
 
-func ConfirmTree(cn confNode, pkgs packageMap, funcName string) bool {
+func (v *callVisitor) Visit(n ast.Node) ast.Visitor {
+	switch rn := n.(type) {
+	default:
+		spew.Printf("unexpected type to callV: %+#v\n", n)
+	case *ast.CommentGroup, *ast.BasicLit:
+	case nil:
+		if v.fun == nil {
+			spew.Printf("callV complete without understanding a Fun\n")
+		} else {
+			if v.fun.on != nil {
+				if v.fun.on.target != nil {
+					ConfirmTree(v.fun.on.target, v.pkgs, v.fun.targetName)
+				}
+
+				for _, a := range v.args {
+					if a.target != nil {
+						ConfirmTree(a.target, v.pkgs, v.fun.targetName)
+					}
+				}
+			}
+
+		}
+	case *ast.Ident:
+		if v.fun == nil {
+			spew.Printf("Call of %q\n", rn.Name)
+			v.fun = &selectorVisitor{target: findVar(v.scope, rn.Name)}
+		} else {
+			as := &selectorVisitor{target: findVar(v.scope, rn.Name)}
+			v.args = append(v.args, as)
+		}
+	case *ast.SelectorExpr:
+		if v.fun == nil {
+			spew.Printf("Call of %v\n", rn)
+			as := &selectorVisitor{tree: v.tree, scope: v.scope}
+			v.fun = as
+			return as
+		}
+		as := &selectorVisitor{tree: v.tree, scope: v.scope}
+		v.args = append(v.args, as)
+		return as
+	case *ast.CallExpr:
+		return &callVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
+	case *ast.UnaryExpr, *ast.BinaryExpr:
+		return &exprVisitor{pkgs: v.pkgs, tree: v.tree, scope: v.scope}
+	}
+
+	return nil
+}
+
+func ConfirmTree(cn confNode, pkgs packageMap, funcName string) []string {
+	spew.Printf("Confirming %q touches fields of %q\n", funcName, cn.name())
 	for _, pkg := range pkgs {
-		ff := &functionFinder{target: funcName, tree: cn, scope: ast.NewScope(nil)}
+		ff := &functionFinder{pkgs: pkgs, target: funcName, tree: cn, scope: ast.NewScope(nil)}
 		for _, file := range pkg.Files {
 			for _, decl := range file.Decls {
 				ast.Walk(ff, decl)
 			}
 		}
 		if cn.confirmed() {
-			return true
+			return []string{}
 		}
 	}
 
-	return cn.confirmed()
+	missed := []string{}
+	tName := cn.name()
+	for _, f := range cn.missed() {
+		missed = append(missed, tName+f)
+	}
+	return missed
+
 }

--- a/util/allfields/confirmtree.go
+++ b/util/allfields/confirmtree.go
@@ -142,15 +142,20 @@ func (rep missedReport) Exempt(forgiven []string) []string {
 	realBad := []string{}
 	for _, miss := range rep {
 		keep := true
-		for _, forgive := range forgiven {
+		for n, forgive := range forgiven {
 			if miss == forgive {
 				keep = false
+				forgiven[n] = forgiven[len(forgiven)-1]
+				forgiven = forgiven[:len(forgiven)-1]
 				break
 			}
 		}
 		if keep {
 			realBad = append(realBad, miss)
 		}
+	}
+	if len(forgiven) > 0 {
+		panic(fmt.Errorf("extra strings passed to Exempt: %v", forgiven))
 	}
 	return realBad
 }

--- a/util/allfields/conftree.go
+++ b/util/allfields/conftree.go
@@ -1,0 +1,81 @@
+package allfields
+
+type (
+	confNode interface {
+		name() string
+		confirm()
+		selfConfirmed() bool
+		confirmed() bool
+	}
+
+	structNode struct {
+		*confirmation
+		kids  map[string]confNode
+		needs []fieldNeed
+	}
+
+	confirmation struct {
+		isConfirmed bool
+		typeName    string
+	}
+
+	confTreeNode interface {
+		confNode
+		child(named string) confNode
+		children() []confNode
+	}
+)
+
+func (c *confirmation) name() string {
+	return c.typeName
+}
+
+func (c *confirmation) confirm() {
+	c.isConfirmed = true
+}
+
+func (c *confirmation) confirmed() bool {
+	return c.isConfirmed
+}
+
+func (c *confirmation) selfConfirmed() bool {
+	return c.isConfirmed
+}
+
+func newStructNode(name string) *structNode {
+	return &structNode{
+		kids: map[string]confNode{},
+		confirmation: &confirmation{
+			typeName: name,
+		},
+		needs: []fieldNeed{},
+	}
+}
+
+func (sn *structNode) children() []confNode {
+	ns := []confNode{}
+	for _, k := range sn.kids {
+		ns = append(ns, k)
+	}
+	return ns
+}
+
+func (sn *structNode) child(named string) confNode {
+	return sn.kids[named]
+}
+
+func (sn *structNode) selfConfirmed() bool {
+	return sn.confirmation.confirmed()
+}
+
+func (sn *structNode) confirmed() bool {
+	if !sn.selfConfirmed() {
+		return false
+	}
+	for _, c := range sn.children() {
+		if !c.confirmed() {
+			return false
+		}
+	}
+	return true
+}

--- a/util/allfields/conftree.go
+++ b/util/allfields/conftree.go
@@ -3,6 +3,7 @@ package allfields
 type (
 	confNode interface {
 		name() string
+		clone() confNode
 		confirm()
 		selfConfirmed() bool
 		confirmed() bool
@@ -11,8 +12,7 @@ type (
 
 	structNode struct {
 		*confirmation
-		kids  map[string]confNode
-		needs []fieldNeed
+		kids map[string]confNode
 	}
 
 	confirmation struct {
@@ -29,6 +29,10 @@ type (
 
 func (c *confirmation) name() string {
 	return c.typeName
+}
+
+func (c *confirmation) clone() confNode {
+	return &confirmation{typeName: c.typeName}
 }
 
 func (c *confirmation) confirm() {
@@ -50,14 +54,24 @@ func (c *confirmation) missed() []string {
 	return []string{""}
 }
 
+func newConfirmation(name string) *confirmation {
+	return &confirmation{typeName: name}
+}
+
 func newStructNode(name string) *structNode {
 	return &structNode{
-		kids: map[string]confNode{},
-		confirmation: &confirmation{
-			typeName: name,
-		},
-		needs: []fieldNeed{},
+		kids:         map[string]confNode{},
+		confirmation: newConfirmation(name),
 	}
+}
+
+func (sn *structNode) clone() confNode {
+	o := newStructNode(sn.name())
+	for n, v := range sn.kids {
+		o.kids[n] = v.clone()
+	}
+
+	return o
 }
 
 func (sn *structNode) children() []confNode {

--- a/util/allfields/conftree.go
+++ b/util/allfields/conftree.go
@@ -6,6 +6,7 @@ type (
 		confirm()
 		selfConfirmed() bool
 		confirmed() bool
+		missed() []string
 	}
 
 	structNode struct {
@@ -42,6 +43,13 @@ func (c *confirmation) selfConfirmed() bool {
 	return c.isConfirmed
 }
 
+func (c *confirmation) missed() []string {
+	if c.selfConfirmed() {
+		return []string{}
+	}
+	return []string{""}
+}
+
 func newStructNode(name string) *structNode {
 	return &structNode{
 		kids: map[string]confNode{},
@@ -66,6 +74,19 @@ func (sn *structNode) child(named string) confNode {
 
 func (sn *structNode) selfConfirmed() bool {
 	return sn.confirmation.confirmed()
+}
+
+func (sn *structNode) missed() []string {
+	missed := []string{}
+	if !sn.selfConfirmed() {
+		missed = append(missed, "")
+	}
+	for n, c := range sn.kids {
+		for _, cm := range c.missed() {
+			missed = append(missed, "."+n+cm)
+		}
+	}
+	return missed
 }
 
 func (sn *structNode) confirmed() bool {

--- a/util/allfields/tester/main.go
+++ b/util/allfields/tester/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/davecgh/go-spew/spew"
+	"github.com/opentable/sous/util/allfields"
+)
+
+func main() {
+	ast := allfields.ParseDir("lib/")
+	tree := allfields.ExtractTree(ast, "Deployment")
+	spew.Dump(tree)
+	spew.Dump(allfields.ConfirmTree(tree, ast, "Diff"))
+	spew.Dump(tree)
+}

--- a/util/allfields/tester/main.go
+++ b/util/allfields/tester/main.go
@@ -8,6 +8,5 @@ import (
 func main() {
 	ast := allfields.ParseDir("lib/")
 	tree := allfields.ExtractTree(ast, "Deployment")
-	spew.Dump(tree)
 	spew.Dump(allfields.ConfirmTree(tree, ast, "Diff"))
 }

--- a/util/allfields/tester/main.go
+++ b/util/allfields/tester/main.go
@@ -10,5 +10,4 @@ func main() {
 	tree := allfields.ExtractTree(ast, "Deployment")
 	spew.Dump(tree)
 	spew.Dump(allfields.ConfirmTree(tree, ast, "Diff"))
-	spew.Dump(tree)
 }


### PR DESCRIPTION
Adds: static analysis of Go code,
to extract a "confirmation tree" based on a struct and its struct members,
and then walking the AST of a method definition to check that
all the members are "touched" by the function.

A couple of shortcomings of the analysis:
loops in struct definitions
(trivial example: a linked list)
will never complete.
Function return values aren't considered,
so using a function to extract a sub-struct
and then operating on the result
won't be detected.
It may be that
functions that use confirmation tree nodes
as arguments (as opposed to as the method receiver)
won't be considered.
(To be clear, methods of the confirmation nodes are checked.)
Finally,
non-struct composites
(maps and slices)
are considered "leaves"
of the confirmation tree -
we don't confirm that
e.g. members of structs that are elements of a slice
are themselves checked.

This shortcomings aren't actually
surfaced by our Diff methods,
so I didn't pursue fixing them.

The static analysis has only been applied,
so far,
to Deployment.Diff().
Other valid and useful targets would be
Manifest.Diff() and
the associated Clone() methods.