### PR TITLE
fix: Semver tag with prefix validation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.14...HEAD)
+### Fixed
+- Client: 'sous build' was failing when using a semver tag with a non-numeric prefix.
+  Validation logic is now shared, so 'sous build' succeeds with these tags.
+ 
 ## [0.5.14](//github.com/opentable/sous/compare/0.5.13...0.5.14)
 
 ### Fixed

--- a/lib/build_config.go
+++ b/lib/build_config.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-
-	"github.com/samsalisbury/semv"
 )
 
 type (
@@ -131,8 +129,8 @@ func (c *BuildConfig) Resolve() {
 
 // Validate checks that the Config is well formed
 func (c *BuildConfig) Validate() error {
-	if _, ve := semv.Parse(c.Tag); ve != nil {
-		return fmt.Errorf("semver git tag required.  invalid tag: %q", c.Tag)
+	if _, ve := parseSemverTagWithOptionalPrefix(c.Tag); ve != nil {
+		return fmt.Errorf("semver git tag required: invalid tag: %q", c.Tag)
 	}
 	return nil
 }

--- a/lib/source_context.go
+++ b/lib/source_context.go
@@ -105,10 +105,13 @@ func (sc *SourceContext) TagVersion() string {
 
 var versionStrip = regexp.MustCompile(`^\D*`)
 
+func parseSemverTagWithOptionalPrefix(tagName string) (semv.Version, error) {
+	return semv.Parse(versionStrip.ReplaceAllString(tagName, ""))
+}
+
 func nearestVersion(tags []Tag) semv.Version {
 	for _, t := range tags {
-
-		v, err := semv.Parse(versionStrip.ReplaceAllString(t.Name, ""))
+		v, err := parseSemverTagWithOptionalPrefix(t.Name)
 		if err == nil {
 			return v
 		}


### PR DESCRIPTION
Addresses an issue where 'sous build' fails when tag has a non-numeric prefix. Related to #413 