### PR TITLE
singularity: Add stack trace to recovered errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.14...HEAD)
+
+### Changed
+- Panics during rectify print the stack trace along with the error message in the logs.
+  Previously the stack trace was printed earlier in the log, making correlation
+  difficult.
+
 ## [0.5.14](//github.com/opentable/sous/compare/0.5.13...0.5.14)
 
 ### Fixed

--- a/ext/singularity/actual_deployment_set.go
+++ b/ext/singularity/actual_deployment_set.go
@@ -160,17 +160,15 @@ func dontrecover() error {
 func catchAndSend(from string, errs chan error) {
 	defer catchAll(from)
 	if err := recover(); err != nil {
-		stack := string(debug.Stack())
 		Log.Debug.Printf("from = %s err = %+v\n", from, err)
-		Log.Debug.Printf("debug.Stack() = %+v\n", stack)
+		Log.Debug.Printf("debug.Stack() = %+v\n", string(debug.Stack()))
 		switch err := err.(type) {
 		default:
 			if err != nil {
-				errs <- fmt.Errorf("%s: Panicked with not-error: %v\n%s",
-					from, err, stack)
+				errs <- fmt.Errorf("%s: Panicked with not-error: %v", from, err)
 			}
 		case error:
-			errs <- errors.Wrapf(err, from+" stack trace below:\n%s", stack)
+			errs <- errors.Wrapf(err, from)
 		}
 	}
 }

--- a/ext/singularity/actual_deployment_set.go
+++ b/ext/singularity/actual_deployment_set.go
@@ -160,15 +160,17 @@ func dontrecover() error {
 func catchAndSend(from string, errs chan error) {
 	defer catchAll(from)
 	if err := recover(); err != nil {
+		stack := string(debug.Stack())
 		Log.Debug.Printf("from = %s err = %+v\n", from, err)
-		Log.Debug.Printf("debug.Stack() = %+v\n", string(debug.Stack()))
+		Log.Debug.Printf("debug.Stack() = %+v\n", stack)
 		switch err := err.(type) {
 		default:
 			if err != nil {
-				errs <- fmt.Errorf("%s: Panicked with not-error: %v", from, err)
+				errs <- fmt.Errorf("%s: Panicked with not-error: %v\n%s",
+					from, err, stack)
 			}
 		case error:
-			errs <- errors.Wrapf(err, from)
+			errs <- errors.Wrapf(err, from+" stack trace below:\n%s", stack)
 		}
 	}
 }

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -109,10 +109,11 @@ func (r *deployer) buildSingClient(url string) *singularity.Client {
 
 func rectifyRecover(d interface{}, f string, err *error) {
 	if r := recover(); r != nil {
+		stack := string(debug.Stack())
 		sous.Log.Warn.Printf("Panic in %s with %# v", f, d)
 		sous.Log.Warn.Printf("  %v", r)
-		sous.Log.Warn.Print(string(debug.Stack()))
-		*err = errors.Errorf("Panicked")
+		sous.Log.Warn.Print(stack)
+		*err = errors.Errorf("Panicked: %s; stack trace:\n%s", r, stack)
 	}
 }
 

--- a/ext/singularity/deployer_test.go
+++ b/ext/singularity/deployer_test.go
@@ -153,17 +153,17 @@ func TestMakeRequestID_Collisions(t *testing.T) {
 
 func TestRectifyRecover(t *testing.T) {
 	var err error
-	expected := "Panicked"
+	expectedPrefix := "Panicked: What's that coming over the hill?!; stack trace:\n"
 	func() {
 		defer rectifyRecover("something", "TestRectifyRecover", &err)
 		panic("What's that coming over the hill?!")
 	}()
 	if err == nil {
-		t.Fatalf("got nil, want error %q", expected)
+		t.Fatalf("got nil, want error beginning %q", expectedPrefix)
 	}
 	actual := err.Error()
-	if actual != expected {
-		t.Errorf("got error %q; want %q", actual, expected)
+	if !strings.HasPrefix(actual, expectedPrefix) {
+		t.Errorf("got error %q; want error with prefix %q", actual, expectedPrefix)
 	}
 }
 

--- a/ext/singularity/deployment_builder.go
+++ b/ext/singularity/deployment_builder.go
@@ -318,7 +318,7 @@ func (db *deploymentBuilder) retrieveImageLabels() error {
 	if err != nil {
 		return malformedResponse{err.Error()}
 	}
-	Log.Vomit.Print("%q Labels: ", db.reqID, labels)
+	Log.Vomit.Printf("%q Labels: %v", db.reqID, labels)
 
 	db.Target.SourceID, err = docker.SourceIDFromLabels(labels)
 	if err != nil {

--- a/ext/singularity/deployment_builder.go
+++ b/ext/singularity/deployment_builder.go
@@ -133,18 +133,14 @@ func (db *deploymentBuilder) completeConstruction() error {
 	)
 }
 
-func reqID(rp *dtos.SingularityRequestParent) (ID string) {
-	defer func() {
-		if e := recover(); e != nil {
-			return
-		}
-	}()
-	ID = "<null RP>"
-	if rp != nil {
-		ID = "<null Request>"
+func reqID(rp *dtos.SingularityRequestParent) string {
+	if rp == nil {
+		return "<null RequestParent>"
 	}
-	ID = rp.Request.Id
-	return
+	if rp.Request == nil {
+		return "<null Request>"
+	}
+	return rp.Request.Id
 }
 
 func (db *deploymentBuilder) basics() error {

--- a/ext/singularity/deployment_builder.go
+++ b/ext/singularity/deployment_builder.go
@@ -133,7 +133,16 @@ func (db *deploymentBuilder) completeConstruction() error {
 	)
 }
 
-func reqID(rp *dtos.SingularityRequestParent) string {
+func reqID(rp *dtos.SingularityRequestParent) (id string) {
+	// defer func() { recover() }() because we explicitly do not care if this
+	// panics. It is only used in certain low-level logs, and we don't mind
+	// if we get some garbage data there. There is a fear that some race
+	// condition between asserting that rp and rp.Request are not nil and
+	// accessing their members may cause panics here. Please do not remove
+	// this line before asserting somehow that this race condition does not
+	// exist.
+	defer func() { recover() }()
+	id = "singularity.reqID() panicked"
 	if rp == nil {
 		return "<null RequestParent>"
 	}


### PR DESCRIPTION
- Also remove an odd looking recover() from reading
  SingularityRequestParent. Also remove named output
  that was stuttering, and simplify flow.

Previously the stack trace was being printed, but not near where the error was handled. Hopefully printing it where we handle the error will make the logs easier to read.