### PR TITLE
Eliminate segfault on server HTTP error

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -284,10 +284,10 @@
 			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
-			"checksumSHA1": "dH+qw8ZPrERZljJeM2FesLFlpyg=",
+			"checksumSHA1": "MPzOOIKBzAz8il3ng/fgbdxBJGM=",
 			"path": "github.com/samsalisbury/psyringe",
-			"revision": "5f46c5431ed3997dd5c1a78cd6580aad8329fce9",
-			"revisionTime": "2017-02-11T10:25:57Z"
+			"revision": "afa419dfe20cdfb9c1ed69eb5ea6e400f32954ec",
+			"revisionTime": "2017-10-05T11:45:37Z"
 		},
 		{
 			"checksumSHA1": "IRgb8yeKkWGY5gp1TLk9rpGitB0=",


### PR DESCRIPTION
Also prints an HTTP error message in some cases. ~Note that because injection order is nondeterministic, when the server is down you will see one of 3 error messages when server unavailable.~

**EDIT:** Fixed a bug in psyringe that was allowing constructors to be called despite one of their dependencies failing. This has the result that we now get stable error messages including the HTTP status code returned from the server. See https://github.com/samsalisbury/psyringe/commit/afa419dfe20cdfb9c1ed69eb5ea6e400f32954ec