### PR TITLE
(WIP do not merge) Return current error from status pollers.

### DIFF
--- a/lib/status_poller_test.go
+++ b/lib/status_poller_test.go
@@ -79,7 +79,7 @@ func TestSubPoller_ComputeState(t *testing.T) {
 				Tag: NewResolveFieldMatcher(version),
 			},
 		}
-		if actual := sub.computeState(intent, current); expected != actual {
+		if actual, _ := sub.computeState(intent, current); expected != actual {
 			t.Errorf("sub.computeState(%v, %v) -> %v != %v", intent, current, actual, expected)
 		}
 	}


### PR DESCRIPTION
This is a quick spike to see how easy it is to get error messages from status endpoint to users/teamcity logs. It may turn into the actual solution for that if all goes well.

* Diff method of Startup now diffs value of SkipCheck.
* Singularity DTO round-trips nil `SingularityDeployment.Healthcheck` as `Startup.SkipCheck = true`.