### PR TITLE
Adding 'plumbing normalizegdm'

### DIFF
--- a/cli/sous_plumbing_normalizegdm.go
+++ b/cli/sous_plumbing_normalizegdm.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"github.com/opentable/sous/ext/storage"
+	"github.com/opentable/sous/graph"
+	"github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/cmdr"
+)
+
+// SousPlumbingNormalizeGDM is the description of the `sous plumbing normalizegdm` command
+type SousPlumbingNormalizeGDM struct {
+	graph.LocalSousConfig
+}
+
+func init() { PlumbingSubcommands["normalizegdm"] = &SousPlumbingNormalizeGDM{} }
+
+// RegisterOn registers services on Addable
+func (*SousPlumbingNormalizeGDM) RegisterOn(psy Addable) {
+	psy.Add(graph.DryrunNeither)
+}
+
+// Help prints the help
+func (*SousPlumbingNormalizeGDM) Help() string {
+	return `Normalizes the storage format of GDM.
+
+Loads and saves the GDM, such that it's storage format will be normalized.
+This is needed sometimes after manually editing the GDM, so that spurious
+formatting changes won't be considered real, conflicting updates.
+`
+}
+
+// Execute defines the behavior of `sous plumbing normalizegdm`
+func (sqa *SousPlumbingNormalizeGDM) Execute(args []string) cmdr.Result {
+	dsm := storage.NewDiskStateManager(sqa.LocalSousConfig.StateLocation)
+
+	state, err := dsm.ReadState()
+	if err != nil {
+		return EnsureErrorResult(err)
+	}
+	if err := dsm.WriteState(state, sous.User{}); err != nil {
+		return EnsureErrorResult(err)
+	}
+	return cmdr.Success("Normalized.")
+}


### PR DESCRIPTION
This just reads the SOUS_STATE_LOCATION into memory and then writes it back.

Because storing is a stable operation, but the format is flexible enough to
represent the same configuration many ways, it's easy to produce an intended
configuration in a way that will be stored in a different textual form. The
result is that spurious differences cause a conflict in the GitStateManager and
prevent deploys.

It's possible that running `sous plumbing normalizegdm` after any manual
changes to the Git backed GDM will alleviate this problem entirely.