### PR TITLE
Fixes a bug in the splitbuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ with respect to its command line interface and HTTP interface.
 ### Changed
 - Developer: Refactors of filters and logging. Mostly to the good.
 
+### Fixed
+- Client: `sous build` for split containers was adding a path component,
+  which broke the resulting deploy container.
+
 ## [0.5.31](//github.com/opentable/sous/compare/0.5.30...0.5.31)
 ### Fixed
 - Client: `sous init` defaults resources correctly in the absence of other input.

--- a/ext/docker/splitcontainer_runnablebuilder.go
+++ b/ext/docker/splitcontainer_runnablebuilder.go
@@ -45,7 +45,7 @@ func (rb *runnableBuilder) extractFiles() error {
 		fromPath := fmt.Sprintf("%s:%s", sb.buildContainerID, inst.Source.Dir)
 		toPath := filepath.Join(rb.buildDir(), inst.Destination.Dir)
 
-		err := os.MkdirAll(toPath, os.ModePerm)
+		err := os.MkdirAll(filepath.Dir(toPath), os.ModePerm)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Because of how Docker handles `docker cp` paths,
and how Go's filepath handles joining,
there's an oddity about how run containers were being build.
This fixes the extra path component that was being added.