### PR TITLE
Fixes `manifest set` JSON putback.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ with respect to its command line interface and HTTP interface.
 
 ### Fixed
 - Client: certain commands were missing DI for a particular value. These are fixed, and tests added for the omission.
+- Client: new values for optional fields no longer elided on `manifest set`
 
 ## [0.5.29](//github.com/opentable/sous/compare/0.5.28...0.5.29)
 ### Changed

--- a/util/restful/httpclient_test.go
+++ b/util/restful/httpclient_test.go
@@ -54,9 +54,11 @@ func TestPutbackJSON(t *testing.T) {
 	b, err := ioutil.ReadAll(outB)
 	assert.NoError(t, err)
 	json.Unmarshal(b, &mapped)
-	assert.Equal(t, 7.0, mapped["a"]) //missing from update
+	assert.Equal(t, 7.0, mapped["a"]) //missing from base, therefore untouched
 	assert.Equal(t, "y", mapped["b"])
 	assert.Equal(t, "w", dig(mapped, "d", "y", 0, "q"))
+	assert.Equal(t, "w", dig(mapped, "d", "y", 1, "zx"))
+	assert.Equal(t, float64(1), dig(mapped, "d", "z"))
 	assert.Equal(t, "a", dig(mapped, "e", "a"))
 }
 

--- a/util/restful/httpclient_test.go
+++ b/util/restful/httpclient_test.go
@@ -22,7 +22,8 @@ func TestPutbackJSON(t *testing.T) {
 			"z": 1,
 			"y": [{"q":"q", "z": "o"}],
 			"x": "x"
-		}
+		},
+		"e": null
 	}`)
 
 	baseB := bytes.NewBufferString(`{
@@ -56,6 +57,7 @@ func TestPutbackJSON(t *testing.T) {
 	assert.Equal(t, 7.0, mapped["a"]) //missing from update
 	assert.Equal(t, "y", mapped["b"])
 	assert.Equal(t, "w", dig(mapped, "d", "y", 0, "q"))
+	assert.Equal(t, "a", dig(mapped, "e", "a"))
 }
 
 func TestClientRetrieve(t *testing.T) {

--- a/util/restful/putbackjson.go
+++ b/util/restful/putbackjson.go
@@ -42,6 +42,7 @@ func applyChanges(base, changed, target map[string]interface{}) map[string]inter
 			}
 		case map[string]interface{}:
 			if b, old := base[k]; !old || b == nil {
+				delete(base, k)
 				target[k] = v //created
 			} else {
 				delete(base, k)

--- a/util/restful/putbackjson.go
+++ b/util/restful/putbackjson.go
@@ -41,11 +41,10 @@ func applyChanges(base, changed, target map[string]interface{}) map[string]inter
 				}
 			}
 		case map[string]interface{}:
+			delete(base, k)
 			if b, old := base[k]; !old || b == nil {
-				delete(base, k)
 				target[k] = v //created
 			} else {
-				delete(base, k)
 				// Unchecked cast: if base[k] isn't also a map, we have bigger problems.
 				// If target[k] isn't a map, then the server has changed the type under us, and we should crash
 

--- a/util/restful/putbackjson.go
+++ b/util/restful/putbackjson.go
@@ -8,6 +8,21 @@ import (
 
 type jsonMap map[string]interface{}
 
+// This function is used in order to safely update JSON based on (possibly) out of date local structs.
+// We serialize our version of the struct, and then produce an updated version
+// of the JSON based on what changed in our understanding of the JSON. Fields
+// that don't serialize (because, presumably, they're additive changes to the
+// API) are untouched.
+//
+// Of note is that lists of all kinds are considered a "unit" of comparison.
+// For the time being this is sufficient, but it means that a list-of-object is
+// potentially a backwards-compatibility issue. The problem isn't insoluable,
+// but it's more challenging than it's worth at the moment.
+
+// originalBuf should contain the JSON-as-received.
+// baseBuf should contain a round-trip to the DTO captured when the original was received.
+// changedBuf should contain the serialization of the updated DTO
+//
 func putbackJSON(originalBuf, baseBuf, changedBuf io.Reader) *bytes.Buffer {
 	var original, base, changed jsonMap
 	if err := mapDecode(originalBuf, &original); err != nil {
@@ -35,13 +50,11 @@ func applyChanges(base, changed, target map[string]interface{}) map[string]inter
 			if b, old := base[k]; !old {
 				target[k] = v //created
 			} else {
-				delete(base, k)
 				if !same(b, v) { // changed
 					target[k] = v
 				}
 			}
 		case map[string]interface{}:
-			delete(base, k)
 			if b, old := base[k]; !old || b == nil {
 				target[k] = v //created
 			} else {
@@ -58,6 +71,7 @@ func applyChanges(base, changed, target map[string]interface{}) map[string]inter
 				target[k] = newMap
 			}
 		}
+		delete(base, k)
 	}
 
 	// the remaining fields were deleted


### PR DESCRIPTION
Null fields were being put into the proposed document, then removed because
they weren't being marked as found (by deletion from the base map.)