### PR TITLE
Autodetect offset for deploy, manifest get & set 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.42...master)
+### Fixed
+* Client: commands 'sous deploy', 'sous manifest get' and 'sous manifest set' now receive the correct auto-detected offset
+  so you no longer require the -offset flag in most cases (unless you need to override it).
+
 ## [0.5.42](//github.com/opentable/sous/compare/0.5.41..0.5.42)
 ### Fixed
 * All: Graphite output was like `sous.sous.ci.sfautoresolver.fullcycle-duration.count`, now `sous.ci.sf.auto...`

--- a/cli/sous_manifest_get.go
+++ b/cli/sous_manifest_get.go
@@ -14,7 +14,7 @@ import (
 
 type SousManifestGet struct {
 	config.DeployFilterFlags
-	*sous.ResolveFilter
+	ResolveFilter *graph.RefinedResolveFilter
 	graph.TargetManifestID
 	graph.HTTPClient
 	graph.LogSink

--- a/cli/sous_manifest_set.go
+++ b/cli/sous_manifest_set.go
@@ -18,7 +18,7 @@ type SousManifestSet struct {
 	graph.TargetManifestID
 	graph.HTTPClient
 	graph.InReader
-	*sous.ResolveFilter
+	ResolveFilter graph.RefinedResolveFilter
 	graph.LogSink
 	User sous.User
 }

--- a/graph/sourcecontext_test.go
+++ b/graph/sourcecontext_test.go
@@ -97,4 +97,22 @@ func TestResolveSourceLocation_success(t *testing.T) {
 			OffsetDir:        "the/detected/offset",
 		},
 	)
+
+	// No flags, therefore use detected repo and offset.
+	assertSourceContextSuccess(t,
+		// expected
+		sous.ManifestID{
+			Source: sous.SourceLocation{
+				Repo: "github.com/original/context",
+				Dir:  "the/detected/offset",
+			},
+		},
+		// flags (empty)
+		&sous.ResolveFilter{},
+		// context
+		&sous.SourceContext{
+			PrimaryRemoteURL: "github.com/original/context",
+			OffsetDir:        "the/detected/offset",
+		},
+	)
 }

--- a/graph/sourcecontext_test.go
+++ b/graph/sourcecontext_test.go
@@ -39,24 +39,59 @@ func assertSourceContextSuccess(t *testing.T, expected sous.ManifestID, flags *s
 }
 
 func TestResolveSourceLocation_success(t *testing.T) {
+
+	// -repo set and matches detected repo, so that repo used.
 	assertSourceContextSuccess(t,
-		sous.ManifestID{Source: sous.SourceLocation{Repo: "github.com/user/project"}},
-		&sous.ResolveFilter{Repo: sous.NewResolveFieldMatcher("github.com/user/project")},
-		&sous.SourceContext{PrimaryRemoteURL: "github.com/user/project"},
+		// expected
+		sous.ManifestID{
+			Source: sous.SourceLocation{
+				Repo: "github.com/user/project",
+			},
+		},
+		// flags
+		&sous.ResolveFilter{
+			Repo: sous.NewResolveFieldMatcher("github.com/user/project"),
+		},
+		// context
+		&sous.SourceContext{
+			PrimaryRemoteURL: "github.com/user/project",
+		},
 	)
+
+	// -repo and -offset set, providing full SourceLocation.
 	assertSourceContextSuccess(t,
-		sous.ManifestID{Source: sous.SourceLocation{Repo: "github.com/user/project", Dir: "some/path"}},
-		&sous.ResolveFilter{Repo: sous.NewResolveFieldMatcher("github.com/user/project"), Offset: sous.NewResolveFieldMatcher("some/path")},
+		// expected
+		sous.ManifestID{
+			Source: sous.SourceLocation{
+				Repo: "github.com/user/project",
+				Dir:  "some/path",
+			},
+		},
+		// flags
+		&sous.ResolveFilter{
+			Repo:   sous.NewResolveFieldMatcher("github.com/user/project"),
+			Offset: sous.NewResolveFieldMatcher("some/path"),
+		},
+		// context
 		&sous.SourceContext{
 			PrimaryRemoteURL: "github.com/user/project",
 			OffsetDir:        "some/path",
 		},
 	)
+
+	// -repo set explicitly, therefore detected offset ignored.
 	assertSourceContextSuccess(t,
-		sous.ManifestID{Source: sous.SourceLocation{Repo: "github.com/from/flags"}},
+		// expected
+		sous.ManifestID{
+			Source: sous.SourceLocation{
+				Repo: "github.com/from/flags",
+			},
+		},
+		// flags
 		&sous.ResolveFilter{
 			Repo: sous.NewResolveFieldMatcher("github.com/from/flags"),
 		},
+		// context
 		&sous.SourceContext{
 			PrimaryRemoteURL: "github.com/original/context",
 			OffsetDir:        "the/detected/offset",

--- a/graph/sourcecontext_test.go
+++ b/graph/sourcecontext_test.go
@@ -33,9 +33,9 @@ func assertSourceContextSuccess(t *testing.T, expected sous.ManifestID, flags *s
 
 	actual, err := newTargetManifestID(rrf)
 	assert.NoError(t, err)
-	assert.Equal(t, actual.Source.Repo, expected.Source.Repo, "repos differ")
-	assert.Equal(t, actual.Source.Dir, expected.Source.Dir, "offsets differ")
-	assert.Equal(t, actual.Flavor, expected.Flavor, "flavors differ")
+	assert.Equal(t, expected.Source.Repo, actual.Source.Repo, "repos differ")
+	assert.Equal(t, expected.Source.Dir, actual.Source.Dir, "offsets differ")
+	assert.Equal(t, expected.Flavor, actual.Flavor, "flavors differ")
 }
 
 func TestResolveSourceLocation_success(t *testing.T) {
@@ -85,6 +85,7 @@ func TestResolveSourceLocation_success(t *testing.T) {
 		sous.ManifestID{
 			Source: sous.SourceLocation{
 				Repo: "github.com/from/flags",
+				Dir:  "",
 			},
 		},
 		// flags
@@ -108,7 +109,7 @@ func TestResolveSourceLocation_success(t *testing.T) {
 			},
 		},
 		// flags (empty)
-		&sous.ResolveFilter{},
+		nil,
 		// context
 		&sous.SourceContext{
 			PrimaryRemoteURL: "github.com/original/context",

--- a/graph/targetmanifest.go
+++ b/graph/targetmanifest.go
@@ -22,12 +22,18 @@ func newRefinedResolveFilter(f *sous.ResolveFilter, discovered *SourceContextDis
 		if c.PrimaryRemoteURL != "" {
 			rrf.Repo = sous.NewResolveFieldMatcher(c.PrimaryRemoteURL)
 		}
-		if rrf.Offset.All() && c.OffsetDir != "" {
+		if rrf.Offset.All() || *rrf.Offset.Match == "" {
 			rrf.Offset = sous.NewResolveFieldMatcher(c.OffsetDir)
 		}
 		if f.Tag.All() && discovered.SourceContext != nil && discovered.TagVersion() != "" {
 			rrf.SetTag(discovered.TagVersion())
 		}
+	} else {
+		var offset string
+		if rrf.Offset.Match != nil {
+			offset = *rrf.Offset.Match
+		}
+		rrf.Offset = sous.NewResolveFieldMatcher(offset)
 	}
 
 	if rrf.Repo.All() {

--- a/graph/targetmanifest_test.go
+++ b/graph/targetmanifest_test.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/opentable/sous/config"
@@ -253,4 +254,217 @@ func TestNewTargetManifest(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expected, tm.Manifest)
+}
+
+func TestNewRefinedResolveFilter(t *testing.T) {
+	type In struct {
+		Filter     *sous.ResolveFilter
+		Discovered *SourceContextDiscovery
+	}
+
+	rrfTests := []struct {
+		Desc        string
+		In          In
+		ExpectPanic bool
+		ExpectErr   string
+		Expect      func(*RefinedResolveFilter) error
+	}{
+		{
+			Desc:        "nil inputs panics",
+			ExpectPanic: true,
+		},
+		{
+			Desc: "nil SourceContextDiscovery panics",
+			In: In{
+				Filter: &sous.ResolveFilter{},
+			},
+			ExpectPanic: true,
+		},
+		{
+			Desc: "no repo specified results in error",
+			In: In{
+				Discovered: &SourceContextDiscovery{},
+			},
+			ExpectErr: "no repo specified, please use -repo or run sous inside a git repo with a configured remote",
+		},
+		{
+			Desc: "no repo specified results in error",
+			In: In{
+				Discovered: &SourceContextDiscovery{},
+			},
+			ExpectErr: "no repo specified, please use -repo or run sous inside a git repo with a configured remote",
+		},
+		{
+			Desc: "detected repo results in success",
+			In: In{
+				Discovered: &SourceContextDiscovery{
+					SourceContext: &sous.SourceContext{
+						PrimaryRemoteURL: "github.com/a/b",
+					},
+				},
+			},
+			Expect: func(rrf *RefinedResolveFilter) error {
+				expectedRepo := "github.com/a/b"
+				if rrf.Repo.All() {
+					return fmt.Errorf("got ALL; want %q", expectedRepo)
+				}
+				actual := *rrf.Repo.Match
+				if actual != expectedRepo {
+					return fmt.Errorf("got %q; want %q", actual, expectedRepo)
+				}
+				return nil
+			},
+		},
+		{
+			Desc: "flag repo overrides detected",
+			In: In{
+				Discovered: &SourceContextDiscovery{
+					SourceContext: &sous.SourceContext{
+						PrimaryRemoteURL: "github.com/from/context",
+					},
+				},
+				Filter: &sous.ResolveFilter{
+					Repo: sous.NewResolveFieldMatcher("github.com/from/flags"),
+				},
+			},
+			Expect: func(rrf *RefinedResolveFilter) error {
+				expectedRepo := "github.com/from/flags"
+				if rrf.Repo.All() {
+					return fmt.Errorf("got ALL; want %q", expectedRepo)
+				}
+				actual := *rrf.Repo.Match
+				if actual != expectedRepo {
+					return fmt.Errorf("got %q; want %q", actual, expectedRepo)
+				}
+				return nil
+			},
+		},
+		{
+			Desc: "flag offset overrides detected offset",
+			In: In{
+				Discovered: &SourceContextDiscovery{
+					SourceContext: &sous.SourceContext{
+						PrimaryRemoteURL: "github.com/from/context",
+						OffsetDir:        "from/context",
+					},
+				},
+				Filter: &sous.ResolveFilter{
+					Offset: sous.NewResolveFieldMatcher("from/flags"),
+				},
+			},
+			Expect: func(rrf *RefinedResolveFilter) error {
+				expectedOffset := "from/flags"
+				if rrf.Offset.All() {
+					return fmt.Errorf("got ALL; want %q", expectedOffset)
+				}
+				actual := *rrf.Offset.Match
+				if actual != expectedOffset {
+					return fmt.Errorf("got %q; want %q", actual, expectedOffset)
+				}
+				return nil
+			},
+		},
+		{
+			Desc: "flag repo sets detected offset to empty",
+			In: In{
+				Discovered: &SourceContextDiscovery{
+					SourceContext: &sous.SourceContext{
+						PrimaryRemoteURL: "github.com/from/context",
+						OffsetDir:        "from/context",
+					},
+				},
+				Filter: &sous.ResolveFilter{
+					Repo: sous.NewResolveFieldMatcher("github.com/from/flags"),
+				},
+			},
+			Expect: func(rrf *RefinedResolveFilter) error {
+				expectedOffset := ""
+				if rrf.Offset.All() {
+					return fmt.Errorf("got ALL; want %q", expectedOffset)
+				}
+				actual := *rrf.Offset.Match
+				if actual != expectedOffset {
+					return fmt.Errorf("got %q; want %q", actual, expectedOffset)
+				}
+				return nil
+			},
+		},
+		{
+			Desc: "flag repo and offset override sets detected",
+			In: In{
+				Discovered: &SourceContextDiscovery{
+					SourceContext: &sous.SourceContext{
+						PrimaryRemoteURL: "github.com/from/context",
+						OffsetDir:        "from/context",
+					},
+				},
+				Filter: &sous.ResolveFilter{
+					Repo:   sous.NewResolveFieldMatcher("github.com/from/flags"),
+					Offset: sous.NewResolveFieldMatcher("from/flags"),
+				},
+			},
+			Expect: func(rrf *RefinedResolveFilter) error {
+				expectedRepo := "github.com/from/flags"
+				if rrf.Repo.All() {
+					return fmt.Errorf("got ALL; want %q", expectedRepo)
+				}
+				actualRepo := *rrf.Repo.Match
+				if actualRepo != expectedRepo {
+					return fmt.Errorf("got %q; want %q", actualRepo, expectedRepo)
+				}
+				expectedOffset := "from/flags"
+				if rrf.Offset.All() {
+					return fmt.Errorf("got ALL; want %q", expectedOffset)
+				}
+				actual := *rrf.Offset.Match
+				if actual != expectedOffset {
+					return fmt.Errorf("got %q; want %q", actual, expectedOffset)
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, test := range rrfTests {
+		t.Run("", func(t *testing.T) {
+			t.Run(test.Desc, func(t *testing.T) {
+				t.Parallel()
+				if !test.ExpectPanic && test.ExpectErr == "" && test.Expect == nil {
+					t.Fatalf("test case must have ExpectPanic, ExpectErr or Expect")
+				}
+				var recovered interface{}
+				var actual *RefinedResolveFilter
+				var err error
+				func() {
+					defer func() { recovered = recover() }()
+					actual, err = newRefinedResolveFilter(test.In.Filter, test.In.Discovered)
+				}()
+				if recovered != nil && !test.ExpectPanic {
+					t.Fatalf("got panic (%T): %+v", recovered, recovered)
+				}
+				if test.ExpectPanic && recovered == nil {
+					t.Fatal("did not panic; want panic")
+				}
+				if test.ExpectErr != "" && err == nil {
+					t.Fatalf("got nil error; want %q", test.ExpectErr)
+				}
+				if test.ExpectErr == "" && err != nil {
+					t.Fatalf("got error %q", err.Error())
+				}
+				if test.ExpectErr != "" && err != nil {
+					actualErr := err.Error()
+					if test.ExpectErr != actualErr {
+						t.Fatalf("got error %q; want %q", actualErr, test.ExpectErr)
+					}
+				}
+				if test.Expect == nil {
+					return
+				}
+				if err := test.Expect(actual); err != nil {
+					t.Fatal(err)
+				}
+			})
+		})
+	}
+
 }

--- a/graph/targetmanifest_test.go
+++ b/graph/targetmanifest_test.go
@@ -175,6 +175,25 @@ func TestNewTargetManifest_Existing(t *testing.T) {
 	}
 }
 
+func TestNewTargetManifest_Existing_withOffset(t *testing.T) {
+	detected := userSelectedOTPLDeployManifest{}
+	sl := sous.MustParseSourceLocation("github.com/user/project,offset")
+	flavor := "some-flavor"
+	mid := sous.ManifestID{Source: sl, Flavor: flavor}
+	tmid := TargetManifestID(mid)
+	m := &sous.Manifest{Source: sl, Flavor: flavor, Kind: sous.ManifestKindService}
+	s := sous.NewState()
+	s.Manifests.Add(m)
+	tm := newTargetManifest(detected, tmid, s)
+	if tm.Source != sl {
+		t.Errorf("unexpected manifest %q", m)
+	}
+	flaws := tm.Manifest.Validate()
+	if len(flaws) > 0 {
+		t.Errorf("Invalid existing manifest: %#v, flaws were %v", tm.Manifest, flaws)
+	}
+}
+
 func TestNewTargetManifest(t *testing.T) {
 	detected := userSelectedOTPLDeployManifest{}
 	sl := sous.MustParseSourceLocation("github.com/user/project")

--- a/graph/targetmanifest_test.go
+++ b/graph/targetmanifest_test.go
@@ -177,7 +177,10 @@ func TestNewTargetManifest_Existing(t *testing.T) {
 
 func TestNewTargetManifest_Existing_withOffset(t *testing.T) {
 	detected := userSelectedOTPLDeployManifest{}
-	sl := sous.MustParseSourceLocation("github.com/user/project,offset")
+	sl := sous.SourceLocation{
+		Repo: "github.com/user/project",
+		Dir:  "server",
+	}
 	flavor := "some-flavor"
 	mid := sous.ManifestID{Source: sl, Flavor: flavor}
 	tmid := TargetManifestID(mid)


### PR DESCRIPTION
Ideally this needs an integration test but not got that far yet. All existing tests pass, and I have manually verified it so opening PR for discussion.

Most of the commits here just add or tidy up unit tests. The crux of this change is https://github.com/opentable/sous/commit/21bf57ec2edf5ce73474a228a24db79ccef53b2c