### PR TITLE
Fix panic caused when using ignore-otpl-deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ with respect to its command line interface and HTTP interface.
 ## [Unreleased](//github.com/opentable/sous/compare/0.5.33...HEAD)
 ### Fixed
 - Client: `sous init -use-otpl-deploy` wasn't handling flavors properly.
+- Client: `sous init -ignore-otpl-deploy` caused panic.
 
 ## [0.5.33](//github.com/opentable/sous/compare/0.5.32...0.5.33)
 ### Added

--- a/graph/otpldeploy.go
+++ b/graph/otpldeploy.go
@@ -12,7 +12,7 @@ import (
 
 func newDetectedOTPLConfig(wd LocalWorkDirShell, otplFlags *config.OTPLFlags) (detectedOTPLDeployManifest, error) {
 	if otplFlags.IgnoreOTPLDeploy {
-		return detectedOTPLDeployManifest{}, nil
+		return detectedOTPLDeployManifest{sous.NewManifests()}, nil
 	}
 	otplParser := otpl.NewManifestParser()
 	otplDeploySpecs := otplParser.ParseManifests(wd.Sh)


### PR DESCRIPTION
sous init -flavor EU -ignore-otpl-deploy
panic: uninitialised Manifests (you should use NewManifests)

goroutine 99 [running]:
panic(0x47bcf00, 0xc4205f0040)
        /usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/opentable/sous/lib.Manifests.read(0x0, 0x0, 0xc4205db478)
        /ext-go/1/src/github.com/opentable/sous/lib/manifests_generated.go:36 +0xde
github.com/opentable/sous/lib.Manifests.Len(0x0, 0x0, 0x4030170)
        /ext-go/1/src/github.com/opentable/sous/lib/manifests_generated.go:211 +0x68
github.com/opentable/sous/graph.newUserSelectedOTPLDeploySpecs(0x0, 0x0, 0xc420530ab0, 0x28, 0x0, 0x0, 0x7fff5fbff4ca, 0x2, 0xc4200ec8e8, 0xc42047f880, ...)
        /ext-go/1/src/github.com/opentable/sous/graph/otpldeploy.go:30 +0xba
reflect.Value.call(0x4800700, 0x4957388, 0x13, 0x48b319b, 0x4, 0xc420516000, 0x4, 0x4, 0xc41ffeb7fe, 0x0, ...)
        /usr/local/go/src/reflect/value.go:434 +0x5c8
reflect.Value.Call(0x4800700, 0x4957388, 0x13, 0xc420516000, 0x4, 0x4, 0x1000000001640, 0x10, 0x18)
        /usr/local/go/src/reflect/value.go:302 +0xa4
github.com/opentable/sous/vendor/github.com/samsalisbury/psyringe.newCtor.func1(0xc420516000, 0x4, 0x4, 0xc420018270, 0xc42001daa0, 0x3, 0x4cc5f20, 0x4857c40)
        /ext-go/1/src/github.com/opentable/sous/vendor/github.com/samsalisbury/psyringe/ctor.go:48 +0xc7
github.com/opentable/sous/vendor/github.com/samsalisbury/psyringe.(*ctor).manifest(0xc42001daa0, 0xc420018270)
        /ext-go/1/src/github.com/opentable/sous/vendor/github.com/samsalisbury/psyringe/ctor.go:110 +0x21e
created by github.com/opentable/sous/vendor/github.com/samsalisbury/psyringe.(*ctor).getValue.func1
        /ext-go/1/src/github.com/opentable/sous/vendor/github.com/samsalisbury/psyringe/ctor.go:82 +0x47
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x428926e]

goroutine 88 [running]:
panic(0x47fa260, 0xc4200121b0)
        /usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/opentable/sous/vendor/github.com/samsalisbury/psyringe.(*ctor).getValue(0xc42001daa0, 0xc420018270, 0xc420030eb8, 0xc42048c658, 0x1, 0xc4200ec908, 0x8)
        /ext-go/1/src/github.com/opentable/sous/vendor/github.com/samsalisbury/psyringe/ctor.go:85 +0xce
github.com/opentable/sous/vendor/github.com/samsalisbury/psyringe.(*Psyringe).getValueForConstructor(0xc420018270, 0xc420490240, 0x0, 0x4cc5f20, 0x487ece0, 0xc4200ec908, 0x199, 0x48954e0, 0xc4203131e8, 0x99)
        /ext-go/1/src/github.com/opentable/sous/vendor/github.com/samsalisbury/psyringe/psyringe.go:330 +0x113
github.com/opentable/sous/vendor/github.com/samsalisbury/psyringe.(*ctor).manifest.func1(0xc4204b8000, 0xc420018270, 0xc420490240, 0x0, 0x4cc5f20, 0x487ece0, 0xc4203119f0, 0x3, 0x3)
        /ext-go/1/src/github.com/opentable/sous/vendor/github.com/samsalisbury/psyringe/ctor.go:102 +0xa3
created by github.com/opentable/sous/vendor/github.com/samsalisbury/psyringe.(*ctor).manifest
        /ext-go/1/src/github.com/opentable/sous/vendor/github.com/samsalisbury/psyringe/ctor.go:107 +0x175