### PR TITLE
Restores debugging flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.37...HEAD)
+
+### Fixed
+* All: restores -d and -v flags
+
 ## [0.5.37](//github.com/opentable/sous/compare/0.5.36...0.5.37)
 
 ### Fixed

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/opentable/sous/ext/docker"
 	"github.com/opentable/sous/graph"
 	"github.com/opentable/sous/util/cmdr"
 	"github.com/opentable/sous/util/logging"
@@ -137,18 +136,6 @@ func NewSousCLI(di *graph.SousGraph, s *Sous, out, errout io.Writer) (*CLI, erro
 	chain := []cmdr.Command{}
 	rootGraph := BuildCLIGraph(s, cli, out, errout)
 	s.RegisterOn(rootGraph)
-
-	/*
-		This ensures the singularity of the field types - otherwise, if they're
-		injected twice and we have issues.
-
-		This is a temporary fix ahead of transitioning to a simpler DI.
-		 - jdl 9/28/17
-	*/
-	fixedPoint := struct {
-		*docker.NameCache
-	}{}
-	rootGraph.MustInject(&fixedPoint)
 
 	cli.scopedGraphs = map[cmdr.Command]*graph.SousGraph{s: rootGraph}
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -388,8 +388,7 @@ func TestInvokeRectifyWithDebugFlags(t *testing.T) {
 	require := require.New(t)
 
 	// XXX see below
-	//_, exe, _, stderr := prepareCommand(t, []string{`sous`, `rectify`, `-d`, `-v`, `-all`})
-	_, exe, _, _ := prepareCommand(t, []string{`sous`, `rectify`, `-d`, `-v`, `-all`})
+	_, exe, _, stderr := prepareCommand(t, []string{`sous`, `rectify`, `-d`, `-v`, `-all`})
 	assert.Len(exe.Args, 0)
 	require.IsType(&SousRectify{}, exe.Cmd)
 
@@ -399,11 +398,8 @@ func TestInvokeRectifyWithDebugFlags(t *testing.T) {
 	assert.NotNil(rect.GDM)
 	require.NotNil(rect.SourceFlags)
 	assert.Equal(rect.SourceFlags.All, true)
-	/*
-		XXX this mechanism needs to be reinstated, but it'll have to be after current outage is fixed
-		assert.Regexp(`Verbose debugging`, stderr.String())
-		assert.Regexp(`Regular debugging`, stderr.String())
-	*/
+	assert.Regexp(`Verbose debugging`, stderr.String())
+	assert.Regexp(`Regular debugging`, stderr.String())
 }
 
 func TestInvokeRectifyDryruns(t *testing.T) {

--- a/cli/sous.go
+++ b/cli/sous.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	"github.com/opentable/sous/config"
+	"github.com/opentable/sous/ext/docker"
 	"github.com/opentable/sous/graph"
 	"github.com/opentable/sous/util/cmdr"
 	"github.com/opentable/sous/util/whitespace"
@@ -31,6 +32,16 @@ type Sous struct {
 		Help bool
 		config.Verbosity
 	}
+
+	/*
+		This ensures the singularity of the field types - otherwise, if they're
+		injected twice and we have issues.
+
+		This is a temporary fix ahead of transitioning to a simpler DI.
+		 - jdl 9/28/17
+	*/
+	// added as a field here so that it will be singleton for the app
+	SingletonNameCache *docker.NameCache
 }
 
 // TopLevelCommands is populated once per command file (beginning sous_) in this


### PR DESCRIPTION
Previous fix for the singleton NameCacheb
knowingly broke -d and -v.

This approach gets us both options.