### PR TITLE
GitStateManager now returns an error if any push would include more than one file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ with respect to its command line interface and HTTP interface.
   `install-brew`. These allow developers on a Mac to quickly switch between having
   a personal dev build, or the latest release from homebrew installed locally.
 
-### Changed
+### Fixed
 - Operations that change more than one manifest will now be rejected with an
   error. We do not believe there are any such legitimate operations, and
   there's a storage anomoly that surfaces as multiple manifests changing at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ with respect to its command line interface and HTTP interface.
   `install-brew`. These allow developers on a Mac to quickly switch between having
   a personal dev build, or the latest release from homebrew installed locally.
 
+### Changed
+- Operations that change more than one manifest will now be rejected with an
+  error. We do not believe there are any such legitimate operations, and
+  there's a storage anomoly that surfaces as multiple manifests changing at
+  once which we hope this will correct.
+
 ## [0.5.12](//github.com/opentable/sous/compare/0.5.11...0.5.12)
 ### Fixed
 - Issue where deployments constantly re-deployed due to spurious Startup.Timeout diff.

--- a/ext/storage/git_state_manager.go
+++ b/ext/storage/git_state_manager.go
@@ -32,8 +32,13 @@ func NewGitStateManager(dsm *DiskStateManager) *GitStateManager {
 }
 
 func (gsm *GitStateManager) git(cmd ...string) error {
+	_, err := gsm.gitOut(cmd...)
+	return err
+}
+
+func (gsm *GitStateManager) gitOut(cmd ...string) (string, error) {
 	if !gsm.isRepo() {
-		return nil
+		return "", fmt.Errorf("not in a git repo")
 	}
 	git := exec.Command(`git`, cmd...)
 	git.Dir = gsm.DiskStateManager.BaseDir
@@ -56,7 +61,7 @@ func (gsm *GitStateManager) git(cmd ...string) error {
 		sous.Log.Debug.Printf("%+v: error: %v", git.Args, err)
 	}
 	sous.Log.Vomit.Print("git: " + string(out))
-	return errors.Wrapf(err, strings.Join(git.Args, " ")+": "+string(out))
+	return string(out), errors.Wrapf(err, strings.Join(git.Args, " ")+": "+string(out))
 }
 
 func (gsm *GitStateManager) reset(tn string) {


### PR DESCRIPTION
Test changes were surprising in the extent. Turns out that the old tests didn't
seem to actually be testing the git part of things.