### PR TITLE
Fixes a DI context issue between CLI and server injection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.27...HEAD)
+### Fixed
+- Client & Server: rework of DI to contain scope of variable assignment,
+  and retain scope from CLI invocation to server.
+
 ## [0.5.27](//github.com/opentable/sous/compare/0.5.26...0.5.27)
 ### Fixed
 - Client: omitting query params on update.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/opentable/sous/graph"
 	"github.com/opentable/sous/util/cmdr"
 	"github.com/opentable/sous/util/logging"
@@ -82,7 +84,8 @@ func (cli *CLI) Plumb(cmds ...cmdr.Executor) error {
 
 // BuildCLIGraph builds the CLI DI graph.
 func BuildCLIGraph(cli *CLI, root *Sous, in io.Reader, out, err io.Writer) *graph.SousGraph {
-	g := cli.baseGraph.Clone()
+	spew.Print("BuildCLIGraph", string(debug.Stack()))
+	g := cli.baseGraph //was .Clone() - caused problems
 	g.Add(cli)
 	g.Add(root)
 	g.Add(func(c *CLI) graph.Out {
@@ -91,7 +94,7 @@ func BuildCLIGraph(cli *CLI, root *Sous, in io.Reader, out, err io.Writer) *grap
 	g.Add(func(c *CLI) graph.ErrOut {
 		return graph.ErrOut{Output: c.Err}
 	})
-	cli.SousGraph = &graph.SousGraph{Psyringe: g} //Ugh, weird state.
+	cli.SousGraph = g
 
 	return cli.SousGraph
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime/debug"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/opentable/sous/graph"
@@ -41,6 +40,7 @@ type (
 	CLI struct {
 		*cmdr.CLI
 		baseGraph, SousGraph *graph.SousGraph
+		scopedGraphs         map[cmdr.Command]*graph.SousGraph
 	}
 	// Addable objects are able to receive lists of interface{}, presumably to add
 	// them to a DI registry. Abstracts Psyringe's Add()
@@ -65,17 +65,17 @@ func SuccessYAML(v interface{}) cmdr.Result {
 
 // Plumbing injects a command with the current psyringe,
 // then it Executes it, returning the result.
-func (cli *CLI) Plumbing(cmd cmdr.Executor, args []string) cmdr.Result {
-	if err := cli.Plumb(cmd); err != nil {
+func (cli *CLI) Plumbing(from cmdr.Command, cmd cmdr.Executor, args []string) cmdr.Result {
+	if err := cli.Plumb(from, cmd); err != nil {
 		return cmdr.EnsureErrorResult(err)
 	}
 	return cmd.Execute(args)
 }
 
 // Plumb injects a lists of commands with the currect psyringe, returning early in the event of an error
-func (cli *CLI) Plumb(cmds ...cmdr.Executor) error {
+func (cli *CLI) Plumb(from cmdr.Command, cmds ...cmdr.Executor) error {
 	for _, cmd := range cmds {
-		if err := cli.SousGraph.Inject(cmd); err != nil {
+		if err := cli.scopedGraph(from, nil).Inject(cmd); err != nil {
 			return err
 		}
 	}
@@ -84,7 +84,6 @@ func (cli *CLI) Plumb(cmds ...cmdr.Executor) error {
 
 // BuildCLIGraph builds the CLI DI graph.
 func BuildCLIGraph(cli *CLI, root *Sous, in io.Reader, out, err io.Writer) *graph.SousGraph {
-	spew.Print("BuildCLIGraph", string(debug.Stack()))
 	g := cli.baseGraph //was .Clone() - caused problems
 	g.Add(cli)
 	g.Add(root)
@@ -97,6 +96,21 @@ func BuildCLIGraph(cli *CLI, root *Sous, in io.Reader, out, err io.Writer) *grap
 	cli.SousGraph = g
 
 	return cli.SousGraph
+}
+
+func (cli *CLI) scopedGraph(cmd, under cmdr.Command) *graph.SousGraph {
+	if g, ok := cli.scopedGraphs[cmd]; ok {
+		return g
+	}
+
+	parent := cli.scopedGraphs[under]
+
+	g := &graph.SousGraph{Psyringe: parent.Clone()}
+	if r, ok := cmd.(Registrant); ok {
+		r.RegisterOn(g)
+	}
+	cli.scopedGraphs[cmd] = g
+	return g
 }
 
 // NewSousCLI creates a new Sous cli app.
@@ -120,14 +134,10 @@ func NewSousCLI(s *Sous, in io.Reader, out, errout io.Writer) (*CLI, error) {
 		baseGraph: graph.BuildGraph(in, out, errout),
 	}
 
-	var g *graph.SousGraph
-	var chain []cmdr.Command
-
-	cli.Hooks.Startup = func(*cmdr.CLI) error {
-		g = BuildCLIGraph(cli, s, in, out, errout)
-		chain = make([]cmdr.Command, 0)
-		return nil
-	}
+	chain := []cmdr.Command{}
+	rootGraph := BuildCLIGraph(cli, s, in, out, errout)
+	s.RegisterOn(rootGraph)
+	cli.scopedGraphs = map[cmdr.Command]*graph.SousGraph{s: rootGraph}
 
 	cli.Hooks.Parsed = func(cmd cmdr.Command) error {
 		chain = append(chain, cmd)
@@ -139,15 +149,15 @@ func NewSousCLI(s *Sous, in io.Reader, out, errout io.Writer) (*CLI, error) {
 	cli.Hooks.PreExecute = func(cmd cmdr.Command) error {
 		// Create the CLI dependency graph.
 
-		for _, c := range chain {
-			if r, ok := c.(Registrant); ok {
-				r.RegisterOn(g)
+		for n, c := range chain {
+			var under cmdr.Command
+			if n > 0 {
+				under = chain[n-1]
 			}
-		}
-
-		for _, c := range chain {
+			g := cli.scopedGraph(c, under)
 			if err := g.Inject(c); err != nil {
-				return err
+				spew.Dump(g, c)
+				return errors.Wrapf(err, "setup for execute")
 			}
 		}
 		return nil

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/opentable/sous/graph"
 	"github.com/opentable/sous/util/cmdr"
 	"github.com/opentable/sous/util/logging"
@@ -156,7 +155,6 @@ func NewSousCLI(s *Sous, in io.Reader, out, errout io.Writer) (*CLI, error) {
 			}
 			g := cli.scopedGraph(c, under)
 			if err := g.Inject(c); err != nil {
-				spew.Dump(g, c)
 				return errors.Wrapf(err, "setup for execute")
 			}
 		}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -27,7 +27,6 @@ func prepareCommand(t *testing.T, cl []string) (*CLI, *cmdr.PreparedExecution, f
 	require.NoError(err)
 
 	c.baseGraph = graph.BuildTestGraph(stdin, stdout, stderr)
-	//spew.Dump(c.baseGraph)
 
 	exe, err := c.Prepare(cl)
 	require.NoError(err)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -99,7 +99,7 @@ func TestInvokeDeploy_RepoFlag(t *testing.T) {
 	su := &SousUpdate{}
 	sps := &SousPlumbingStatus{}
 	logging.Log.Debug.Printf("Plumbing Update...")
-	require.NoError(sd.CLI.Plumb(su, sps))
+	require.NoError(sd.CLI.Plumb(sd, su, sps))
 
 	assert.NotEqual(su.ResolveFilter.Repo, "")
 	assert.NotEqual(su.ResolveFilter.Repo, "github.com/example/project")
@@ -116,7 +116,7 @@ func TestInvokeDeploy_RepoFlag(t *testing.T) {
 	sd, ok = exe.Cmd.(*SousDeploy)
 	require.True(ok)
 	su = &SousUpdate{}
-	sd.CLI.Plumb(su, sps)
+	sd.CLI.Plumb(sd, su, sps)
 	assert.Equal(su.ResolveFilter.Repo, "github.com/example/project")
 
 	assert.Equal(su.Manifest.ID().Source.Repo, sps.StatusPoller.Repo)

--- a/cli/sous_deploy.go
+++ b/cli/sous_deploy.go
@@ -54,7 +54,7 @@ func (sd *SousDeploy) RegisterOn(psy Addable) {
 
 // Execute fulfills the cmdr.Executor interface.
 func (sd *SousDeploy) Execute(args []string) cmdr.Result {
-	res := sd.CLI.Plumbing(&SousUpdate{}, []string{})
+	res := sd.CLI.Plumbing(sd, &SousUpdate{}, []string{})
 
 	sd.CLI.OutputResult(res)
 	if !sd.CLI.IsSuccess(res) {
@@ -63,12 +63,12 @@ func (sd *SousDeploy) Execute(args []string) cmdr.Result {
 
 	// Running serverless, so run rectify.
 	if sd.Config.Server == "" {
-		return sd.CLI.Plumbing(&SousRectify{}, []string{})
+		return sd.CLI.Plumbing(sd, &SousRectify{}, []string{})
 	}
 
 	if sd.waitStable {
 		fmt.Fprintf(sd.CLI.Out, "Waiting for server to report that deploy has stabilized...\n")
-		return sd.CLI.Plumbing(&SousPlumbingStatus{}, []string{})
+		return sd.CLI.Plumbing(sd, &SousPlumbingStatus{}, []string{})
 	}
 	return cmdr.Successf("Updated the global deploy manifest. Deploy in process.")
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -564,7 +564,7 @@ func newLocalStateWriter(sm *StateManager) StateWriter {
 // NewCurrentState returns the current *sous.State.
 func NewCurrentState(sr StateReader) (*sous.State, error) {
 	state, err := sr.ReadState()
-	if os.IsNotExist(errors.Cause(err)) {
+	if os.IsNotExist(errors.Cause(err)) || storage.IsGSMError(err) {
 		log.Println("error reading state:", err)
 		log.Println("defaulting to empty state")
 		return sous.NewState(), nil

--- a/graph/server_injection_test.go
+++ b/graph/server_injection_test.go
@@ -60,6 +60,17 @@ func TestServerGetDefHandlerInjection(t *testing.T) {
 	assert.NotNil(t, serverDefsGet.State)
 }
 
+func TestServerGetManifestHandlerInjection(t *testing.T) {
+	mr := &server.ManifestResource{}
+
+	mgh := basicInjectedHandler(mr.Get, t)
+
+	serverManifestGet, ok := mgh.(*server.GETManifestHandler)
+	require.True(t, ok)
+
+	assert.NotNil(t, serverManifestGet.State)
+}
+
 func TestServerPutGDMHandlerInjection(t *testing.T) {
 	sdr := &server.GDMResource{}
 

--- a/util/cmdr/cli.go
+++ b/util/cmdr/cli.go
@@ -122,6 +122,7 @@ func (c *CLI) Prepare(args []string) (*PreparedExecution, error) {
 	base, ff := c.Root, c.GlobalFlagSetFuncs
 	if c.Hooks.Startup != nil {
 		c.Hooks.Startup(c)
+		c.Hooks.Startup = nil
 	}
 	return c.prepare(base, args, ff)
 }


### PR DESCRIPTION
There was a problem with how DI contexts were being passed around: the command object responsible for `sous server` registered providers with its DI, but the actual server component didn't get that DI - it got one from further up the chain of contexts, which meant that important machinery wasn't available - so the server would blow up when certain requests were made of it.

Fixing this involved pulling a fair amount of the plumbing out and packing it back in.