### PR TITLE
Implements locking Git state via Etags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
 ## [Unreleased](//github.com/opentable/sous/compare/0.5.16...HEAD)
+
 ### Changed
+- Etags on /gdm are generated using the current head revision of the GDM git
+  repo. Updates are checked against this revision, which should mean we have a
+  closed loop against conflicting updates.
 - Makefile directives to build a Sous .deb and upload it to an Artifactory server.
 
 ### Fixed
 - Increased buffer size in shell to handle super-long tokens.
+
 
 ## [0.5.16](//github.com/opentable/sous/compare/0.5.15...0.5.16)
 - Fixed prefixed versions for update and deploy. At this point, git "package" tags should work everywhere they're used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,15 @@ with respect to its command line interface and HTTP interface.
 ## [Unreleased](//github.com/opentable/sous/compare/0.5.16...HEAD)
 
 ### Changed
-- Etags on /gdm are generated using the current head revision of the GDM git
-  repo. Updates are checked against this revision, which should mean we have a
-  closed loop against conflicting updates.
-- Makefile directives to build a Sous .deb and upload it to an Artifactory server.
+- Developer: Makefile directives to build a Sous .deb and upload it to an Artifactory server.
+- Server: /gdm now sets Etag header based on current revision of the GDM. Clients attempting
+  to update with a stale Etag will have update rejected appropriately.
 
 ### Fixed
-- Increased buffer size in shell to handle super-long tokens.
-
+- Client: Increased buffer size in shell to handle super-long tokens.
+- Client: Conflicting updates to the same manifest now fail appropriately (e.g. during 'sous deploy').
+  This should mean better performance when running 'sous deploy' concurrently on the same manifest,
+  as conflicting updates won't require multiple passes to resolve.
 
 ## [0.5.16](//github.com/opentable/sous/compare/0.5.15...0.5.16)
 - Fixed prefixed versions for update and deploy. At this point, git "package" tags should work everywhere they're used.

--- a/ext/storage/git_state_manager_test.go
+++ b/ext/storage/git_state_manager_test.go
@@ -126,7 +126,9 @@ func TestGitStateManager_WriteState_multiple_manifests(t *testing.T) {
 func TestGitReadState(t *testing.T) {
 	require := require.New(t)
 
-	gsm := NewGitStateManager(NewDiskStateManager("testdata/in"))
+	s := exampleState()
+	gitPrepare(t, s, "testdata/remote", "testdata/out")
+	gsm := NewGitStateManager(NewDiskStateManager("testdata/out"))
 
 	actual, err := gsm.ReadState()
 	require.NoError(err)

--- a/ext/storage/git_state_manager_test.go
+++ b/ext/storage/git_state_manager_test.go
@@ -160,7 +160,7 @@ func TestStateEtags(t *testing.T) {
 	s, err := gsm.ReadState()
 
 	if err != nil {
-		t.Errorf("Unexpected error when reading state")
+		t.Errorf("Unexpected error when reading state: %v", err)
 	}
 	if s.CheckEtag("cannot match this") == nil {
 		t.Errorf("No error for busted etag")

--- a/ext/storage/preparetestgitrepo.go
+++ b/ext/storage/preparetestgitrepo.go
@@ -12,6 +12,7 @@ import (
 
 var testUser = sous.User{Name: "Test User", Email: "test@user.com"}
 
+// PrepareTestGitRepo prepares a git repo for test purposes.
 func PrepareTestGitRepo(t *testing.T, s *sous.State, remotepath, outpath string) {
 
 	clobberDir(t, remotepath)

--- a/ext/storage/preparetestgitrepo.go
+++ b/ext/storage/preparetestgitrepo.go
@@ -1,0 +1,56 @@
+package storage
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sous "github.com/opentable/sous/lib"
+)
+
+var testUser = sous.User{Name: "Test User", Email: "test@user.com"}
+
+func PrepareTestGitRepo(t *testing.T, s *sous.State, remotepath, outpath string) {
+
+	clobberDir(t, remotepath)
+	clobberDir(t, outpath)
+
+	runCmd(t, remotepath, "git", "init", "--template=/dev/null", "--bare")
+
+	remoteAbs, err := filepath.Abs(remotepath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runCmd(t, outpath, "git", "init", "--template=/dev/null")
+	runCmd(t, outpath, "git", "config", "user.email", "sous-test@testing.example.com")
+	runCmd(t, outpath, "git", "config", "user.name", "sous-test@testing.example.com")
+	runCmd(t, outpath, "git", "remote", "add", "origin", "file://"+remoteAbs)
+
+	dsm := NewDiskStateManager(outpath)
+	dsm.WriteState(s, testUser)
+
+	runCmd(t, outpath, "git", "add", ".")
+	runCmd(t, outpath, "git", "commit", "--no-gpg-sign", "-a", "-m", "birthday")
+	runCmd(t, outpath, "git", "push", "-u", "origin", "master")
+}
+
+func clobberDir(t *testing.T, path string) {
+	if err := os.RemoveAll(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runCmd(t *testing.T, path string, cmd ...string) {
+	gitCmd := exec.Command(cmd[0], cmd[1:]...)
+	gitCmd.Dir = path
+	out, err := gitCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%q errored: %v\n %s", strings.Join(cmd, " "), err, out)
+	}
+}

--- a/graph/testsupport.go
+++ b/graph/testsupport.go
@@ -29,6 +29,7 @@ func TestGraphWithConfig(in io.Reader, out, err io.Writer, cfg string) *SousGrap
 	graph := buildBaseGraph(in, out, err)
 	addTestFilesystem(graph)
 	addTestNetwork(graph)
+	sous.Log.Vomitf("Adding confing:\n%s", cfg)
 	graph.Add(configYAML(cfg))
 	graph.Add(sous.User{Name: "Test User", Email: "testuser@example.com"})
 	return graph

--- a/lib/state.go
+++ b/lib/state.go
@@ -110,8 +110,16 @@ func (s State) CheckEtag(etag string) error {
 }
 
 // SetEtag sets an etag on the state.
-func (s State) SetEtag(etag string) {
+func (s *State) SetEtag(etag string) {
 	s.etag = &etag
+}
+
+// GetEtag gets the etag, or returns an error if no etag set.
+func (s State) GetEtag() (string, error) {
+	if s.etag != nil {
+		return *s.etag, nil
+	}
+	return "", errors.Errorf("no etag set on state")
 }
 
 // Clone returns a deep copy of this State.

--- a/lib/state.go
+++ b/lib/state.go
@@ -15,6 +15,7 @@ type (
 		// Manifests contains a mapping of source code repositories to global
 		// deployment configurations for artifacts built using that source code.
 		Manifests Manifests `hy:"manifests/"`
+		etag      *string
 	}
 
 	// Defs holds definitions for organisation-level objects.
@@ -93,6 +94,24 @@ func NewState() *State {
 	return &State{
 		Manifests: NewManifests(),
 	}
+}
+
+// etag is a private field to ensure that we don't interfere with YAML storage,
+// hence the getter/setter
+
+// Etag returns an etag (if one is present) on the State.
+func (s State) CheckEtag(etag string) error {
+	if s.etag != nil {
+		if etag != *(s.etag) {
+			return errors.Errorf("etag doesn't match on state: checking %q against %q", etag, *s.etag)
+		}
+	}
+	return nil
+}
+
+// SetEtag sets an etag on the state.
+func (s State) SetEtag(etag string) {
+	s.etag = &etag
 }
 
 // Clone returns a deep copy of this State.

--- a/lib/state.go
+++ b/lib/state.go
@@ -99,7 +99,7 @@ func NewState() *State {
 // etag is a private field to ensure that we don't interfere with YAML storage,
 // hence the getter/setter
 
-// Etag returns an etag (if one is present) on the State.
+// CheckEtag checks that the etag matches the etag on the state (if present).
 func (s State) CheckEtag(etag string) error {
 	if s.etag != nil {
 		if etag != *(s.etag) {

--- a/lib/state.go
+++ b/lib/state.go
@@ -15,7 +15,9 @@ type (
 		// Manifests contains a mapping of source code repositories to global
 		// deployment configurations for artifacts built using that source code.
 		Manifests Manifests `hy:"manifests/"`
-		etag      *string
+		// etag is not exported to ensure that we don't interfere with YAML
+		// storage, hence the getter/setter.
+		etag *string
 	}
 
 	// Defs holds definitions for organisation-level objects.
@@ -95,9 +97,6 @@ func NewState() *State {
 		Manifests: NewManifests(),
 	}
 }
-
-// etag is a private field to ensure that we don't interfere with YAML storage,
-// hence the getter/setter
 
 // CheckEtag checks that the etag matches the etag on the state (if present).
 func (s State) CheckEtag(etag string) error {

--- a/server/graph.go
+++ b/server/graph.go
@@ -29,6 +29,7 @@ func liveGDM(sr graph.StateReader) (*LiveGDM, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Ignore this error because an empty string etag is acceptable.
 	etag, _ := state.GetEtag()
 	return &LiveGDM{Etag: etag, Deployments: gdm.Deployments}, nil
 }

--- a/server/graph.go
+++ b/server/graph.go
@@ -9,6 +9,7 @@ import (
 type (
 	// A LiveGDM wraps a sous.Deployments and gets refreshed per server request
 	LiveGDM struct {
+		Etag string
 		sous.Deployments
 	}
 )
@@ -28,5 +29,6 @@ func liveGDM(sr graph.StateReader) (*LiveGDM, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &LiveGDM{gdm.Deployments}, nil
+	etag, _ := state.GetEtag()
+	return &LiveGDM{Etag: etag, Deployments: gdm.Deployments}, nil
 }

--- a/server/handle_gdm.go
+++ b/server/handle_gdm.go
@@ -17,7 +17,8 @@ type (
 	// GETGDMHandler is an injectable request handler
 	GETGDMHandler struct {
 		*sous.LogSet
-		GDM *LiveGDM
+		GDM      *LiveGDM
+		RzWriter *restful.ResponseWriter
 	}
 
 	// PUTGDMHandler is an injectable request handler
@@ -51,6 +52,7 @@ func (h *GETGDMHandler) Exchange() (interface{}, int) {
 		}
 		data.Deployments = append(data.Deployments, d)
 	}
+	h.RzWriter.Header().Set("Etag", h.GDM.Etag)
 
 	return data, http.StatusOK
 }

--- a/server/handle_gdm.go
+++ b/server/handle_gdm.go
@@ -87,6 +87,10 @@ func (h *PUTGDMHandler) Exchange() (interface{}, int) {
 		return "Invalid GDM", http.StatusBadRequest
 	}
 
+	if _, got := h.Header["Etag"]; got {
+		state.SetEtag(h.Header.Get("Etag"))
+	}
+
 	if err := h.StateManager.WriteState(state, sous.User(h.User)); err != nil {
 		h.Warn.Printf("%#v", err)
 		return "Error committing state", http.StatusInternalServerError

--- a/server/handle_gdm_test.go
+++ b/server/handle_gdm_test.go
@@ -1,21 +1,30 @@
 package server
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/restful"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestHandlesGDMGet(t *testing.T) {
 	assert := assert.New(t)
 
+	w := httptest.NewRecorder()
+	etag := "swordfish"
+
 	th := &GETGDMHandler{
-		LogSet: &sous.Log,
+		RzWriter: &restful.ResponseWriter{w},
+		LogSet:   &sous.Log,
 		GDM: &LiveGDM{
+			Etag:        etag,
 			Deployments: sous.NewDeployments(),
 		}}
+
 	data, status := th.Exchange()
+	assert.Equal(w.Header().Get("Etag"), etag)
 	assert.Equal(status, 200)
 	assert.Len(data.(gdmWrapper).Deployments, 0)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/opentable/sous/config"
 	"github.com/opentable/sous/ext/storage"
 	"github.com/opentable/sous/graph"
-	sous "github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/restful"
 	"github.com/stretchr/testify/suite"
 )

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -76,6 +76,8 @@ func (suite serverTests) TearDownTest() {
 }
 
 func (suite serverTests) TestOverallRouter() {
+	sous.Log.BeChatty()
+	defer sous.Log.BeQuiet()
 	res, err := http.Get(suite.url + "/gdm")
 	suite.NoError(err)
 	gdm, err := ioutil.ReadAll(res.Body)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -11,7 +11,9 @@ import (
 	"testing"
 
 	"github.com/opentable/sous/config"
+	"github.com/opentable/sous/ext/storage"
 	"github.com/opentable/sous/graph"
+	sous "github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/restful"
 	"github.com/stretchr/testify/suite"
 )
@@ -30,18 +32,35 @@ type profServerSuite struct {
 	serverTests
 }
 
-func (suite *serverSuite) SetupTest() {
+func (suite serverTests) prepare() *graph.SousGraph {
+	sourcepath, remotepath, outpath :=
+		"../ext/storage/testdata/in",
+		"../ext/storage/testdata/remote",
+		"../ext/storage/testdata/out"
+
+	dsm := storage.NewDiskStateManager(sourcepath)
+	s, err := dsm.ReadState()
+	suite.Require().NoError(err)
+
+	storage.PrepareTestGitRepo(suite.T(), s, remotepath, outpath)
+
 	g := graph.TestGraphWithConfig(&bytes.Buffer{}, os.Stdout, os.Stdout,
-		"StateLocation: '../ext/storage/testdata/in'\n")
+		"StateLocation: '"+outpath+"'\n")
 	g.Add(&config.Verbosity{})
-	suite.serverTests.server = httptest.NewServer(Handler(g, restful.PlaceholderLogger()))
+	return g
+}
+
+func (suite *serverSuite) SetupTest() {
+	g := suite.prepare()
+
+	logger := restful.PlaceholderLogger()
+	logger = sous.Log
+	suite.serverTests.server = httptest.NewServer(Handler(g, logger))
 	suite.serverTests.url = suite.server.URL
 }
 
 func (suite *profServerSuite) SetupTest() {
-	g := graph.TestGraphWithConfig(&bytes.Buffer{}, os.Stdout, os.Stdout,
-		"StateLocation: '../ext/storage/testdata/in'\n")
-	g.Add(&config.Verbosity{})
+	g := suite.prepare()
 	suite.serverTests.server = httptest.NewServer(profilingHandler(g, restful.PlaceholderLogger())) // <--- profiling
 	suite.serverTests.url = suite.server.URL
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -54,7 +54,6 @@ func (suite *serverSuite) SetupTest() {
 	g := suite.prepare()
 
 	logger := restful.PlaceholderLogger()
-	logger = sous.Log
 	suite.serverTests.server = httptest.NewServer(Handler(g, logger))
 	suite.serverTests.url = suite.server.URL
 }
@@ -76,8 +75,6 @@ func (suite serverTests) TearDownTest() {
 }
 
 func (suite serverTests) TestOverallRouter() {
-	sous.Log.BeChatty()
-	defer sous.Log.BeQuiet()
 	res, err := http.Get(suite.url + "/gdm")
 	suite.NoError(err)
 	gdm, err := ioutil.ReadAll(res.Body)

--- a/test/http_state_manager_test.go
+++ b/test/http_state_manager_test.go
@@ -43,6 +43,7 @@ func TestWriteState(t *testing.T) {
 	newManifest := buildManifest("test-cluster", "github.com/opentable/new", "0.0.1")
 
 	state := &sous.State{}
+	state.SetEtag("qwertybeatsdvorak")
 	state.Defs.Clusters = make(sous.Clusters)
 	state.Defs.Clusters["test-cluster"] = &sous.Cluster{Name: "test-cluster"}
 


### PR DESCRIPTION
The state gets an etag from the GitStateManager
(the revision of the current head).

The restul.Server will reject PUTs unless they
If-Match the current git-rev Etag.

The Etag gets set on the written state,
which the GSM checks against the head revision.

The upshot should be that it is impossible now to make an update
to the GDM unless
you are basing that update on the current revision.