### PR TITLE
Adding a -flavor flag so that existing functionality will work.

### DIFF
--- a/cli/deploy_filter_flags.go
+++ b/cli/deploy_filter_flags.go
@@ -38,7 +38,7 @@ var (
 	// ClusterFilterFlagsHelp just exposes the -cluster flag (for server)
 	ClusterFilterFlagsHelp = clusterFlagHelp
 	// ManifestFilterFlagsHelp the text/config for selecting manifests
-	ManifestFilterFlagsHelp = sourceFlagHelp + repoFlagHelp + offsetFlagHelp
+	ManifestFilterFlagsHelp = sourceFlagHelp + repoFlagHelp + offsetFlagHelp + flavorFlagHelp
 	// MetadataFilterFlagsHelp the the text/config for metadata commands
 	MetadataFilterFlagsHelp = sourceFlagHelp + repoFlagHelp + offsetFlagHelp + flavorFlagHelp + clusterFlagHelp
 	// SourceFlagsHelp is the text (and config) for source flags

--- a/cli/sous_manifest_test.go
+++ b/cli/sous_manifest_test.go
@@ -27,7 +27,7 @@ func TestManifestGetArgs(t *testing.T) {
 }
 
 func TestManifestSetArgs(t *testing.T) {
-	fs := flag.NewFlagSet("test-for-manifest-get", flag.ContinueOnError)
+	fs := flag.NewFlagSet("test-for-manifest-set", flag.ContinueOnError)
 	smg := &SousManifestSet{}
 	smg.AddFlags(fs)
 	fs.Parse([]string{"-repo", "github.com/example/test", "-flavor", "winning"})

--- a/cli/sous_manifest_test.go
+++ b/cli/sous_manifest_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"flag"
 	"os"
 	"testing"
 
@@ -15,6 +16,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestManifestGetArgs(t *testing.T) {
+	fs := flag.NewFlagSet("test-for-manifest-get", flag.ContinueOnError)
+	smg := &SousManifestGet{}
+	smg.AddFlags(fs)
+	fs.Parse([]string{"-repo", "github.com/example/test", "-flavor", "winning"})
+
+	assert.Equal(t, "github.com/example/test", smg.DeployFilterFlags.Repo)
+	assert.Equal(t, "winning", smg.DeployFilterFlags.Flavor)
+}
+
+func TestManifestSetArgs(t *testing.T) {
+	fs := flag.NewFlagSet("test-for-manifest-get", flag.ContinueOnError)
+	smg := &SousManifestSet{}
+	smg.AddFlags(fs)
+	fs.Parse([]string{"-repo", "github.com/example/test", "-flavor", "winning"})
+
+	assert.Equal(t, "github.com/example/test", smg.DeployFilterFlags.Repo)
+	assert.Equal(t, "winning", smg.DeployFilterFlags.Flavor)
+}
+
 func TestManifestGet(t *testing.T) {
 	out := &bytes.Buffer{}
 
@@ -24,6 +45,7 @@ func TestManifestGet(t *testing.T) {
 			Source: sous.SourceLocation{
 				Repo: project1.Repo,
 			},
+			Flavor: "chocolate",
 		},
 		HTTPClient: graph.HTTPClient{cl},
 
@@ -41,7 +63,10 @@ func TestManifestGet(t *testing.T) {
 
 	if assert.Len(t, control.Calls(), 1) {
 		assert.Regexp(t, "/manifests", control.Calls()[0].PassedArgs().String(0))
-		assert.Contains(t, control.Calls()[0].PassedArgs().Get(1).(map[string]string), "repo")
+		params := control.Calls()[0].PassedArgs().Get(1).(map[string]string)
+		assert.Contains(t, params, "repo")
+		assert.Contains(t, params, "flavor")
+		assert.Equal(t, params["flavor"], "chocolate")
 	}
 
 	assert.Regexp(t, "github", out.String())


### PR DESCRIPTION
Very simple fix makes `sous manifest {get,set}` honor the -flavor flag.