### PR TITLE
Reporting orthodoxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ with respect to its command line interface and HTTP interface.
 * All: ot_* fields are actually populated - also instance-no
 * All: metrics are scoped to env and region so that multiple sous instances don't
   clobber each other's metrics.
-* All: component-id as used moved to "logger" field, in line with usage elsewhere
-* All: component-id is either sous-server or sous-client.
 
 ## [0.5.40](//github.com/opentable/sous/compare/0.5.39..0.5.40)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.40..HEAD)
+
+### Fixed
+
+* All: ot_* fields are actually populated - also instance-no
+* All: metrics are scoped to env and region so that multiple sous instances don't
+  clobber each other's metrics.
+* All: component-id as used moved to "logger" field, in line with usage elsewhere
+* All: component-id is either sous-server or sous-client.
 
 ## [0.5.40](//github.com/opentable/sous/compare/0.5.39..0.5.40)
 

--- a/util/logging/applicationid.go
+++ b/util/logging/applicationid.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"os"
+	"strconv"
 
 	"github.com/samsalisbury/semv"
 )
@@ -20,10 +21,10 @@ type applicationID struct {
 	sequenceNumber     uint
 }
 
-func collectAppID(version semv.Version) *applicationID {
+func collectAppID(version semv.Version, env map[string]string) *applicationID {
 	id := applicationID{}
 	getenv := func(n string) string {
-		v, found := os.LookupEnv("OTENV")
+		v, found := env[n]
 		if !found {
 			return "unknown"
 		}
@@ -33,7 +34,9 @@ func collectAppID(version semv.Version) *applicationID {
 	id.otenvtype = getenv("OT_ENV_TYPE")
 	id.otenvlocation = getenv("OT_ENV_LOCATION")
 	id.singularitytaskid = getenv("TASK_ID")
-
+	if i, err := strconv.ParseUint(getenv("INSTANCE_NO"), 10, 32); err == nil {
+		id.instanceno = uint(i)
+	}
 	host, err := os.Hostname()
 	id.host = host
 	if err != nil {

--- a/util/logging/applicationid.go
+++ b/util/logging/applicationid.go
@@ -72,3 +72,7 @@ func (id *applicationID) EachField(f FieldReportFn) {
 		  singularity-task-id:
 	*/
 }
+
+func (id *applicationID) metricsScope() string {
+	return id.otenvtype + "." + id.otenvlocation
+}

--- a/util/logging/applicationid_test.go
+++ b/util/logging/applicationid_test.go
@@ -1,0 +1,32 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/samsalisbury/semv"
+)
+
+func TestApplicationId(t *testing.T) {
+	apid := collectAppID(semv.MustParse("2.3.9"), map[string]string{
+		"OT_ENV":          "staging-luna",
+		"OT_ENV_TYPE":     "staging",
+		"OT_ENV_LOCATION": "luna",
+		"TASK_ID":         "cabbage",
+		"INSTANCE_NO":     "17",
+	})
+
+	variableFields := []string{"host"}
+
+	fixedFields := map[string]interface{}{
+		"ot-env":              "staging-luna",
+		"application-version": "2.3.9",
+		"ot-env-type":         "staging",
+		"ot-env-location":     "luna",
+		"singularity-task-id": "cabbage",
+		"service-type":        "sous",
+		"instance-no":         uint(17),
+		"sequence-number":     uint(1), // a little fragile
+	}
+
+	AssertMessageFields(t, apid, variableFields, fixedFields)
+}

--- a/util/logging/applicationid_test.go
+++ b/util/logging/applicationid_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 
 	"github.com/samsalisbury/semv"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestApplicationId(t *testing.T) {
+func TestApplicationIdMessageFields(t *testing.T) {
 	apid := collectAppID(semv.MustParse("2.3.9"), map[string]string{
 		"OT_ENV":          "staging-luna",
 		"OT_ENV_TYPE":     "staging",
@@ -15,18 +16,24 @@ func TestApplicationId(t *testing.T) {
 		"INSTANCE_NO":     "17",
 	})
 
-	variableFields := []string{"host"}
+	t.Run("MessageFields", func(t *testing.T) {
+		variableFields := []string{"host"}
 
-	fixedFields := map[string]interface{}{
-		"ot-env":              "staging-luna",
-		"application-version": "2.3.9",
-		"ot-env-type":         "staging",
-		"ot-env-location":     "luna",
-		"singularity-task-id": "cabbage",
-		"service-type":        "sous",
-		"instance-no":         uint(17),
-		"sequence-number":     uint(1), // a little fragile
-	}
+		fixedFields := map[string]interface{}{
+			"ot-env":              "staging-luna",
+			"application-version": "2.3.9",
+			"ot-env-type":         "staging",
+			"ot-env-location":     "luna",
+			"singularity-task-id": "cabbage",
+			"service-type":        "sous",
+			"instance-no":         uint(17),
+			"sequence-number":     uint(1), // a little fragile
+		}
 
-	AssertMessageFields(t, apid, variableFields, fixedFields)
+		AssertMessageFields(t, apid, variableFields, fixedFields)
+	})
+
+	t.Run("MetricsScope", func(t *testing.T) {
+		assert.Equal(t, "staging.luna", apid.metricsScope())
+	})
 }

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -92,10 +92,11 @@ func NewLogSet(version semv.Version, name string, err io.Writer) *LogSet {
 	ls := newls(name, WarningLevel, bundle)
 	ls.imposeLevel()
 
+	// use sous.<env>.<region>.*, he said
 	if name == "" {
-		ls.metrics = metrics.NewRegistry()
+		ls.metrics = metrics.NewPrefixedRegistry("sous." + bundle.appIdent.metricsScope())
 	} else {
-		ls.metrics = metrics.NewPrefixedRegistry(name + ".")
+		ls.metrics = metrics.NewPrefixedRegistry(name + "." + bundle.appIdent.metricsScope())
 	}
 	return ls
 }

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -107,9 +107,26 @@ func (ls LogSet) Child(name string) LogSink {
 	return child
 }
 
+func getEnvHash() map[string]string {
+	h := map[string]string{}
+	get := func(n string) {
+		if v, has := os.LookupEnv(n); has {
+			h[n] = v
+		}
+	}
+	get("OT_ENV")
+	get("OT_ENV_TYPE")
+	get("OT_ENV_LOCATION")
+	get("TASK_ID")
+	get("INSTANCE_NO")
+	return h
+}
+
 func newdb(vrsn semv.Version, err io.Writer, lgrs *logrus.Logger) *dumpBundle {
+	env := getEnvHash()
+
 	return &dumpBundle{
-		appIdent:   collectAppID(vrsn),
+		appIdent:   collectAppID(vrsn, env),
 		context:    context.Background(),
 		err:        err,
 		defaultErr: err,

--- a/util/logging/messages.go
+++ b/util/logging/messages.go
@@ -112,11 +112,15 @@ type (
 		io.Writer
 	}
 
+	eachFielder interface {
+		EachField(FieldReportFn)
+	}
+
 	// A LogMessage has structured data to report to a log (c.f. Deliver)
 	LogMessage interface {
 		DefaultLevel() Level
 		Message() string
-		EachField(FieldReportFn)
+		eachFielder
 	}
 
 	// A MetricsMessage has metrics data to record (c.f. Deliver)

--- a/util/logging/messages/messages_test.go
+++ b/util/logging/messages/messages_test.go
@@ -32,24 +32,20 @@ func TestReportCHResponseFields(t *testing.T) {
 		"time":logging.callTime{sec:63639633602, nsec:854240181, loc:(*time.Location)(0x8f3780)},
 	*/
 
-	variableFields := []string{"call-stack-line-number", "call-stack-function", "call-stack-file", "@timestamp", "thread-name"}
-	for _, f := range variableFields {
-		assert.Contains(t, actualFields, f)
-		delete(actualFields, f)
-	}
-
-	assert.Equal(t, map[string]interface{}{
-		"@loglov3-otl":    "http-v1",
-		"incoming":        false,
-		"method":          "GET",
-		"url":             "http://example.com/api?a=a",
-		"url-hostname":    "example.com",
-		"url-pathname":    "/api",
-		"url-querystring": "a=a",
-		"duration":        time.Duration(30000000),
-		"body-size":       int64(0),
-		"response-size":   int64(123),
-		"status":          200,
-	}, actualFields)
+	logging.AssertMessageFields(t, message,
+		[]string{"call-stack-line-number", "call-stack-function", "call-stack-file", "@timestamp", "thread-name"},
+		map[string]interface{}{
+			"@loglov3-otl":    "http-v1",
+			"incoming":        false,
+			"method":          "GET",
+			"url":             "http://example.com/api?a=a",
+			"url-hostname":    "example.com",
+			"url-pathname":    "/api",
+			"url-querystring": "a=a",
+			"duration":        time.Duration(30000000),
+			"body-size":       int64(0),
+			"response-size":   int64(123),
+			"status":          200,
+		})
 
 }

--- a/util/logging/testsupport.go
+++ b/util/logging/testsupport.go
@@ -2,9 +2,11 @@ package logging
 
 import (
 	"fmt"
+	"testing"
 	"time"
 
 	"github.com/nyarly/spies"
+	"github.com/stretchr/testify/assert"
 )
 
 type (
@@ -135,4 +137,24 @@ func (wds writeDonerSpy) Write(p []byte) (n int, err error) {
 
 func (wds writeDonerSpy) Done() {
 	wds.spy.Called()
+}
+
+// AssertMessageFields is a testing function - it receives an eachFielder and confirms that it:
+//  * generates no duplicate fields
+//  * generates fields with the names in variableFields, and ignores their values
+//  * generates fields with the names and values in fixedFields
+func AssertMessageFields(t *testing.T, msg eachFielder, variableFields []string, fixedFields map[string]interface{}) {
+	actualFields := map[string]interface{}{}
+
+	msg.EachField(func(name string, value interface{}) {
+		assert.NotContains(t, actualFields, name) //don't clobber a field
+		actualFields[name] = value
+	})
+
+	for _, f := range variableFields {
+		assert.Contains(t, actualFields, f)
+		delete(actualFields, f)
+	}
+
+	assert.Equal(t, fixedFields, actualFields)
 }


### PR DESCRIPTION
Adds metrics scope (sous.<env>.<region>)
Pulls environment variables correctly into reports, instead of "unknown"