### PR TITLE
Startup.SkipCheck changes now results in re-deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.42..master)
+
+### Fixed
+* All: Changing Startup.SkipCheck now correctly results in a re-deploy with the
+  updated value.
+
 ## [0.5.42](//github.com/opentable/sous/compare/0.5.41..0.5.42)
 ### Fixed
 * All: Graphite output was like `sous.sous.ci.sfautoresolver.fullcycle-duration.count`, now `sous.ci.sf.auto...`

--- a/ext/singularity/deployment_builder.go
+++ b/ext/singularity/deployment_builder.go
@@ -414,6 +414,8 @@ func (db *deploymentBuilder) unpackDeployConfig() error {
 		for n, code := range db.deploy.Healthcheck.FailureStatusCodes {
 			db.Target.Startup.CheckReadyFailureStatuses[n] = int(code)
 		}
+	} else {
+		db.Target.Startup.SkipCheck = true
 	}
 
 	return nil

--- a/lib/startup.go
+++ b/lib/startup.go
@@ -226,6 +226,10 @@ func (s Startup) diff(o Startup) []string {
 		r = zeroStartup
 	}
 
+	if s.SkipCheck != o.SkipCheck {
+		diff("SkipCheck; this %v, other %v", s.SkipCheck, o.SkipCheck)
+	}
+
 	if l.ConnectDelay != r.ConnectDelay {
 		diff("ConnectDelay; this %d, other %d", l.ConnectDelay, r.ConnectDelay)
 	}

--- a/lib/startup_test.go
+++ b/lib/startup_test.go
@@ -137,3 +137,20 @@ func (s *StartupTest) TestMerge() {
 }
 
 // PutPut is guaranteed by the instance receiver
+
+func TestStartup_diff(t *testing.T) {
+	a := Startup{}
+	b := Startup{SkipCheck: true}
+	actualDiff := a.diff(b)
+	expected := "blah"
+	if len(actualDiff) == 0 {
+		t.Fatalf("no diff for %+v vs %+v", a, b)
+	}
+	if len(actualDiff) != 1 {
+		t.Fatalf("multiple diffs for %+v vs %+v (%+v)", a, b, actualDiff)
+	}
+	actual := actualDiff[0]
+	if actual != expected {
+		t.Fatalf("got diff %q; want %q", actual, expected)
+	}
+}

--- a/lib/startup_test.go
+++ b/lib/startup_test.go
@@ -142,7 +142,7 @@ func TestStartup_diff(t *testing.T) {
 	a := Startup{}
 	b := Startup{SkipCheck: true}
 	actualDiff := a.diff(b)
-	expected := "blah"
+	expected := `SkipCheck; this false, other true`
 	if len(actualDiff) == 0 {
 		t.Fatalf("no diff for %+v vs %+v", a, b)
 	}


### PR DESCRIPTION
* Diff method of Startup now diffs value of SkipCheck.
* Singularity DTO round-trips nil `SingularityDeployment.Healthcheck` as `Startup.SkipCheck = true`.