### PR TITLE
Commands were using logging.LogSet directly TECHOPS-3149 TECHOPS-3152

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ with respect to its command line interface and HTTP interface.
 ## [Unreleased](//github.com/opentable/sous/compare/0.5.33...HEAD)
 ### Fixed
 - Client: `sous init -use-otpl-deploy` wasn't handling flavors properly.
+- Server: Logging wasn't being properly initialized and crashed on boot.
 
 ## [0.5.33](//github.com/opentable/sous/compare/0.5.32...0.5.33)
 ### Added

--- a/cli/sous.go
+++ b/cli/sous.go
@@ -6,7 +6,6 @@ import (
 	"github.com/opentable/sous/config"
 	"github.com/opentable/sous/graph"
 	"github.com/opentable/sous/util/cmdr"
-	"github.com/opentable/sous/util/logging"
 	"github.com/opentable/sous/util/whitespace"
 	"github.com/samsalisbury/semv"
 )
@@ -16,7 +15,7 @@ type Sous struct {
 	// CLI is a reference to the CLI singleton. We use it here to set global
 	// verbosity.
 	CLI *CLI
-	logging.LogSet
+	graph.LogSink
 	// Err is the error message stream.
 	Err *graph.ErrOut
 	// Version is the version of Sous itself.

--- a/cli/sous_server.go
+++ b/cli/sous_server.go
@@ -11,7 +11,6 @@ import (
 	"github.com/opentable/sous/lib"
 	"github.com/opentable/sous/server"
 	"github.com/opentable/sous/util/cmdr"
-	"github.com/opentable/sous/util/logging"
 	"github.com/opentable/sous/util/shell"
 )
 
@@ -19,7 +18,7 @@ import (
 type SousServer struct {
 	Sous              *Sous
 	DeployFilterFlags config.DeployFilterFlags
-	Log               logging.LogSet
+	Log               graph.LogSink
 
 	*config.Config
 	graph.ServerHandler
@@ -71,15 +70,15 @@ func (ss *SousServer) RegisterOn(psy Addable) {
 
 // Execute is part of the cmdr.Command interface(s).
 func (ss *SousServer) Execute(args []string) cmdr.Result {
-	if err := ensureGDMExists(ss.flags.gdmRepo, ss.Config.StateLocation, ss.Log.Info.Printf); err != nil {
+	if err := ensureGDMExists(ss.flags.gdmRepo, ss.Config.StateLocation, ss.Log.Warnf); err != nil {
 		return EnsureErrorResult(err)
 	}
-	ss.Log.Info.Println("Starting scheduled GDM resolution.")
-	ss.Log.Debug.Print("Filtering the GDM to resolve on this server to: %v", ss.DeployFilterFlags)
+	ss.Log.Warnf("Starting scheduled GDM resolution.")
+	ss.Log.Warnf("Filtering the GDM to resolve on this server to: %v", ss.DeployFilterFlags)
 
 	ss.AutoResolver.Kickoff()
 
-	ss.Log.Info.Printf("Sous Server v%s running at %s for %s", ss.Sous.Version, ss.flags.laddr, ss.DeployFilterFlags.Cluster)
+	ss.Log.Warnf("Sous Server v%s running at %s for %s", ss.Sous.Version, ss.flags.laddr, ss.DeployFilterFlags.Cluster)
 
 	if os.Getenv("SOUS_PROFILING") == "enable" {
 		ss.flags.profiling = true

--- a/util/logging/config.go
+++ b/util/logging/config.go
@@ -125,12 +125,12 @@ func (cfg Config) Validate() error {
 }
 
 func (cfg Config) validateKafka() error {
-	switch cfg.Kafka.DefaultLevel {
-	default:
-		return errors.Errorf("default Kafka log level unrecognized: configured as %q", cfg.Kafka.DefaultLevel)
-	case "":
+	if cfg.Kafka.DefaultLevel == "" {
 		return errors.Errorf("default Kafka log level empty")
-	case "Critical", "Warning", "Information", "Debug", "ExtraDebug1":
+	}
+
+	if levelFromString(cfg.Kafka.DefaultLevel) == ExtremeLevel {
+		return errors.Errorf("default Kafka log level unrecognized: configured as %q", cfg.Kafka.DefaultLevel)
 	}
 
 	switch {


### PR DESCRIPTION
Everything should be using the LogSink interface, not LogSet

n.b. that there are many uses of the global logging.Log LogSet - which
means that e.g. the logwrappers can't be removed yet - the correct
behavior, where possible, should be to replace those uses with injected
LogSinks.

TECHOPS-3149 TECHOPS-3152