### PR TITLE
Fixes DB DDL related race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ with respect to its command line interface and HTTP interface.
 ### Fixed
 - Client: If only one otpl config found with no flavor, and a flavor is specified the found config was used.
 - Client: If only one otpl config found for only one flavor, and no flavor or different flavor specified the found config was used.
+- Server: Initial database grooming had a race condition. Solved by ensuring NameCache is singular.
 
 ### Changed
 - Client: Improve testability of default OT_ENV_FLAVOR logic and test.

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/opentable/sous/config"
-	"github.com/opentable/sous/ext/docker"
 	"github.com/opentable/sous/ext/storage"
 	"github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/logging"
@@ -111,34 +110,6 @@ func TestStateManagerSelectsGit(t *testing.T) {
 
 	if _, ok := smgr.StateManager.(*storage.GitStateManager); !ok {
 		t.Errorf("Injected %#v which isn't a GitStateManager", smgr.StateManager)
-	}
-}
-
-func testBuildInserter(t *testing.T, serverStr string) sous.Inserter {
-	ins, err := newInserter(LocalSousConfig{Config: &config.Config{
-		Server: serverStr,
-		Docker: docker.Config{
-			DatabaseDriver:     "sqlite3_sous",
-			DatabaseConnection: docker.InMemory,
-		},
-	}}, LogSink{logging.SilentLogSet()}, LocalDockerClient{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	return ins
-}
-
-func TestNameInserterSelectsNameCache(t *testing.T) {
-	ins := testBuildInserter(t, "")
-	if _, ok := ins.(*docker.NameCache); !ok {
-		t.Errorf("Injected %#v which isn't a docker.NameCache", ins)
-	}
-}
-
-func TestNameInserterSelectsHTTP(t *testing.T) {
-	ins := testBuildInserter(t, "http//example.com")
-	if _, ok := ins.(*sous.HTTPNameInserter); !ok {
-		t.Errorf("Injected %#v which isn't a docker.NameCache", ins)
 	}
 }
 

--- a/integration/deployment_builder_test.go
+++ b/integration/deployment_builder_test.go
@@ -49,7 +49,8 @@ func TestBuildDeployments(t *testing.T) {
 	clusterNick := "tcluster"
 	reqID := appLocation + clusterNick
 
-	nc := docker.NewNameCache("", drc, logging.SilentLogSet(), db)
+	nc, err := docker.NewNameCache("", drc, logging.SilentLogSet(), db)
+	assert.NoError(err)
 
 	singCl := sing.NewClient(SingularityURL)
 	//singCl.Debug = true

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -100,7 +100,9 @@ func (suite *integrationSuite) newNameCache(name string) *docker.NameCache {
 
 	suite.Require().NoError(err)
 
-	return docker.NewNameCache(registryName, suite.registry, logging.NewLogSet(semv.MustParse("0.0.0"), "", os.Stdout), db)
+	cache, err := docker.NewNameCache(registryName, suite.registry, logging.NewLogSet(semv.MustParse("0.0.0"), "", os.Stdout), db)
+	suite.Require().NoError(err)
+	return cache
 }
 
 func (suite *integrationSuite) waitUntilSettledStatus(clusters []string, sourceRepo string) *sous.DeployState {


### PR DESCRIPTION
* Wraps DDL modifications in a Once
* Reports on errors from the DDL change
* "scoops" out NameCaches instead of reusing the constructor