### PR TITLE
Log and filtering refactors

### DIFF
--- a/cli/sous.go
+++ b/cli/sous.go
@@ -16,7 +16,7 @@ type Sous struct {
 	// CLI is a reference to the CLI singleton. We use it here to set global
 	// verbosity.
 	CLI *CLI
-	*logging.LogSet
+	logging.LogSet
 	// Err is the error message stream.
 	Err *graph.ErrOut
 	// Version is the version of Sous itself.

--- a/cli/sous_manifest_get.go
+++ b/cli/sous_manifest_get.go
@@ -18,7 +18,7 @@ type SousManifestGet struct {
 	*sous.ResolveFilter
 	graph.TargetManifestID
 	graph.HTTPClient
-	*logging.LogSet
+	logging.LogSet
 	graph.OutWriter
 }
 

--- a/cli/sous_manifest_set.go
+++ b/cli/sous_manifest_set.go
@@ -20,7 +20,7 @@ type SousManifestSet struct {
 	graph.HTTPClient
 	graph.InReader
 	*sous.ResolveFilter
-	*logging.LogSet
+	logging.LogSet
 	User sous.User
 }
 

--- a/cli/sous_plumbing.go
+++ b/cli/sous_plumbing.go
@@ -1,6 +1,9 @@
 package cli
 
-import "github.com/opentable/sous/util/cmdr"
+import (
+	"github.com/opentable/sous/graph"
+	"github.com/opentable/sous/util/cmdr"
+)
 
 // SousPlumbing is the `sous plumbing` subcommand
 type SousPlumbing struct{}
@@ -11,6 +14,11 @@ var PlumbingSubcommands = cmdr.Commands{}
 func init() { TopLevelCommands["plumbing"] = &SousPlumbing{} }
 
 const sousPlumbingHelp = `Plumbing subcommands of Sous - usually not needed by users`
+
+// RegisterOn implements Registrant on SousPlumbing
+func (SousPlumbing) RegisterOn(psy Addable) {
+	psy.Add(graph.DryrunNeither)
+}
 
 // Subcommands implements Submcommandor for SousPlumbing
 func (SousPlumbing) Subcommands() cmdr.Commands {

--- a/cli/sous_server.go
+++ b/cli/sous_server.go
@@ -19,7 +19,7 @@ import (
 type SousServer struct {
 	Sous              *Sous
 	DeployFilterFlags config.DeployFilterFlags
-	Log               *logging.LogSet
+	Log               logging.LogSet
 
 	*config.Config
 	graph.ServerHandler

--- a/cli/sous_update_test.go
+++ b/cli/sous_update_test.go
@@ -140,7 +140,7 @@ func TestUpdateRetryLoop(t *testing.T) {
 
 	serverScoop := struct {
 		Handler graph.ServerHandler
-		LogSet  *logging.LogSet
+		LogSet  logging.LogSet
 	}{}
 	g.MustInject(&serverScoop)
 	if serverScoop.Handler.Handler == nil {

--- a/ext/docker/image_mapping.go
+++ b/ext/docker/image_mapping.go
@@ -32,7 +32,7 @@ type (
 		RegistryClient     docker_registry.Client
 		DB                 *sql.DB
 		DockerRegistryHost string
-		Log                *logging.LogSet
+		Log                logging.LogSet
 	}
 
 	imageName string
@@ -89,7 +89,7 @@ func (e NotModifiedErr) Error() string {
 }
 
 // NewNameCache builds a new name cache.
-func NewNameCache(drh string, cl docker_registry.Client, ls *logging.LogSet, db *sql.DB) *NameCache {
+func NewNameCache(drh string, cl docker_registry.Client, ls logging.LogSet, db *sql.DB) *NameCache {
 	nc := &NameCache{
 		RegistryClient:     cl,
 		DB:                 db,

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -280,7 +280,7 @@ func newResolver(filter *sous.ResolveFilter, d sous.Deployer, r sous.Registry) *
 	return sous.NewResolver(d, r, filter)
 }
 
-func newAutoResolver(rez *sous.Resolver, sr *ServerStateManager, ls *logging.LogSet) *sous.AutoResolver {
+func newAutoResolver(rez *sous.Resolver, sr *ServerStateManager, ls logging.LogSet) *sous.AutoResolver {
 	return sous.NewAutoResolver(rez, sr, ls.Child("autoresolver"))
 }
 
@@ -296,7 +296,7 @@ func newRegistryDumper(r sous.Registry) *sous.RegistryDumper {
 	return sous.NewRegistryDumper(r)
 }
 
-func newLogSet(v *config.Verbosity, err ErrWriter) *logging.LogSet { // XXX temporary until we settle on logging
+func newLogSet(v *config.Verbosity, err ErrWriter) logging.LogSet { // XXX temporary until we settle on logging
 	ls := logging.NewLogSet("sous", err)
 
 	if v.Debug {
@@ -436,7 +436,7 @@ func newLocalGitRepo(c LocalGitClient) (v LocalGitRepo, err error) {
 	return v, initErr(err, "opening local git repository")
 }
 
-func newSelector(regClient LocalDockerClient, log *logging.LogSet) sous.Selector {
+func newSelector(regClient LocalDockerClient, log logging.LogSet) sous.Selector {
 	return &sous.EchoSelector{
 		Factory: func(ctx *sous.BuildContext) (sous.Buildpack, error) {
 			sbp := docker.NewSplitBuildpack(regClient.Client)
@@ -472,7 +472,7 @@ func newRegistrar(db *docker.Builder) sous.Registrar {
 	return db
 }
 
-func newRegistry(dryrun DryrunOption, cfg LocalSousConfig, ls *logging.LogSet, cl LocalDockerClient) (sous.Registry, error) {
+func newRegistry(dryrun DryrunOption, cfg LocalSousConfig, ls logging.LogSet, cl LocalDockerClient) (sous.Registry, error) {
 	if dryrun == DryrunBoth || dryrun == DryrunRegistry {
 		return sous.NewDummyRegistry(), nil
 	}
@@ -493,7 +493,7 @@ func newDockerClient() LocalDockerClient {
 	return LocalDockerClient{docker_registry.NewClient()}
 }
 
-func newServerHandler(g *SousGraph, ComponentLocator server.ComponentLocator, log *logging.LogSet) ServerHandler {
+func newServerHandler(g *SousGraph, ComponentLocator server.ComponentLocator, log logging.LogSet) ServerHandler {
 	var handler http.Handler
 
 	profileQuery := struct{ Yes ProfilingServer }{}
@@ -509,7 +509,7 @@ func newServerHandler(g *SousGraph, ComponentLocator server.ComponentLocator, lo
 
 // newHTTPClient returns an HTTP client if c.Server is not empty.
 // Otherwise it returns nil, and emits some warnings.
-func newHTTPClient(c LocalSousConfig, user sous.User, srvr ServerHandler, log *logging.LogSet) (HTTPClient, error) {
+func newHTTPClient(c LocalSousConfig, user sous.User, srvr ServerHandler, log logging.LogSet) (HTTPClient, error) {
 	if c.Server == "" {
 		logging.Log.Warn.Println("No server set, Sous is running in server or workstation mode.")
 		logging.Log.Warn.Println("Configure a server like this: sous config server http://some.sous.server")
@@ -538,7 +538,7 @@ func newStateManager(cl HTTPClient, c LocalSousConfig) *StateManager {
 	return &StateManager{StateManager: hsm}
 }
 
-func newStatusPoller(cl HTTPClient, rf *RefinedResolveFilter, user sous.User) *sous.StatusPoller {
+func newStatusPoller(cl HTTPClient, rf *RefinedResolveFilter, user sous.User, logs logging.LogSet) *sous.StatusPoller {
 	logging.Log.Debug.Printf("Building StatusPoller...")
 	if cl.HTTPClient == nil {
 		logging.Log.Debug.Print(logging.Log.Warn)
@@ -546,7 +546,7 @@ func newStatusPoller(cl HTTPClient, rf *RefinedResolveFilter, user sous.User) *s
 		return nil
 	}
 	logging.Log.Debug.Printf("...looks good...")
-	return sous.NewStatusPoller(cl, (*sous.ResolveFilter)(rf), user)
+	return sous.NewStatusPoller(cl, (*sous.ResolveFilter)(rf), user, logs)
 }
 
 func newLocalStateReader(sm *StateManager) StateReader {
@@ -587,7 +587,7 @@ func NewCurrentGDM(state *sous.State) (CurrentGDM, error) {
 // sous native types.
 
 // newDockerRegistry creates a Docker version of sous.Registry
-func newDockerRegistry(cfg LocalSousConfig, ls *logging.LogSet, cl LocalDockerClient) (*docker.NameCache, error) {
+func newDockerRegistry(cfg LocalSousConfig, ls logging.LogSet, cl LocalDockerClient) (*docker.NameCache, error) {
 	dbCfg := cfg.Docker.DBConfig()
 	db, err := docker.GetDatabase(&dbCfg)
 	if err != nil {
@@ -597,7 +597,7 @@ func newDockerRegistry(cfg LocalSousConfig, ls *logging.LogSet, cl LocalDockerCl
 	return docker.NewNameCache(drh, cl.Client, ls.Child("docker-images"), db), nil
 }
 
-func newInserter(cfg LocalSousConfig, ls *logging.LogSet, cl LocalDockerClient) (sous.Inserter, error) {
+func newInserter(cfg LocalSousConfig, ls logging.LogSet, cl LocalDockerClient) (sous.Inserter, error) {
 	if cfg.Server == "" {
 		return newDockerRegistry(cfg, ls.Child("docker-registry"), cl)
 	}

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -13,18 +13,36 @@ import (
 	"github.com/opentable/sous/util/logging"
 	"github.com/opentable/sous/util/shell"
 	"github.com/samsalisbury/psyringe"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewStatusPoller(t *testing.T) {
-	// func newRefinedResolveFilter(f *sous.ResolveFilter, discovered *SourceContextDiscovery) (*RefinedResolveFilter, error) {
-	rf, err := newRefinedResolveFilter(f, disc)
-	require.NoError(err)
-	cl := newDummyHTTPClient()
+	testPoller := func(sf config.DeployFilterFlags) *sous.StatusPoller {
+		shc := sous.SourceHostChooser{}
+		f, err := sf.BuildFilter(shc.ParseSourceLocation)
+		require.NoError(t, err)
 
-	//newStatusPoller(cl HTTPClient, rf *RefinedResolveFilter, user sous.User) *sous.StatusPoller {
-	poller := newStatusPoller(cl, rf, user)
+		// func newRefinedResolveFilter(f *sous.ResolveFilter, discovered *SourceContextDiscovery) (*RefinedResolveFilter, error) {
 
+		disc := &SourceContextDiscovery{
+			SourceContext: &sous.SourceContext{
+				PrimaryRemoteURL: "github.com/somewhere/thing",
+				NearestTag:       sous.Tag{Name: "1.2.3", Revision: "cabbage"},
+				Tags:             []sous.Tag{},
+			},
+		}
+		rf, err := newRefinedResolveFilter(f, disc)
+		require.NoError(t, err)
+		cl := newDummyHTTPClient()
+		user := sous.User{}
+
+		//newStatusPoller(cl HTTPClient, rf *RefinedResolveFilter, user sous.User) *sous.StatusPoller {
+		return newStatusPoller(cl, rf, user, logging.SilentLogSet())
+	}
+
+	p := testPoller(config.DeployFilterFlags{})
+	assert.False(t, p.ResolveFilter.Flavor.All())
 }
 
 func TestBuildGraph(t *testing.T) {

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -13,7 +13,19 @@ import (
 	"github.com/opentable/sous/util/logging"
 	"github.com/opentable/sous/util/shell"
 	"github.com/samsalisbury/psyringe"
+	"github.com/stretchr/testify/require"
 )
+
+func TestNewStatusPoller(t *testing.T) {
+	// func newRefinedResolveFilter(f *sous.ResolveFilter, discovered *SourceContextDiscovery) (*RefinedResolveFilter, error) {
+	rf, err := newRefinedResolveFilter(f, disc)
+	require.NoError(err)
+	cl := newDummyHTTPClient()
+
+	//newStatusPoller(cl HTTPClient, rf *RefinedResolveFilter, user sous.User) *sous.StatusPoller {
+	poller := newStatusPoller(cl, rf, user)
+
+}
 
 func TestBuildGraph(t *testing.T) {
 	log.SetFlags(log.Flags() | log.Lshortfile)

--- a/graph/server.go
+++ b/graph/server.go
@@ -6,7 +6,7 @@ import (
 	"github.com/opentable/sous/util/logging"
 )
 
-func newServerComponentLocator(ls *logging.LogSet, cfg LocalSousConfig, ins sous.Inserter, sm *ServerStateManager, rf *sous.ResolveFilter, ar *sous.AutoResolver) server.ComponentLocator {
+func newServerComponentLocator(ls logging.LogSet, cfg LocalSousConfig, ins sous.Inserter, sm *ServerStateManager, rf *sous.ResolveFilter, ar *sous.AutoResolver) server.ComponentLocator {
 	return server.ComponentLocator{
 		LogSet:        ls,
 		Config:        cfg.Config,

--- a/graph/sourcecontext_test.go
+++ b/graph/sourcecontext_test.go
@@ -14,16 +14,16 @@ type resolveSourceLocationInput struct {
 }
 
 func TestResolveSourceLocation_failure(t *testing.T) {
+	assertSourceContextError := func(t *testing.T, flags *sous.ResolveFilter, ctx *SourceContextDiscovery, msgPattern string) {
+		_, actualErr := newRefinedResolveFilter(flags, ctx)
+		require.NotNil(t, actualErr)
+		assert.Regexp(t, msgPattern, actualErr.Error())
+	}
+
 	assertSourceContextError(t, &sous.ResolveFilter{}, &SourceContextDiscovery{},
 		"no repo specified, please use -repo or run sous inside a git repo with a configured remote")
 	assertSourceContextError(t, nil, &SourceContextDiscovery{},
 		"no repo specified, please use -repo or run sous inside a git repo with a configured remote")
-}
-
-func assertSourceContextError(t *testing.T, flags *sous.ResolveFilter, ctx *SourceContextDiscovery, msgPattern string) {
-	_, actualErr := newRefinedResolveFilter(flags, ctx)
-	assert.NotNil(t, actualErr)
-	assert.Regexp(t, msgPattern, actualErr.Error())
 }
 
 func assertSourceContextSuccess(t *testing.T, expected sous.ManifestID, flags *sous.ResolveFilter, ctx *sous.SourceContext) {
@@ -41,12 +41,12 @@ func assertSourceContextSuccess(t *testing.T, expected sous.ManifestID, flags *s
 func TestResolveSourceLocation_success(t *testing.T) {
 	assertSourceContextSuccess(t,
 		sous.ManifestID{Source: sous.SourceLocation{Repo: "github.com/user/project"}},
-		&sous.ResolveFilter{Repo: "github.com/user/project"},
+		&sous.ResolveFilter{Repo: sous.NewResolveFieldMatcher("github.com/user/project")},
 		&sous.SourceContext{PrimaryRemoteURL: "github.com/user/project"},
 	)
 	assertSourceContextSuccess(t,
 		sous.ManifestID{Source: sous.SourceLocation{Repo: "github.com/user/project", Dir: "some/path"}},
-		&sous.ResolveFilter{Repo: "github.com/user/project", Offset: sous.NewResolveFieldMatcher("some/path")},
+		&sous.ResolveFilter{Repo: sous.NewResolveFieldMatcher("github.com/user/project"), Offset: sous.NewResolveFieldMatcher("some/path")},
 		&sous.SourceContext{
 			PrimaryRemoteURL: "github.com/user/project",
 			OffsetDir:        "some/path",
@@ -55,7 +55,7 @@ func TestResolveSourceLocation_success(t *testing.T) {
 	assertSourceContextSuccess(t,
 		sous.ManifestID{Source: sous.SourceLocation{Repo: "github.com/from/flags"}},
 		&sous.ResolveFilter{
-			Repo: "github.com/from/flags",
+			Repo: sous.NewResolveFieldMatcher("github.com/from/flags"),
 		},
 		&sous.SourceContext{
 			PrimaryRemoteURL: "github.com/original/context",

--- a/lib/auto_resolver.go
+++ b/lib/auto_resolver.go
@@ -24,7 +24,7 @@ type (
 		StateReader
 		GDM Deployments
 		*Resolver
-		*logging.LogSet
+		logging.LogSet
 		listeners []autoResolveListener
 		sync.RWMutex
 		stableStatus, liveStatus *ResolveStatus
@@ -37,7 +37,7 @@ func (tc TriggerChannel) trigger() {
 }
 
 // NewAutoResolver creates a new AutoResolver.
-func NewAutoResolver(rez *Resolver, sr StateReader, ls *logging.LogSet) *AutoResolver {
+func NewAutoResolver(rez *Resolver, sr StateReader, ls logging.LogSet) *AutoResolver {
 	ar := &AutoResolver{
 		UpdateTime:  60 * time.Second,
 		Resolver:    rez,

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -94,7 +94,7 @@ func (d *Deployment) String() string {
 	if d.Cluster != nil {
 		clusterName = d.Cluster.Name
 	}
-	return fmt.Sprintf("%s @ %s %s", d.SourceID, clusterName, d.DeployConfig.String())
+	return fmt.Sprintf("%s %q @ %s %s", d.SourceID, d.Flavor, clusterName, d.DeployConfig.String())
 }
 
 // ID returns the DeployID of this deployment.

--- a/lib/resolvefilter_test.go
+++ b/lib/resolvefilter_test.go
@@ -30,7 +30,7 @@ func TestGetSourceID(t *testing.T) {
 	})
 
 	t.Run("successful source id", func(t *testing.T) {
-		sid, err := (&ResolveFilter{Cluster: "blah", Tag: NewResolveFieldMatcher("1.1.1")}).SourceID(rMid)
+		sid, err := (&ResolveFilter{Cluster: NewResolveFieldMatcher("blah"), Tag: NewResolveFieldMatcher("1.1.1")}).SourceID(rMid)
 		if err != nil {
 			t.Fatalf("no error expected, but got: %q", err)
 		}
@@ -58,7 +58,7 @@ func TestGetDeployID(t *testing.T) {
 	})
 
 	t.Run("successful deploy id", func(t *testing.T) {
-		did, err := (&ResolveFilter{Cluster: "blah", Tag: NewResolveFieldMatcher("1.1.1")}).DeploymentID(rMid)
+		did, err := (&ResolveFilter{Cluster: NewResolveFieldMatcher("blah"), Tag: NewResolveFieldMatcher("1.1.1")}).DeploymentID(rMid)
 		if err != nil {
 			t.Fatalf("no error expected, but got: %q", err)
 		}

--- a/lib/status_poller.go
+++ b/lib/status_poller.go
@@ -159,7 +159,6 @@ func newSubPoller(clusterName, serverURL string, baseFilter *ResolveFilter, user
 
 	loc := *baseFilter
 	loc.Cluster = ""
-
 	loc.Tag = ResolveFieldMatcher{}
 	loc.Revision = ""
 
@@ -230,17 +229,17 @@ func (sp *StatusPoller) subPollers(clusters *serverListData, deps Deployments) (
 	for _, s := range clusters.Servers {
 		// skip clusters the user isn't interested in
 		if !sp.ResolveFilter.FilterClusterName(s.ClusterName) {
-			logging.Log.Vomit.Printf("%s not requested for polling", s.ClusterName)
+			logging.Log.Vomitf("%s not requested for polling", s.ClusterName)
 			continue
 		}
 		// skip clusters that there's no current intention of deploying into
 		if _, intended := deps.Single(func(d *Deployment) bool {
 			return d.ClusterName == s.ClusterName
 		}); !intended {
-			logging.Log.Debug.Printf("No intention in GDM for %s to deploy %s", s.ClusterName, sp.ResolveFilter)
+			logging.Log.Debugf("No intention in GDM for %s to deploy %s", s.ClusterName, sp.ResolveFilter)
 			continue
 		}
-		logging.Log.Debug.Printf("Starting poller against %v", s)
+		logging.Log.Debugf("Starting poller against %v", s)
 
 		// Kick off a separate process to issue HTTP requests against this cluster.
 		sub, err := newSubPoller(s.ClusterName, s.URL, sp.ResolveFilter, sp.User, logging.Log)
@@ -282,13 +281,13 @@ func (sp *StatusPoller) poll(subs []*subPoller) ResolveState {
 func (sp *StatusPoller) nextSubStatus(collect chan statPair) {
 	update := <-collect
 	sp.pollChans[update.url] = update.stat
-	logging.Log.Debug.Printf("%s reports state: %s", update.url, update.stat)
+	logging.Log.Debugf("%s reports state: %s", update.url, update.stat)
 }
 
 func (sp *StatusPoller) updateStatus() {
 	max := ResolveMAX
 	for u, s := range sp.pollChans {
-		logging.Log.Vomit.Printf("Current state from %s: %s", u, s)
+		logging.Log.Vomitf("Current state from %s: %s", u, s)
 
 		//if max is already > EJECT, we can quit without waiting for other subs
 		if s <= max {
@@ -328,8 +327,8 @@ func (sub *subPoller) start(rs chan statPair, done chan struct{}) {
 func (sub *subPoller) pollOnce() ResolveState {
 	data := &statusData{}
 	if _, err := sub.Retrieve("./status", nil, data, sub.User.HTTPHeaders()); err != nil {
-		logging.Log.Debug.Printf("%s: error on GET /status: %s", sub.ClusterName, errors.Cause(err))
-		logging.Log.Vomit.Printf("%s: %T %+v", sub.ClusterName, errors.Cause(err), err)
+		logging.Log.Debugf("%s: error on GET /status: %s", sub.ClusterName, errors.Cause(err))
+		logging.Log.Vomitf("%s: %T %+v", sub.ClusterName, errors.Cause(err), err)
 		sub.httpErrorCount++
 		if sub.httpErrorCount > 10 {
 			return ResolveFailed
@@ -361,8 +360,8 @@ func (sub *subPoller) pollOnce() ResolveState {
 func (sub *subPoller) stateFeatures(kind string, rezState *ResolveStatus) (*Deployment, *DiffResolution) {
 	current := diffResolutionFor(rezState, sub.locationFilter)
 	srvIntent := serverIntent(rezState, sub.locationFilter)
-	logging.Log.Debug.Printf("%s reports %s intent to resolve [%v]", sub.URL, kind, srvIntent)
-	logging.Log.Debug.Printf("%s reports %s rez: %v", sub.URL, kind, current)
+	logging.Log.Debugf("%s reports %s intent to resolve [%v]", sub.URL, kind, srvIntent)
+	logging.Log.Debugf("%s reports %s rez: %v", sub.URL, kind, current)
 
 	return srvIntent, current
 }
@@ -403,13 +402,13 @@ func (sub *subPoller) computeState(srvIntent *Deployment, current *DiffResolutio
 		// resolution cycle, Singularity will e.g. have finished a pending->running
 		// transition and be ready to receive a new Deploy)
 		if IsTransientResolveError(current.Error) {
-			logging.Log.Debug.Printf("%s: received resolver error %s, retrying", sub.ClusterName, current.Error)
+			logging.Log.Debugf("%s: received resolver error %s, retrying", sub.ClusterName, current.Error)
 			return ResolveErredRez
 		}
 		// Other errors are unlikely to clear by themselves. In this case, log the
 		// error for operator action, and consider this subpoller done as failed.
-		logging.Log.Vomit.Printf("%#v", current)
-		logging.Log.Vomit.Printf("%#v", current.Error)
+		logging.Log.Vomitf("%#v", current)
+		logging.Log.Vomitf("%#v", current.Error)
 		subject := ""
 		if sub.locationFilter == nil {
 			subject = "<no filter defined>"
@@ -441,40 +440,42 @@ func (sub *subPoller) computeState(srvIntent *Deployment, current *DiffResolutio
 }
 
 func serverIntent(rstat *ResolveStatus, rf *ResolveFilter) *Deployment {
-	logging.Log.Debug.Printf("Filtering with %q", rf)
+	logging.Log.Debugf("Filtering with %q", rf)
 	if rstat == nil {
-		logging.Log.Debug.Printf("Nil resolve status!")
+		logging.Log.Debugf("Nil resolve status!")
 		return nil
 	}
-	logging.Log.Vomit.Printf("Filtering %#v", rstat.Intended)
+	logging.Log.Vomitf("Filtering %s", rstat.Intended)
 	var dep *Deployment
 
 	for _, d := range rstat.Intended {
 		if rf.FilterDeployment(d) {
 			if dep != nil {
-				logging.Log.Debug.Printf("With %s we didn't match exactly one deployment.", rf)
+				logging.Log.Debugf("With %s we didn't match exactly one deployment.", rf)
 				return nil
 			}
 			dep = d
 		}
 	}
+	logging.Log.Debugf("Filtering found %s", dep.String())
 
 	return dep
 }
 
 func diffResolutionFor(rstat *ResolveStatus, rf *ResolveFilter) *DiffResolution {
 	if rstat == nil {
-		logging.Log.Vomit.Printf("Status was nil - no match for %s", rf)
+		logging.Log.Vomitf("Status was nil - no match for %s", rf)
 		return nil
 	}
 	rezs := rstat.Log
 	for _, rez := range rezs {
+		logging.Log.Vomitf("Checking resolution for: %#v(%[1]T)", rez.ManifestID)
 		if rf.FilterManifestID(rez.ManifestID) {
-			logging.Log.Vomit.Printf("Matching intent for %s: %#v", rf, rez)
+			logging.Log.Vomitf("Matching intent for %s: %#v", rf, rez)
 			return &rez
 		}
 	}
-	logging.Log.Vomit.Printf("No match for %s in %d entries", rf, len(rezs))
+	logging.Log.Vomitf("No match for %s in %d entries", rf, len(rezs))
 	return nil
 }
 

--- a/lib/status_poller.go
+++ b/lib/status_poller.go
@@ -158,12 +158,12 @@ func newSubPoller(clusterName, serverURL string, baseFilter *ResolveFilter, user
 	}
 
 	loc := *baseFilter
-	loc.Cluster = ""
+	loc.Cluster = ResolveFieldMatcher{}
 	loc.Tag = ResolveFieldMatcher{}
-	loc.Revision = ""
+	loc.Revision = ResolveFieldMatcher{}
 
 	id := *baseFilter
-	id.Cluster = ""
+	id.Cluster = ResolveFieldMatcher{}
 
 	return &subPoller{
 		ClusterName:    clusterName,

--- a/lib/status_poller_test.go
+++ b/lib/status_poller_test.go
@@ -214,9 +214,6 @@ func TestStatusPoller(t *testing.T) {
 		"inprogress": {"log":[]}
 	}`)
 
-	logging.Log.BeChatty()
-	defer logging.Log.BeQuiet()
-
 	rf := &ResolveFilter{
 		Repo: NewResolveFieldMatcher(repoName),
 	}
@@ -228,7 +225,7 @@ func TestStatusPoller(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error building HTTP client: %#v", err)
 	}
-	poller := NewStatusPoller(cl, rf, User{Name: "Test User"})
+	poller := NewStatusPoller(cl, rf, User{Name: "Test User"}, logging.SilentLogSet())
 
 	testCh := make(chan ResolveState)
 	go func() {
@@ -327,7 +324,7 @@ func TestStatusPoller_OldServer2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error building HTTP client: %#v", err)
 	}
-	poller := NewStatusPoller(cl, rf, User{Name: "Test User"})
+	poller := NewStatusPoller(cl, rf, User{Name: "Test User"}, logging.SilentLogSet())
 
 	testCh := make(chan ResolveState)
 	go func() {
@@ -436,7 +433,7 @@ func TestStatusPoller_MesosFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error building HTTP client: %#v", err)
 	}
-	poller := NewStatusPoller(cl, rf, User{Name: "Test User"})
+	poller := NewStatusPoller(cl, rf, User{Name: "Test User"}, logging.SilentLogSet())
 
 	testCh := make(chan ResolveState)
 	go func() {
@@ -520,7 +517,7 @@ func TestStatusPoller_NotIntended(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error building HTTP client: %#v", err)
 	}
-	poller := NewStatusPoller(cl, rf, User{Name: "Test User"})
+	poller := NewStatusPoller(cl, rf, User{Name: "Test User"}, logging.SilentLogSet())
 
 	testCh := make(chan ResolveState)
 	go func() {
@@ -571,7 +568,7 @@ func TestStatusPoller_OldServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error building HTTP client: %#v", err)
 	}
-	poller := NewStatusPoller(cl, rf, User{Name: "Test User"})
+	poller := NewStatusPoller(cl, rf, User{Name: "Test User"}, logging.SilentLogSet())
 
 	testCh := make(chan ResolveState)
 	go func() {

--- a/lib/status_poller_test.go
+++ b/lib/status_poller_test.go
@@ -205,7 +205,7 @@ func TestStatusPoller(t *testing.T) {
 				"flavor": "canhaz"
 			} ],
 			"log":[ {
-					"manifestid": "` + repoName + `-canhaz",
+					"manifestid": "` + repoName + `~canhaz",
 					"desc": "unchanged"
 				} ]
 		},
@@ -219,6 +219,8 @@ func TestStatusPoller(t *testing.T) {
 		Repo: repoName,
 	}
 	rf.SetTag("")
+	// XXX Flavor
+	//   and deploy should probably not treat Flavor as * by default (instead "")
 
 	cl, err := restful.NewClient(mainSrv.URL, logging.SilentLogSet())
 	if err != nil {

--- a/lib/status_poller_test.go
+++ b/lib/status_poller_test.go
@@ -192,7 +192,8 @@ func TestStatusPoller(t *testing.T) {
 				"sourceid": {
 					"location": "` + repoName + `",
 					"version": "1.0.1+1234"
-				}
+				},
+				"flavor": "canhaz"
 			}
 		],
 		"completed": {
@@ -200,15 +201,19 @@ func TestStatusPoller(t *testing.T) {
 				"sourceid": {
 					"location": "` + repoName + `",
 					"version": "1.0.1+1234"
-				}
+				},
+				"flavor": "canhaz"
 			} ],
 			"log":[ {
-					"manifestid": "` + repoName + `",
+					"manifestid": "` + repoName + `-canhaz",
 					"desc": "unchanged"
 				} ]
 		},
 		"inprogress": {"log":[]}
 	}`)
+
+	logging.Log.BeChatty()
+	defer logging.Log.BeQuiet()
 
 	rf := &ResolveFilter{
 		Repo: repoName,

--- a/lib/status_poller_test.go
+++ b/lib/status_poller_test.go
@@ -175,14 +175,16 @@ func TestStatusPoller(t *testing.T) {
 				"sourceid": {
 					"location": "` + repoName + `",
 					"version": "1.0.1+1234"
-				}
+				},
+				"flavor": "canhaz"
 			},
 			{
 				"clustername": "main",
 				"sourceid": {
 					"location": "` + repoName + `",
 					"version": "1.0.1+1234"
-				}
+				},
+				"flavor": "canhaz"
 			}
 		]
 	}`)
@@ -216,7 +218,7 @@ func TestStatusPoller(t *testing.T) {
 	defer logging.Log.BeQuiet()
 
 	rf := &ResolveFilter{
-		Repo: repoName,
+		Repo: NewResolveFieldMatcher(repoName),
 	}
 	rf.SetTag("")
 	// XXX Flavor
@@ -317,7 +319,7 @@ func TestStatusPoller_OldServer2(t *testing.T) {
 	}`)
 
 	rf := &ResolveFilter{
-		Repo: repoName,
+		Repo: NewResolveFieldMatcher(repoName),
 	}
 	rf.SetTag("")
 
@@ -426,7 +428,7 @@ func TestStatusPoller_MesosFailed(t *testing.T) {
 	}`)
 
 	rf := &ResolveFilter{
-		Repo: repoName,
+		Repo: NewResolveFieldMatcher(repoName),
 	}
 	rf.SetTag("")
 
@@ -511,7 +513,7 @@ func TestStatusPoller_NotIntended(t *testing.T) {
 	}`)
 
 	rf := &ResolveFilter{
-		Repo: repoName,
+		Repo: NewResolveFieldMatcher(repoName),
 	}
 
 	cl, err := restful.NewClient(mainSrv.URL, logging.SilentLogSet())
@@ -562,7 +564,7 @@ func TestStatusPoller_OldServer(t *testing.T) {
 	mainSrv := httptest.NewServer(http.HandlerFunc(h))
 
 	rf := &ResolveFilter{
-		Repo: "github.com/something/summat",
+		Repo: NewResolveFieldMatcher("github.com/something/summat"),
 	}
 
 	cl, err := restful.NewClient(mainSrv.URL, logging.SilentLogSet())

--- a/server/handle_gdm.go
+++ b/server/handle_gdm.go
@@ -20,7 +20,7 @@ type (
 
 	// GETGDMHandler is an injectable request handler
 	GETGDMHandler struct {
-		*logging.LogSet
+		logging.LogSet
 		GDM      *sous.State
 		RzWriter http.ResponseWriter
 	}
@@ -28,7 +28,7 @@ type (
 	// PUTGDMHandler is an injectable request handler
 	PUTGDMHandler struct {
 		*http.Request
-		*logging.LogSet
+		logging.LogSet
 		GDM          *sous.State
 		StateManager sous.StateManager
 		User         ClientUser

--- a/server/handle_manifest.go
+++ b/server/handle_manifest.go
@@ -30,7 +30,7 @@ type (
 	// PUTManifestHandler handles PUT exchanges for manifests
 	PUTManifestHandler struct {
 		*sous.State
-		*logging.LogSet
+		logging.LogSet
 		*http.Request
 		restful.QueryValues
 		User        ClientUser

--- a/server/handle_servers.go
+++ b/server/handle_servers.go
@@ -25,7 +25,7 @@ type (
 	ServerListUpdater struct {
 		*http.Request
 		Config *config.Config
-		Log    *logging.LogSet
+		Log    logging.LogSet
 	}
 )
 

--- a/server/server.go
+++ b/server/server.go
@@ -29,7 +29,7 @@ type (
 	// ComponentLocator is a service locator for the Sous components that server
 	// endpoints need to function.
 	ComponentLocator struct {
-		*logging.LogSet
+		logging.LogSet
 		*config.Config
 		sous.Inserter
 		sous.StateManager

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -121,16 +121,16 @@ func newls(name string, err io.Writer) *LogSet {
 }
 
 // Vomitf is a simple wrapper on Vomit.Printf
-func (ls LogSet) Vomitf(f string, as ...interface{}) { ls.vomit.Output(3, fmt.Sprintf(f, as...)) }
-func (ls LogSet) vomitf(f string, as ...interface{}) { ls.vomit.Output(4, fmt.Sprintf(f, as...)) }
+func (ls LogSet) Vomitf(f string, as ...interface{}) { ls.vomit.Output(2, fmt.Sprintf(f, as...)) }
+func (ls LogSet) vomitf(f string, as ...interface{}) { ls.vomit.Output(2, fmt.Sprintf(f, as...)) }
 
 // Debugf is a simple wrapper on Debug.Printf
-func (ls LogSet) Debugf(f string, as ...interface{}) { ls.debug.Output(3, fmt.Sprintf(f, as...)) }
-func (ls LogSet) debugf(f string, as ...interface{}) { ls.debug.Output(4, fmt.Sprintf(f, as...)) }
+func (ls LogSet) Debugf(f string, as ...interface{}) { ls.debug.Output(2, fmt.Sprintf(f, as...)) }
+func (ls LogSet) debugf(f string, as ...interface{}) { ls.debug.Output(2, fmt.Sprintf(f, as...)) }
 
 // Warnf is a simple wrapper on Warn.Printf
-func (ls LogSet) Warnf(f string, as ...interface{}) { ls.warn.Output(3, fmt.Sprintf(f, as...)) }
-func (ls LogSet) warnf(f string, as ...interface{}) { ls.warn.Output(4, fmt.Sprintf(f, as...)) }
+func (ls LogSet) Warnf(f string, as ...interface{}) { ls.warn.Output(2, fmt.Sprintf(f, as...)) }
+func (ls LogSet) warnf(f string, as ...interface{}) { ls.warn.Output(2, fmt.Sprintf(f, as...)) }
 
 func (ls LogSet) imposeLevel() {
 	ls.vomit.SetOutput(ioutil.Discard)

--- a/util/logging/metrics.go
+++ b/util/logging/metrics.go
@@ -53,13 +53,13 @@ func (u *multiUpdate) Update(n int64) {
 }
 
 // HasMetrics indicates whether this LogSet has been configured with metrics
-func (ls *LogSet) HasMetrics() bool {
+func (ls LogSet) HasMetrics() bool {
 	return ls.metrics != nil
 }
 
 // ExpHandler returns an http.Handler to export metrics registered with this LogSet.
 // panics if the LogSet hasn't been set up with metrics yet.
-func (ls *LogSet) ExpHandler() http.Handler {
+func (ls LogSet) ExpHandler() http.Handler {
 	if ls.metrics == nil {
 		panic("LogSet metric unset!")
 	}
@@ -67,7 +67,7 @@ func (ls *LogSet) ExpHandler() http.Handler {
 }
 
 // GetTimer returns a timer so that components can record timing metrics.
-func (ls *LogSet) GetTimer(name string) Timer {
+func (ls LogSet) GetTimer(name string) Timer {
 	if ls.metrics == nil {
 		return metrics.NilTimer{}
 	}
@@ -75,7 +75,7 @@ func (ls *LogSet) GetTimer(name string) Timer {
 }
 
 // GetCounter returns a counter so that components can count things.
-func (ls *LogSet) GetCounter(name string) Counter {
+func (ls LogSet) GetCounter(name string) Counter {
 	if ls.metrics == nil {
 		return metrics.NilCounter{}
 	}
@@ -83,7 +83,7 @@ func (ls *LogSet) GetCounter(name string) Counter {
 }
 
 // GetUpdater returns an updater that records both the immediate value and a decaying sample.
-func (ls *LogSet) GetUpdater(name string) Updater {
+func (ls LogSet) GetUpdater(name string) Updater {
 	if ls.metrics == nil {
 		return metrics.NilGauge{}
 	}

--- a/util/restful/client.go
+++ b/util/restful/client.go
@@ -164,7 +164,7 @@ func (client *LiveHTTPClient) Retrieve(urlPath string, qParms map[string]string,
 		state.path = urlPath
 		state.qparms = qParms
 	}
-	return state, errors.Wrapf(err, "Retrieve %s", urlPath)
+	return state, errors.Wrapf(err, "Retrieve %s %v", urlPath, qParms)
 }
 
 // Create uses the contents of qBody to create a new resource at the server at urlPath/qParms
@@ -176,7 +176,7 @@ func (client *LiveHTTPClient) Create(urlPath string, qParms map[string]string, q
 		rz, err := client.sendRequest(rq, err)
 		_, err = client.getBody(rz, nil, err)
 		return err
-	}(), "Create %s", urlPath)
+	}(), "Create %s %v", urlPath, qParms)
 }
 
 func (client *LiveHTTPClient) deelete(urlPath string, qParms map[string]string, from *resourceState, headers map[string]string) error {
@@ -187,7 +187,7 @@ func (client *LiveHTTPClient) deelete(urlPath string, qParms map[string]string, 
 		rz, err := client.sendRequest(rq, err)
 		_, err = client.getBody(rz, nil, err)
 		return err
-	}(), "Delete %s", urlPath)
+	}(), "Delete %s %v", urlPath, qParms)
 }
 
 func (client *LiveHTTPClient) update(urlPath string, qParms map[string]string, from *resourceState, qBody Comparable, headers map[string]string) error {
@@ -199,7 +199,7 @@ func (client *LiveHTTPClient) update(urlPath string, qParms map[string]string, f
 		rz, err := client.sendRequest(rq, err)
 		_, err = client.getBody(rz, nil, err)
 		return err
-	}(), "Update %s", urlPath)
+	}(), "Update %s %v", urlPath, qParms)
 }
 
 // Create implements HTTPClient on DummyHTTPClient - it does nothing and returns nil


### PR DESCRIPTION
While investigating a report that `sous deploy -flavor ...` times out,
I did a fair amount of refactoring to logging and filters.

Once that was complete, I've come to the conclusion that the issue is
data-related (i.e. I think manifests went missing from the GDM.)
Visibility is improved though, as is consistency of filter handling.

Issue raised: different commands may have different "glob" behavior for
the deploy filters.