### PR TITLE
Log entries for deployment diffs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 - bin/ci-setup
 install:
 - bundle
-- pip install proseline
+- sudo apt-get install python3-proselint
 - "./bin/vendor-check"
 script:
 - bundle exec danger

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ go:
 before_install:
 - bin/ci-setup
 install:
+# - sudo apt-get install python3-proselint
 - bundle
-- sudo apt-get install python3-proselint
 - "./bin/vendor-check"
 script:
 - bundle exec danger

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 - bin/ci-setup
 install:
 - bundle
-- sudo pip install proseline
+- pip install proseline
 - "./bin/vendor-check"
 script:
 - bundle exec danger

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
 - bin/ci-setup
 install:
 - bundle
+- sudo pip install proseline
 - "./bin/vendor-check"
 script:
 - bundle exec danger

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ after_script:
 - docker logs testregistry_master_1 || true
 - docker logs testregistry_slave_1 || true
 after_success:
-- if [ x$TRAVIS_PULL_REQUEST != "xfalse" ]; then make coverage; fi
+- make coverage
 - bin/codecov -f /tmp/sous-cover/count_merged.txt
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
 
-## [Unreleased](//github.com/opentable/sous/compare/0.5.39..HEAD)
+## [0.5.40](//github.com/opentable/sous/compare/0.5.39..0.5.40)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
-## [Unreleased](//github.com/opentable/sous/compare/0.5.40..HEAD)
+## [0.5.41](//github.com/opentable/sous/compare/0.5.40..0.5.41)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.39..HEAD)
+
+### Fixed
+
+* Server: mismatches with logging schemas
+
 ## [0.5.39](//github.com/opentable/sous/compare/0.5.38..0.5.39)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
-## [Unreleased](//github.com/opentable/sous/compare/0.5.41..HEAD)
+## [0.5.42](//github.com/opentable/sous/compare/0.5.41..0.5.42)
 ### Fixed
 * All: Graphite output was like `sous.sous.ci.sfautoresolver.fullcycle-duration.count`, now `sous.ci.sf.auto...`
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -14,3 +14,5 @@ if !git.modified_files.include?("CHANGELOG.md") && (app_changes && !declared_tri
 end
 
 lgtm.check_lgtm
+
+p git.diff.full_diff

--- a/Dangerfile
+++ b/Dangerfile
@@ -13,18 +13,32 @@ if !git.modified_files.include?("CHANGELOG.md") && (app_changes && !declared_tri
   fail("Please include a CHANGELOG entry.", sticky: false)
 end
 
-if prose.mdspell_installed? and prose.proselint_installed?
+full_prose = true
+if full_prose
   prose.lint_files "docs/*.md"
 else
+  markdown_files = (modified_files + added_files).select do |line|
+    line.start_with?("_posts") && (line.end_with?(".markdown") || line.end_with?(".md"))
+  end
+
+  # will check any .markdown files in this PR with proselint
+  proselint.lint_files markdown_files
+end
+
+if !(prose.mdspell_installed? and prose.proselint_installed?)
   message "mdspell or proselint not available - prose not linted"
 end
 
 lgtm.check_lgtm
 
-git.diff.each do |file|
-  file.patch.each_line do |patch_line|
-    if /^\+[^+].*spew\./ =~ patch_line
-      fail "Debugging output: #{patch_line} (there may be others)"
+def check_for_debug
+  git.diff.each do |file|
+    file.patch.each_line do |patch_line|
+      if /^\+[^+].*spew\./ =~ patch_line
+        fail "Debugging output: #{patch_line} (there may be others)"
+        return
+      end
     end
   end
 end
+check_for_debug

--- a/Dangerfile
+++ b/Dangerfile
@@ -13,6 +13,18 @@ if !git.modified_files.include?("CHANGELOG.md") && (app_changes && !declared_tri
   fail("Please include a CHANGELOG entry.", sticky: false)
 end
 
+if prose.mdspell_installed? and prose.proselint_installed?
+  prose.lint_files "docs/*.md"
+else
+  message "mdspell or proselint not available - prose not linted"
+end
+
 lgtm.check_lgtm
 
-p git.diff.full_diff
+git.diff.each do |file|
+  file.patch.each_line do |patch_line|
+    if /^\+[^+].*spew\./ =~ patch_line
+      fail "Debugging output: #{patch_line} (there may be others)"
+    end
+  end
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.1)
-      public_suffix (~> 2.0, >= 2.0.2)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     archive-tar-minitar (0.5.2)
     arr-pm (0.0.10)
       cabin (> 0)
@@ -10,7 +10,7 @@ GEM
     cabin (0.9.0)
     childprocess (0.7.1)
       ffi (~> 1.0, >= 1.0.11)
-    claide (1.0.1)
+    claide (1.0.2)
     claide-plugins (0.9.2)
       cork
       nap
@@ -19,7 +19,7 @@ GEM
     colored2 (3.1.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (5.0.3)
+    danger (5.5.3)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -28,7 +28,8 @@ GEM
       faraday-http-cache (~> 1.0)
       git (~> 1)
       kramdown (~> 1.5)
-      octokit (~> 4.2)
+      no_proxy_fix
+      octokit (~> 4.7)
       terminal-table (~> 1)
     danger-lgtm (0.1.1)
       danger-plugin-api (~> 1.0)
@@ -37,7 +38,7 @@ GEM
     danger-prose (2.0.3)
       danger
     dotenv (2.2.1)
-    faraday (0.12.0.1)
+    faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.1)
       faraday (~> 0.8)
@@ -57,10 +58,11 @@ GEM
     insist (1.0.0)
     io-like (0.3.0)
     json (1.8.6)
-    kramdown (1.13.2)
+    kramdown (1.15.0)
     multipart-post (2.0.0)
     mustache (0.99.8)
     nap (1.1.0)
+    no_proxy_fix (0.1.2)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
@@ -71,7 +73,7 @@ GEM
       insist
       mustache (= 0.99.8)
       stud
-    public_suffix (2.0.5)
+    public_suffix (3.0.0)
     ruby-xz (0.2.3)
       ffi (~> 1.9)
       io-like (~> 0.3)
@@ -79,9 +81,9 @@ GEM
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     stud (0.0.22)
-    terminal-table (1.7.3)
-      unicode-display_width (~> 1.1.1)
-    unicode-display_width (1.1.3)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
+    unicode-display_width (1.3.0)
 
 PLATFORMS
   ruby
@@ -91,3 +93,6 @@ DEPENDENCIES
   danger-lgtm
   danger-prose
   fpm
+
+BUNDLED WITH
+   1.14.4

--- a/bin/release-update
+++ b/bin/release-update
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+
+if type versiontool > /dev/null; then
+  echo -n
+else
+  echo versiontool not found
+  echo "try: go get github.com/nyarly/versiontool"
+fi
+
+newversion=$(versiontool increment $(git tag | grep '[.].*[.*]' | versiontool sort | tail -n 1))
+echo Updating to $newversion
+
+set -x
+sed -i "/Unreleased.*HEAD/ s/Unreleased\|HEAD/$newversion/g" CHANGELOG.md
+grep $newversion CHANGELOG.md
+
+git commit -am "Releasing $newversion"
+git tag -sm "Release" $newversion
+git push

--- a/ext/docker/cachemessages.go
+++ b/ext/docker/cachemessages.go
@@ -49,8 +49,8 @@ func (msg cacheHitMessage) Message() string {
 func (msg cacheHitMessage) EachField(f logging.FieldReportFn) {
 	f("@loglov3-otl", "sous-cache-message-v1")
 	msg.CallerInfo.EachField(f)
-	f("source-id", fmt.Sprintf("%+v", msg.source))
-	f("image-name", msg.imageName)
+	f("sous-source-id", fmt.Sprintf("%+v", msg.source))
+	f("sous-image-name", msg.imageName)
 }
 
 func reportCacheMiss(logger logging.LogSink, sid sous.SourceID, name string) {
@@ -74,8 +74,8 @@ func (msg cacheMissMessage) Message() string {
 func (msg cacheMissMessage) EachField(f logging.FieldReportFn) {
 	f("@loglov3-otl", "sous-cache-message-v1")
 	msg.CallerInfo.EachField(f)
-	f("source-id", fmt.Sprintf("%+v", msg.source))
-	f("image-name", msg.imageName)
+	f("sous-source-id", fmt.Sprintf("%+v", msg.source))
+	f("sous-image-name", msg.imageName)
 }
 
 func reportCacheError(logger logging.LogSink, sid sous.SourceID, err error) {
@@ -99,6 +99,6 @@ func (msg cacheErrorMessage) Message() string {
 func (msg cacheErrorMessage) EachField(f logging.FieldReportFn) {
 	f("@loglov3-otl", "sous-cache-message-v1")
 	msg.CallerInfo.EachField(f)
-	f("source-id", fmt.Sprintf("%+v", msg.source))
+	f("sous-source-id", fmt.Sprintf("%+v", msg.source))
 	f("error", msg.err.Error())
 }

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -280,8 +280,8 @@ func newResolveFilter(sf *config.DeployFilterFlags, shc sous.SourceHostChooser) 
 	return sf.BuildFilter(shc.ParseSourceLocation)
 }
 
-func newResolver(filter *sous.ResolveFilter, d sous.Deployer, r sous.Registry) *sous.Resolver {
-	return sous.NewResolver(d, r, filter)
+func newResolver(filter *sous.ResolveFilter, d sous.Deployer, r sous.Registry, ls LogSink) *sous.Resolver {
+	return sous.NewResolver(d, r, filter, ls.Child("resolver"))
 }
 
 func newAutoResolver(rez *sous.Resolver, sr *ServerStateManager, ls LogSink) *sous.AutoResolver {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -103,6 +103,11 @@ func (suite *integrationSuite) newNameCache(name string) *docker.NameCache {
 
 	cache, err := docker.NewNameCache(registryName, suite.registry, logging.NewLogSet(semv.MustParse("0.0.0"), "", "", os.Stdout), db)
 	suite.Require().NoError(err)
+
+	ids, err := cache.ListSourceIDs()
+	suite.Require().NoError(err)
+	suite.Require().Len(ids, 0, "Stale images in cache: %v", ids)
+
 	return cache
 }
 
@@ -138,6 +143,7 @@ func (suite *integrationSuite) BeforeTest(suiteName, testName string) {
 	suite.registry = docker_registry.NewClient()
 	suite.registry.BecomeFoolishlyTrusting()
 
+	suite.T().Logf("New name cache for %q", testName)
 	suite.nameCache = suite.newNameCache(testName)
 	suite.client = singularity.NewRectiAgent(suite.nameCache)
 	suite.deployer = singularity.NewDeployer(suite.client)
@@ -189,6 +195,10 @@ func (suite *integrationSuite) TestNameCache() {
 	suite.Equal("1.1.1", labels[docker.DockerVersionLabel])
 }
 
+func (suite *integrationSuite) depsCount(deps map[sous.DeploymentID]*sous.DeployState, count int) bool {
+	return suite.Len(deps, count, "should have %d members, has %d: \n%#v", count, len(deps), deps)
+}
+
 func (suite *integrationSuite) TestGetRunningDeploymentSet_testCluster() {
 	suite.deployDefaultContainers()
 	clusters := []string{"test-cluster"}
@@ -200,7 +210,7 @@ func (suite *integrationSuite) TestGetRunningDeploymentSet_testCluster() {
 	for i := 0; i < numberOfTestRuns; i++ {
 		ds, which := suite.deploymentWithRepo(clusters, "github.com/example/webapp")
 		deps := ds.Snapshot()
-		if suite.Equal(4, len(deps), "%#v should have members") {
+		if suite.depsCount(deps, 4) {
 			webapp := deps[which]
 			cacheHitText := fmt.Sprintf("on cache hit %d", i+1)
 			suite.Equal(SingularityURL, webapp.Cluster.BaseURL, cacheHitText)
@@ -221,7 +231,7 @@ func (suite *integrationSuite) TestGetRunningDeploymentSet_otherCluster() {
 
 	ds, which := suite.deploymentWithRepo(clusters, "github.com/example/webapp")
 	deps := ds.Snapshot()
-	if suite.Equal(1, len(deps)) {
+	if suite.depsCount(deps, 1) {
 		webapp := deps[which]
 		suite.Equal(SingularityURL, webapp.Cluster.BaseURL)
 		suite.Regexp("^0\\.1", webapp.Resources["cpus"])    // XXX strings and floats...
@@ -241,7 +251,7 @@ func (suite *integrationSuite) TestGetRunningDeploymentSet_all() {
 
 	ds, which := suite.deploymentWithRepo(clusters, "github.com/example/webapp")
 	deps := ds.Snapshot()
-	if suite.Equal(5, len(deps)) {
+	if suite.depsCount(deps, 5) {
 		webapp := deps[which]
 		suite.Equal(SingularityURL, webapp.Cluster.BaseURL)
 		suite.Regexp("^0\\.1", webapp.Resources["cpus"])    // XXX strings and floats...
@@ -378,6 +388,7 @@ func (suite *integrationSuite) TestMissingImage() {
 
 	err = r.Begin(deploymentsOne, clusterDefs.Clusters).Wait()
 
+	suite.T().Logf("Missing Image Error: %v", err)
 	suite.Error(err, "should report 'missing image'")
 
 	// ****
@@ -386,7 +397,7 @@ func (suite *integrationSuite) TestMissingImage() {
 	clusters := []string{"test-cluster"}
 
 	_, which := suite.deploymentWithRepo(clusters, repoOne)
-	suite.Equal(which, none, "opentable/one was deployed")
+	suite.Equal(which, none, "opentable/one was deployed, should not be")
 }
 
 func (suite *integrationSuite) TestResolve() {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -389,7 +389,7 @@ func (suite *integrationSuite) TestMissingImage() {
 	err = r.Begin(deploymentsOne, clusterDefs.Clusters).Wait()
 
 	suite.T().Logf("Missing Image Error: %v", err)
-	suite.Error(err, "should report 'missing image'")
+	suite.Error(err, "should report 'missing image' for opentable/one")
 
 	// ****
 	time.Sleep(1 * time.Second)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -370,7 +370,7 @@ func (suite *integrationSuite) TestMissingImage() {
 	}
 
 	// ****
-	r := sous.NewResolver(suite.deployer, suite.nameCache, &sous.ResolveFilter{})
+	r := sous.NewResolver(suite.deployer, suite.nameCache, &sous.ResolveFilter{}, logging.SilentLogSet())
 
 	deploymentsOne, err := stateOne.Deployments()
 	suite.Require().NoError(err)
@@ -422,7 +422,7 @@ func (suite *integrationSuite) TestResolve() {
 	suite.Require().NoError(err)
 
 	// ****
-	r := sous.NewResolver(suite.deployer, suite.nameCache, &sous.ResolveFilter{})
+	r := sous.NewResolver(suite.deployer, suite.nameCache, &sous.ResolveFilter{}, logging.SilentLogSet())
 
 	logging.Log.Warn.Print("Begining OneTwo")
 	err = r.Begin(deploymentsOneTwo, clusterDefs.Clusters).Wait()
@@ -458,7 +458,7 @@ func (suite *integrationSuite) TestResolve() {
 		client := singularity.NewRectiAgent(suite.nameCache)
 		deployer := singularity.NewDeployer(client)
 
-		r := sous.NewResolver(deployer, suite.nameCache, &sous.ResolveFilter{})
+		r := sous.NewResolver(deployer, suite.nameCache, &sous.ResolveFilter{}, logging.SilentLogSet())
 
 		err = r.Begin(deploymentsTwoThree, clusterDefs.Clusters).Wait()
 		if err != nil {

--- a/lib/auto_resolver_test.go
+++ b/lib/auto_resolver_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func dummyResolver() *Resolver {
-	return NewResolver(NewDummyDeployer(), NewDummyRegistry(), &ResolveFilter{})
+	return NewResolver(NewDummyDeployer(), NewDummyRegistry(), &ResolveFilter{}, logging.SilentLogSet())
 }
 
 func setupAR() *AutoResolver {

--- a/lib/deployable_chans.go
+++ b/lib/deployable_chans.go
@@ -2,12 +2,7 @@ package sous
 
 import (
 	"context"
-	"fmt"
 	"sync"
-
-	"github.com/davecgh/go-spew/spew"
-	"github.com/opentable/sous/util/logging"
-	"github.com/pkg/errors"
 )
 
 type (
@@ -74,41 +69,6 @@ func (d *DeployableChans) collect() diffSet {
 		ds.Changed = append(ds.Changed, m)
 	}
 	return ds
-}
-
-// GuardImage checks that a deployment is valid before deploying it.
-func GuardImage(r Registry, d *Deployment) (*BuildArtifact, error) {
-	if d.NumInstances == 0 {
-		logging.Log.Info.Printf("Deployment %q has 0 instances, skipping artifact check.", d.ID())
-		return nil, nil
-	}
-	art, err := r.GetArtifact(d.SourceID)
-	if err != nil {
-		return nil, &MissingImageNameError{err}
-	}
-	for _, q := range art.Qualities {
-		if q.Kind == "advisory" {
-			if q.Name == "" {
-				continue
-			}
-			advisoryIsValid := false
-			var allowedAdvisories []string
-			if d.Cluster == nil {
-				return nil, fmt.Errorf("nil cluster on deployment %q", d)
-			}
-			allowedAdvisories = d.Cluster.AllowedAdvisories
-			for _, aa := range allowedAdvisories {
-				if aa == q.Name {
-					advisoryIsValid = true
-					break
-				}
-			}
-			if !advisoryIsValid {
-				return nil, &UnacceptableAdvisory{q, &d.SourceID}
-			}
-		}
-	}
-	return art, err
 }
 
 // ID returns the ID of this DeployablePair.
@@ -190,101 +150,4 @@ func (DeployablePassThrough) Stable(dp *DeployablePair) (*DeployablePair, *DiffR
 // Update returns its argument
 func (DeployablePassThrough) Update(dp *DeployablePair) (*DeployablePair, *DiffResolution) {
 	return dp, nil
-}
-
-type nameResolver struct {
-	registry Registry
-}
-
-func (names *nameResolver) Start(dp *DeployablePair) (*DeployablePair, *DiffResolution) {
-	spew.Dump(names)
-	dep := dp.Post
-	logging.Log.Vomit.Printf("Deployment processed, needs artifact: %#v", dep)
-
-	da, err := resolveName(names.registry, dep)
-	if err != nil {
-		logging.Log.Info.Printf("Unable to create new deployment %q: %s", dep.ID(), err)
-		logging.Log.Debug.Printf("Failed create deployment %q: % #v", dep.ID(), dep)
-		return nil, err
-	}
-
-	if da.BuildArtifact == nil {
-		logging.Log.Info.Printf("Unable to create new deployment %q: no artifact for SourceID %q", dep.ID(), dep.SourceID)
-		logging.Log.Debug.Printf("Failed create deployment %q: % #v", dep.ID(), dep)
-		return nil, &DiffResolution{
-			DeploymentID: dp.ID(),
-			Desc:         "not created",
-			Error:        WrapResolveError(errors.Errorf("Unable to create new deployment %q: no artifact for SourceID %q", dep.ID(), dep.SourceID)),
-		}
-	}
-	return &DeployablePair{ExecutorData: dp.ExecutorData, name: dp.name, Prior: nil, Post: da}, nil
-}
-
-func (names *nameResolver) Update(depPair *DeployablePair) (*DeployablePair, *DiffResolution) {
-	logging.Log.Vomit.Printf("Pair of deployments processed, needs artifact: %#v", depPair)
-	d, err := resolvePair(names.registry, depPair)
-	if err != nil {
-		logging.Log.Info.Printf("Unable to modify deployment %q: %s", depPair.Post, err)
-		logging.Log.Debug.Printf("Failed modify deployment %q: % #v", depPair.ID(), depPair.Post)
-		return nil, err
-	}
-	if d.Post.BuildArtifact == nil {
-		logging.Log.Info.Printf("Unable to modify deployment %q: no artifact for SourceID %q", depPair.ID(), depPair.Post.SourceID)
-		logging.Log.Debug.Printf("Failed modify deployment %q: % #v", depPair.ID(), depPair.Post)
-		return nil, &DiffResolution{
-			DeploymentID: depPair.ID(),
-			Desc:         "not updated",
-			Error:        WrapResolveError(errors.Errorf("Unable to modify new deployment %q: no artifact for SourceID %q", depPair.ID(), depPair.Post.SourceID)),
-		}
-	}
-	return d, nil
-}
-
-// Stop always returns no error because we don't need a deploy artifact to delete a deploy
-func (names *nameResolver) Stop(dp *DeployablePair) (*DeployablePair, *DiffResolution) {
-	da := maybeResolveSingle(names.registry, dp.Prior)
-	return &DeployablePair{ExecutorData: dp.ExecutorData, name: dp.name, Prior: da, Post: nil}, nil
-}
-
-// Stable always returns no error because we don't need a deploy artifact for unchanged deploys
-func (names *nameResolver) Stable(dp *DeployablePair) (*DeployablePair, *DiffResolution) {
-	da := maybeResolveSingle(names.registry, dp.Post)
-	return &DeployablePair{ExecutorData: dp.ExecutorData, name: dp.name, Prior: da, Post: da}, nil
-}
-
-// ResolveNames resolves diffs.
-func (d *DeployableChans) ResolveNames(r Registry) *DeployableChans {
-	names := &nameResolver{registry: r}
-
-	return d.Pipeline(context.Background(), names)
-}
-
-// XXX now that everything is DeployablePairs, this can probably be simplified
-
-func maybeResolveSingle(r Registry, dep *Deployable) *Deployable {
-	logging.Log.Vomit.Printf("Attempting to resolve optional artifact: %#v (stable or deletes don't need images)", dep)
-	da, err := resolveName(r, dep)
-	if err != nil {
-		logging.Log.Debug.Printf("Error resolving stopped or stable deployment (proceeding anyway): %#v: %#v", dep, err)
-	}
-	return da
-}
-
-func resolveName(r Registry, d *Deployable) (*Deployable, *DiffResolution) {
-	art, err := GuardImage(r, d.Deployment)
-	if err != nil {
-		return d, &DiffResolution{
-			DeploymentID: d.ID(),
-			Error:        &ErrorWrapper{error: err},
-		}
-	}
-	d.BuildArtifact = art
-	return d, nil
-}
-
-func resolvePair(r Registry, depPair *DeployablePair) (*DeployablePair, *DiffResolution) {
-	prior, _ := resolveName(r, depPair.Prior)
-	post, err := resolveName(r, depPair.Post)
-
-	return &DeployablePair{ExecutorData: depPair.ExecutorData, name: depPair.name, Prior: prior, Post: post}, err
 }

--- a/lib/deployable_chans.go
+++ b/lib/deployable_chans.go
@@ -17,6 +17,7 @@ type (
 	// situation, where the Prior Deployable is the known state and the Post
 	// Deployable is the desired state.
 	DeployablePair struct {
+		Diffs        Differences
 		Prior, Post  *Deployable
 		name         DeploymentID
 		ExecutorData interface{}

--- a/lib/deployable_chans_test.go
+++ b/lib/deployable_chans_test.go
@@ -1,6 +1,7 @@
 package sous
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -99,7 +100,7 @@ func (nrs *NameResolveTestSuite) TestResolveNameSkipped() {
 }
 
 func (nrs *NameResolveTestSuite) TestResolveNameStartChannel() {
-	nrs.depChans = nrs.diffChans.ResolveNames(nrs.reg)
+	nrs.depChans = nrs.diffChans.ResolveNames(context.Background(), nrs.reg)
 	nrs.diffChans.Start <- nrs.makeTestDepPair(nil, nrs.makeTestDep())
 
 	select {
@@ -115,7 +116,7 @@ func (nrs *NameResolveTestSuite) TestResolveNameStartChannel() {
 }
 
 func (nrs *NameResolveTestSuite) TestResolveNameUpdateChannel() {
-	nrs.depChans = nrs.diffChans.ResolveNames(nrs.reg)
+	nrs.depChans = nrs.diffChans.ResolveNames(context.Background(), nrs.reg)
 	nrs.diffChans.Update <- &DeployablePair{
 		Prior: nrs.makeTestDep(),
 		Post:  nrs.makeTestDep(),
@@ -134,7 +135,7 @@ func (nrs *NameResolveTestSuite) TestResolveNameUpdateChannel() {
 
 func (nrs *NameResolveTestSuite) TestResolveNameStartChannelUnresolved() {
 	nrs.reg.FeedArtifact(nil, fmt.Errorf("not found"))
-	nrs.depChans = nrs.diffChans.ResolveNames(nrs.reg)
+	nrs.depChans = nrs.diffChans.ResolveNames(context.Background(), nrs.reg)
 	nrs.diffChans.Start <- nrs.makeTestDepPair(nil, nrs.makeTestDep())
 
 	select {
@@ -149,7 +150,7 @@ func (nrs *NameResolveTestSuite) TestResolveNameStartChannelUnresolved() {
 
 func (nrs *NameResolveTestSuite) TestResolveNameStopChannelUnresolved() {
 	nrs.reg.FeedArtifact(nil, fmt.Errorf("not found"))
-	nrs.depChans = nrs.diffChans.ResolveNames(nrs.reg)
+	nrs.depChans = nrs.diffChans.ResolveNames(context.Background(), nrs.reg)
 	nrs.diffChans.Stop <- nrs.makeTestDepPair(nrs.makeTestDep(), nil)
 
 	select {

--- a/lib/deployable_chans_test.go
+++ b/lib/deployable_chans_test.go
@@ -15,7 +15,6 @@ type NameResolveTestSuite struct {
 	testCluster *Cluster
 	depChans    *DeployableChans
 	diffChans   *DeployableChans
-	errChan     chan *DiffResolution
 }
 
 func (nrs *NameResolveTestSuite) makeTestDep() *Deployable {
@@ -68,10 +67,8 @@ func (nrs *NameResolveTestSuite) SetupTest() {
 
 	nrs.reg = NewDummyRegistry()
 
-	nrs.depChans = NewDeployableChans(10)
 	dc := NewDeployableChans(10)
 	nrs.diffChans = dc
-	nrs.errChan = make(chan *DiffResolution, 10)
 }
 
 func (nrs *NameResolveTestSuite) TearDownTest() {
@@ -102,7 +99,7 @@ func (nrs *NameResolveTestSuite) TestResolveNameSkipped() {
 }
 
 func (nrs *NameResolveTestSuite) TestResolveNameStartChannel() {
-	nrs.depChans.ResolveNames(nrs.reg, nrs.diffChans, nrs.errChan)
+	nrs.depChans = nrs.diffChans.ResolveNames(nrs.reg)
 	nrs.diffChans.Start <- nrs.makeTestDepPair(nil, nrs.makeTestDep())
 
 	select {
@@ -110,7 +107,7 @@ func (nrs *NameResolveTestSuite) TestResolveNameStartChannel() {
 		nrs.NotNil(started)
 		nrs.NotNil(started.Post.Deployment)
 		nrs.NotNil(started.Post.BuildArtifact)
-	case err := <-nrs.errChan:
+	case err := <-nrs.depChans.Errs:
 		nrs.Fail("Unexpected error: %v", err)
 	case <-time.After(time.Second / 2):
 		nrs.Fail("Timeout waiting for depChans to resolve")
@@ -118,7 +115,7 @@ func (nrs *NameResolveTestSuite) TestResolveNameStartChannel() {
 }
 
 func (nrs *NameResolveTestSuite) TestResolveNameUpdateChannel() {
-	nrs.depChans.ResolveNames(nrs.reg, nrs.diffChans, nrs.errChan)
+	nrs.depChans = nrs.diffChans.ResolveNames(nrs.reg)
 	nrs.diffChans.Update <- &DeployablePair{
 		Prior: nrs.makeTestDep(),
 		Post:  nrs.makeTestDep(),
@@ -128,7 +125,7 @@ func (nrs *NameResolveTestSuite) TestResolveNameUpdateChannel() {
 	case updated := <-nrs.depChans.Update:
 		nrs.NotNil(updated)
 		nrs.NotNil(updated.Post.BuildArtifact)
-	case err := <-nrs.errChan:
+	case err := <-nrs.depChans.Errs:
 		nrs.Fail("Unexpected error: %v", err)
 	case <-time.After(time.Second / 2):
 		nrs.Fail("Timeout waiting for depChans to resolve")
@@ -137,13 +134,13 @@ func (nrs *NameResolveTestSuite) TestResolveNameUpdateChannel() {
 
 func (nrs *NameResolveTestSuite) TestResolveNameStartChannelUnresolved() {
 	nrs.reg.FeedArtifact(nil, fmt.Errorf("not found"))
-	nrs.depChans.ResolveNames(nrs.reg, nrs.diffChans, nrs.errChan)
+	nrs.depChans = nrs.diffChans.ResolveNames(nrs.reg)
 	nrs.diffChans.Start <- nrs.makeTestDepPair(nil, nrs.makeTestDep())
 
 	select {
 	case <-nrs.depChans.Start:
 		nrs.Fail("Shouldn't process a starting deployment")
-	case err := <-nrs.errChan:
+	case err := <-nrs.depChans.Errs:
 		nrs.Error(err.Error)
 	case <-time.After(time.Second / 2):
 		nrs.Fail("Timeout waiting for depChans to resolve")
@@ -152,13 +149,13 @@ func (nrs *NameResolveTestSuite) TestResolveNameStartChannelUnresolved() {
 
 func (nrs *NameResolveTestSuite) TestResolveNameStopChannelUnresolved() {
 	nrs.reg.FeedArtifact(nil, fmt.Errorf("not found"))
-	nrs.depChans.ResolveNames(nrs.reg, nrs.diffChans, nrs.errChan)
+	nrs.depChans = nrs.diffChans.ResolveNames(nrs.reg)
 	nrs.diffChans.Stop <- nrs.makeTestDepPair(nrs.makeTestDep(), nil)
 
 	select {
 	case stopped := <-nrs.depChans.Stop:
 		nrs.NotNil(stopped)
-	case err := <-nrs.errChan:
+	case err := <-nrs.depChans.Errs:
 		nrs.Fail("Unexpected error: %v", err)
 	case <-time.After(time.Second / 2):
 		nrs.Fail("Timeout waiting for depChans to resolve")

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -197,13 +197,20 @@ func (d *Deployment) Equal(o *Deployment) bool {
 	return !diff
 }
 
+// Differences records the differences between two Deployments
+type Differences []string
+
+func (diffs Differences) String() string {
+	return strings.Join(diffs, ", ")
+}
+
 // Diff returns the differences between this deployment and another.
-func (d *Deployment) Diff(o *Deployment) (bool, []string) {
+func (d *Deployment) Diff(o *Deployment) (bool, Differences) {
 	if d.ID() != o.ID() {
 		panic(fmt.Sprintf("attempt to compare deployment %q with %q", d.ID(), o.ID()))
 	}
 	logging.Log.Debug.Printf("Comparing two versions of deployment %q", d.ID())
-	var diffs []string
+	var diffs Differences
 	diff := func(format string, a ...interface{}) { diffs = append(diffs, fmt.Sprintf(format, a...)) }
 	if d.ClusterName != o.ClusterName {
 		diff("cluster name; this: %q; other: %q", d.ClusterName, o.ClusterName)

--- a/lib/deployment_diff.go
+++ b/lib/deployment_diff.go
@@ -67,11 +67,9 @@ func newStateDiffer(intended DeployStates) *stateDiffer {
 	for _, dep := range i {
 		startMap[dep.Name()] = dep
 	}
-	chans := NewDeployableChans(len(i))
-
 	return &stateDiffer{
 		from:            startMap,
-		DeployableChans: chans,
+		DeployableChans: NewDeployableChans(len(i)),
 	}
 }
 
@@ -82,11 +80,9 @@ func newDiffer(intended Deployments) *differ {
 	for _, dep := range i {
 		startMap[dep.Name()] = &DeployState{Deployment: *dep}
 	}
-	chans := NewDeployableChans(len(i))
-
 	return &differ{
 		from:            startMap,
-		DeployableChans: chans,
+		DeployableChans: NewDeployableChans(len(i)),
 	}
 }
 

--- a/lib/deployment_diff.go
+++ b/lib/deployment_diff.go
@@ -11,6 +11,7 @@ type (
 	DeploymentPair struct {
 		name        DeploymentID
 		Prior, Post *Deployment
+		Diffs       Differences
 		Status      DeployStatus
 	}
 	// DeploymentPairs is a list of DeploymentPair
@@ -147,6 +148,7 @@ func (d *stateDiffer) diff(existing DeployStates) {
 
 			d.Update <- &DeployablePair{
 				name:         id,
+				Diffs:        differences,
 				ExecutorData: intendDS.ExecutorData,
 				Prior: &Deployable{
 					Deployment: &intendDS.Deployment,
@@ -163,6 +165,7 @@ func (d *stateDiffer) diff(existing DeployStates) {
 		logging.Log.Debug.Printf("Retained deployment: %q (% #v)", id, differences)
 		d.Stable <- &DeployablePair{
 			name:         id,
+			Diffs:        Differences{},
 			ExecutorData: intendDS.ExecutorData,
 			Prior: &Deployable{
 				Deployment: &intendDS.Deployment,
@@ -222,6 +225,7 @@ func (d *differ) diff(existing Deployments) {
 
 			d.Update <- &DeployablePair{
 				name:  id,
+				Diffs: differences,
 				Prior: &Deployable{Deployment: &intendedDeployment.Deployment, Status: intendedDeployment.Status},
 				Post:  &Deployable{Deployment: existingDeployment, Status: DeployStatusActive},
 			}
@@ -229,6 +233,7 @@ func (d *differ) diff(existing Deployments) {
 		}
 		d.Stable <- &DeployablePair{
 			name:  id,
+			Diffs: Differences{},
 			Prior: &Deployable{Deployment: &intendedDeployment.Deployment, Status: intendedDeployment.Status},
 			Post:  &Deployable{Deployment: &intendedDeployment.Deployment, Status: intendedDeployment.Status},
 		}

--- a/lib/deployment_diff.go
+++ b/lib/deployment_diff.go
@@ -77,9 +77,11 @@ func newStateDiffer(intended DeployStates) *stateDiffer {
 	for _, dep := range i {
 		startMap[dep.Name()] = dep
 	}
+	chans := NewDeployableChans(len(i))
+
 	return &stateDiffer{
 		from:            startMap,
-		DeployableChans: NewDeployableChans(len(i)),
+		DeployableChans: chans,
 	}
 }
 
@@ -95,9 +97,11 @@ func newDiffer(intended Deployments) *differ {
 	for _, dep := range i {
 		startMap[dep.Name()] = &DeployState{Deployment: *dep}
 	}
+	chans := NewDeployableChans(len(i))
+
 	return &differ{
 		from:            startMap,
-		DeployableChans: NewDeployableChans(len(i)),
+		DeployableChans: chans,
 	}
 }
 

--- a/lib/fixtures_test.go
+++ b/lib/fixtures_test.go
@@ -2,6 +2,17 @@ package sous
 
 import "github.com/samsalisbury/semv"
 
+// These functions gin up fixtures for various complex structs to be used where
+// a tested component needs e.g. a real manifest but where the manifest itself
+// isn't important.
+// These functions all follow the pattern
+//    xxxFixture(name string) xxx {
+//      switch name {
+//        default:
+//          [a vanilla instance]
+//        ...
+// If more specific forms are required, add them as "named" fixtures here.
+
 func deployConfigFixture(name string) DeployConfig {
 	switch name {
 	default:

--- a/lib/loggingprocessor.go
+++ b/lib/loggingprocessor.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/opentable/sous/util/logging"
 )
 
@@ -141,7 +140,6 @@ func (msg *deployableMessage) EachField(f logging.FieldReportFn) {
 }
 
 func (log loggingProcessor) HandleResolution(rez *DiffResolution) {
-	spew.Dump("loggingProcessor", rez)
 	msg := &diffRezMessage{
 		resolution: rez,
 		callerInfo: logging.GetCallerInfo("loggingprocessor"),

--- a/lib/loggingprocessor.go
+++ b/lib/loggingprocessor.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/opentable/sous/util/logging"
 )
 
@@ -140,6 +141,7 @@ func (msg *deployableMessage) EachField(f logging.FieldReportFn) {
 }
 
 func (log loggingProcessor) HandleResolution(rez *DiffResolution) {
+	spew.Dump("loggingProcessor", rez)
 	msg := &diffRezMessage{
 		resolution: rez,
 		callerInfo: logging.GetCallerInfo("loggingprocessor"),

--- a/lib/loggingprocessor.go
+++ b/lib/loggingprocessor.go
@@ -1,0 +1,131 @@
+package sous
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/opentable/sous/util/logging"
+)
+
+// Log adds a logging pipeline step onto a DeployableChans
+func (d *DeployableChans) Log(ctx context.Context, ls logging.LogSink) *DeployableChans {
+	proc := loggingProcessor{ls: ls}
+	return d.Pipeline(ctx, proc)
+}
+
+type loggingProcessor struct {
+	ls logging.LogSink
+}
+
+type deployableMessage struct {
+	pair       *DeployablePair
+	callerInfo logging.CallerInfo
+}
+
+func (log loggingProcessor) Start(dp *DeployablePair) (*DeployablePair, *DiffResolution) {
+	log.doLog(dp)
+	return dp, nil
+}
+
+func (log loggingProcessor) Stop(dp *DeployablePair) (*DeployablePair, *DiffResolution) {
+	log.doLog(dp)
+	return dp, nil
+}
+
+func (log loggingProcessor) Stable(dp *DeployablePair) (*DeployablePair, *DiffResolution) {
+	log.doLog(dp)
+	return dp, nil
+}
+
+func (log loggingProcessor) Update(dp *DeployablePair) (*DeployablePair, *DiffResolution) {
+	log.doLog(dp)
+	return dp, nil
+}
+
+func (log loggingProcessor) doLog(dp *DeployablePair) {
+	msg := &deployableMessage{
+		pair:       dp,
+		callerInfo: logging.GetCallerInfo("loggingprocessor"),
+	}
+
+	logging.Deliver(msg, log.ls)
+}
+
+func (msg *deployableMessage) DefaultLevel() logging.Level {
+	if msg.pair.Post == nil {
+		return logging.WarningLevel
+	}
+
+	if msg.pair.Prior == nil {
+		return logging.InformationLevel
+	}
+
+	if len(msg.pair.Diffs) == 0 {
+		return logging.DebugLevel
+	}
+
+	return logging.InformationLevel
+}
+
+func (msg *deployableMessage) Message() string {
+	if msg.pair.Prior == nil {
+		return fmt.Sprintf("New deployment: %q", msg.pair.ID())
+	}
+
+	if msg.pair.Post == nil {
+		return fmt.Sprintf("Deleted deployment: %q", msg.pair.ID())
+	}
+
+	if len(msg.pair.Diffs) == 0 {
+		return fmt.Sprintf("Unchanged deployment: %q", msg.pair.ID())
+	}
+
+	return fmt.Sprintf("Modified deployment: %q (% #v)", msg.pair.ID(), msg.pair.Diffs)
+}
+
+func (msg *deployableMessage) EachField(f logging.FieldReportFn) {
+	marshal := func(thing string, data interface{}) string {
+		b, err := json.Marshal(data)
+		if err != nil {
+			return fmt.Sprintf("error marshalling %s: %v", thing, err)
+		}
+		return string(b)
+	}
+	deployableFields := func(prefix string, d *Deployable) {
+		f(prefix+"-status", d.Status.String())
+		f(prefix+"-clustername", d.Deployment.ClusterName)
+		f(prefix+"-repo", d.Deployment.SourceID.Location.Repo)
+		f(prefix+"-offset", d.Deployment.SourceID.Location.Dir)
+		f(prefix+"-offset", d.Deployment.SourceID.Version.String())
+		f(prefix+"-flavor", d.Deployment.Flavor)
+		f(prefix+"-owners", strings.Join(d.Deployment.Owners.Slice(), ","))
+		f(prefix+"-kind", d.Deployment.Kind)
+		f(prefix+"-resources", marshal("resources", d.DeployConfig.Resources))
+		f(prefix+"-metadata", marshal("metadata", d.DeployConfig.Metadata))
+		f(prefix+"-env", marshal("env", d.DeployConfig.Env))
+		f(prefix+"-numinstances", d.DeployConfig.NumInstances)
+		f(prefix+"-volumes", marshal("volumes", d.DeployConfig.Volumes))
+		f(prefix+"-startup-skipcheck", d.DeployConfig.Startup.SkipCheck)
+		f(prefix+"-startup-connectdelay", d.DeployConfig.Startup.ConnectDelay)
+		f(prefix+"-startup-timeout", d.DeployConfig.Startup.Timeout)
+		f(prefix+"-startup-connectinterval", d.DeployConfig.Startup.ConnectInterval)
+		f(prefix+"-checkready-protocol", d.DeployConfig.Startup.CheckReadyProtocol)
+		f(prefix+"-checkready-uripath", d.DeployConfig.Startup.CheckReadyURIPath)
+		f(prefix+"-checkready-portindex", d.DeployConfig.Startup.CheckReadyPortIndex)
+		f(prefix+"-checkready-failurestatuses", d.DeployConfig.Startup.CheckReadyFailureStatuses)
+		f(prefix+"-checkready-uritimeout", d.DeployConfig.Startup.CheckReadyURITimeout)
+		f(prefix+"-checkready-interval", d.DeployConfig.Startup.CheckReadyInterval)
+		f(prefix+"-checkready-retries", d.DeployConfig.Startup.CheckReadyRetries)
+	}
+
+	msg.callerInfo.EachField(f)
+	if msg.pair.Prior != nil {
+		deployableFields("sous-prior", msg.pair.Prior)
+	}
+
+	if msg.pair.Post != nil {
+		deployableFields("sous-post", msg.pair.Post)
+	}
+}

--- a/lib/nameresolver.go
+++ b/lib/nameresolver.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/opentable/sous/util/logging"
 	"github.com/pkg/errors"
 )
@@ -25,7 +24,6 @@ func (names *nameResolver) Start(dp *DeployablePair) (*DeployablePair, *DiffReso
 	logging.Log.Vomit.Printf("Deployment processed, needs artifact: %#v", dep)
 
 	da, err := resolveName(names.registry, dep)
-	spew.Printf("Start resolve name %v %v", dep.Deployment.SourceID, err)
 	if err != nil {
 		logging.Log.Info.Printf("Unable to create new deployment %q: %s", dep.ID(), err)
 		logging.Log.Debug.Printf("Failed create deployment %q: % #v", dep.ID(), dep)
@@ -112,7 +110,6 @@ func guardImage(r Registry, d *Deployment) (*BuildArtifact, error) {
 		return nil, nil
 	}
 	art, err := r.GetArtifact(d.SourceID)
-	spew.Dump("resolving name", d.SourceID, err)
 	if err != nil {
 		return nil, &MissingImageNameError{err}
 	}

--- a/lib/nameresolver.go
+++ b/lib/nameresolver.go
@@ -14,10 +14,10 @@ type nameResolver struct {
 }
 
 // ResolveNames resolves diffs.
-func (d *DeployableChans) ResolveNames(r Registry) *DeployableChans {
+func (d *DeployableChans) ResolveNames(ctx context.Context, r Registry) *DeployableChans {
 	names := &nameResolver{registry: r}
 
-	return d.Pipeline(context.Background(), names)
+	return d.Pipeline(ctx, names)
 }
 
 func (names *nameResolver) Start(dp *DeployablePair) (*DeployablePair, *DiffResolution) {

--- a/lib/nameresolver.go
+++ b/lib/nameresolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/opentable/sous/util/logging"
 	"github.com/pkg/errors"
 )
@@ -110,6 +111,7 @@ func guardImage(r Registry, d *Deployment) (*BuildArtifact, error) {
 		return nil, nil
 	}
 	art, err := r.GetArtifact(d.SourceID)
+	spew.Dump("resolving", d.SourceID, art, err)
 	if err != nil {
 		return nil, &MissingImageNameError{err}
 	}

--- a/lib/nameresolver.go
+++ b/lib/nameresolver.go
@@ -1,0 +1,141 @@
+package sous
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/opentable/sous/util/logging"
+	"github.com/pkg/errors"
+)
+
+type nameResolver struct {
+	registry Registry
+}
+
+// ResolveNames resolves diffs.
+func (d *DeployableChans) ResolveNames(r Registry) *DeployableChans {
+	names := &nameResolver{registry: r}
+
+	return d.Pipeline(context.Background(), names)
+}
+
+func (names *nameResolver) Start(dp *DeployablePair) (*DeployablePair, *DiffResolution) {
+	spew.Dump(names)
+	dep := dp.Post
+	logging.Log.Vomit.Printf("Deployment processed, needs artifact: %#v", dep)
+
+	da, err := resolveName(names.registry, dep)
+	if err != nil {
+		logging.Log.Info.Printf("Unable to create new deployment %q: %s", dep.ID(), err)
+		logging.Log.Debug.Printf("Failed create deployment %q: % #v", dep.ID(), dep)
+		return nil, err
+	}
+
+	if da.BuildArtifact == nil {
+		logging.Log.Info.Printf("Unable to create new deployment %q: no artifact for SourceID %q", dep.ID(), dep.SourceID)
+		logging.Log.Debug.Printf("Failed create deployment %q: % #v", dep.ID(), dep)
+		return nil, &DiffResolution{
+			DeploymentID: dp.ID(),
+			Desc:         "not created",
+			Error:        WrapResolveError(errors.Errorf("Unable to create new deployment %q: no artifact for SourceID %q", dep.ID(), dep.SourceID)),
+		}
+	}
+	return &DeployablePair{ExecutorData: dp.ExecutorData, name: dp.name, Prior: nil, Post: da}, nil
+}
+
+func (names *nameResolver) Update(depPair *DeployablePair) (*DeployablePair, *DiffResolution) {
+	logging.Log.Vomit.Printf("Pair of deployments processed, needs artifact: %#v", depPair)
+	d, err := resolvePair(names.registry, depPair)
+	if err != nil {
+		logging.Log.Info.Printf("Unable to modify deployment %q: %s", depPair.Post, err)
+		logging.Log.Debug.Printf("Failed modify deployment %q: % #v", depPair.ID(), depPair.Post)
+		return nil, err
+	}
+	if d.Post.BuildArtifact == nil {
+		logging.Log.Info.Printf("Unable to modify deployment %q: no artifact for SourceID %q", depPair.ID(), depPair.Post.SourceID)
+		logging.Log.Debug.Printf("Failed modify deployment %q: % #v", depPair.ID(), depPair.Post)
+		return nil, &DiffResolution{
+			DeploymentID: depPair.ID(),
+			Desc:         "not updated",
+			Error:        WrapResolveError(errors.Errorf("Unable to modify new deployment %q: no artifact for SourceID %q", depPair.ID(), depPair.Post.SourceID)),
+		}
+	}
+	return d, nil
+}
+
+// Stop always returns no error because we don't need a deploy artifact to delete a deploy
+func (names *nameResolver) Stop(dp *DeployablePair) (*DeployablePair, *DiffResolution) {
+	da := maybeResolveSingle(names.registry, dp.Prior)
+	return &DeployablePair{ExecutorData: dp.ExecutorData, name: dp.name, Prior: da, Post: nil}, nil
+}
+
+// Stable always returns no error because we don't need a deploy artifact for unchanged deploys
+func (names *nameResolver) Stable(dp *DeployablePair) (*DeployablePair, *DiffResolution) {
+	da := maybeResolveSingle(names.registry, dp.Post)
+	return &DeployablePair{ExecutorData: dp.ExecutorData, name: dp.name, Prior: da, Post: da}, nil
+}
+
+// XXX now that everything is DeployablePairs, this can probably be simplified
+
+func maybeResolveSingle(r Registry, dep *Deployable) *Deployable {
+	logging.Log.Vomit.Printf("Attempting to resolve optional artifact: %#v (stable or deletes don't need images)", dep)
+	da, err := resolveName(r, dep)
+	if err != nil {
+		logging.Log.Debug.Printf("Error resolving stopped or stable deployment (proceeding anyway): %#v: %#v", dep, err)
+	}
+	return da
+}
+
+func resolveName(r Registry, d *Deployable) (*Deployable, *DiffResolution) {
+	art, err := guardImage(r, d.Deployment)
+	if err != nil {
+		return d, &DiffResolution{
+			DeploymentID: d.ID(),
+			Error:        &ErrorWrapper{error: err},
+		}
+	}
+	d.BuildArtifact = art
+	return d, nil
+}
+
+func resolvePair(r Registry, depPair *DeployablePair) (*DeployablePair, *DiffResolution) {
+	prior, _ := resolveName(r, depPair.Prior)
+	post, err := resolveName(r, depPair.Post)
+
+	return &DeployablePair{ExecutorData: depPair.ExecutorData, name: depPair.name, Prior: prior, Post: post}, err
+}
+
+func guardImage(r Registry, d *Deployment) (*BuildArtifact, error) {
+	if d.NumInstances == 0 {
+		logging.Log.Info.Printf("Deployment %q has 0 instances, skipping artifact check.", d.ID())
+		return nil, nil
+	}
+	art, err := r.GetArtifact(d.SourceID)
+	if err != nil {
+		return nil, &MissingImageNameError{err}
+	}
+	for _, q := range art.Qualities {
+		if q.Kind == "advisory" {
+			if q.Name == "" {
+				continue
+			}
+			advisoryIsValid := false
+			var allowedAdvisories []string
+			if d.Cluster == nil {
+				return nil, fmt.Errorf("nil cluster on deployment %q", d)
+			}
+			allowedAdvisories = d.Cluster.AllowedAdvisories
+			for _, aa := range allowedAdvisories {
+				if aa == q.Name {
+					advisoryIsValid = true
+					break
+				}
+			}
+			if !advisoryIsValid {
+				return nil, &UnacceptableAdvisory{q, &d.SourceID}
+			}
+		}
+	}
+	return art, err
+}

--- a/lib/nameresolver.go
+++ b/lib/nameresolver.go
@@ -25,6 +25,7 @@ func (names *nameResolver) Start(dp *DeployablePair) (*DeployablePair, *DiffReso
 	logging.Log.Vomit.Printf("Deployment processed, needs artifact: %#v", dep)
 
 	da, err := resolveName(names.registry, dep)
+	spew.Printf("Start resolve name %v %v", dep.Deployment.SourceID, err)
 	if err != nil {
 		logging.Log.Info.Printf("Unable to create new deployment %q: %s", dep.ID(), err)
 		logging.Log.Debug.Printf("Failed create deployment %q: % #v", dep.ID(), dep)
@@ -111,7 +112,7 @@ func guardImage(r Registry, d *Deployment) (*BuildArtifact, error) {
 		return nil, nil
 	}
 	art, err := r.GetArtifact(d.SourceID)
-	spew.Dump("resolving", d.SourceID, art, err)
+	spew.Dump("resolving name", d.SourceID, err)
 	if err != nil {
 		return nil, &MissingImageNameError{err}
 	}

--- a/lib/pipeline.go
+++ b/lib/pipeline.go
@@ -31,8 +31,8 @@ func (d *DeployableChans) Pipeline(ctx context.Context, proc DeployableProcessor
 			case dp, ok := <-from:
 				if ok {
 					proked, rez := doProc(dp)
-					spew.Dump(doProc, proked, rez)
 					if rez != nil {
+						spew.Printf("Pipeline rez: %v", rez)
 						handle(rez)
 						out.Errs <- rez
 					}
@@ -63,9 +63,7 @@ func (d *DeployableChans) Pipeline(ctx context.Context, proc DeployableProcessor
 	return out
 }
 
-func nullHandler(err *DiffResolution) {
-	spew.Dump("nullHandler", err)
-}
+func nullHandler(err *DiffResolution) {}
 
 // DeployableProcessor processes DeployablePairs off of a DeployableChans channel
 type DeployableProcessor interface {

--- a/lib/pipeline.go
+++ b/lib/pipeline.go
@@ -1,0 +1,83 @@
+package sous
+
+import (
+	"context"
+	"sync"
+)
+
+// Pipeline attaches a DeployableProcessor to the DeployableChans, and returns a new DeployableChans.
+func (d *DeployableChans) Pipeline(ctx context.Context, proc DeployableProcessor) *DeployableChans {
+	out := NewDeployableChans(1)
+
+	wg := sync.WaitGroup{}
+	wg.Add(4)
+
+	go func() {
+		for rez := range d.Errs {
+			out.Errs <- rez
+		}
+		wg.Wait()
+		close(out.Errs)
+	}()
+
+	process := func(from, to chan *DeployablePair, doProc func(dp *DeployablePair) (*DeployablePair, *DiffResolution)) {
+		defer close(to)
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case dp, ok := <-from:
+				if ok {
+					proked, rez := doProc(dp)
+					if rez != nil {
+						out.Errs <- rez
+					}
+					if proked != nil {
+						to <- proked
+					}
+				} else {
+					return
+				}
+			}
+		}
+	}
+
+	go process(d.Start, out.Start, proc.Start)
+	go process(d.Stop, out.Stop, proc.Stop)
+	go process(d.Stable, out.Stable, proc.Stable)
+	go process(d.Update, out.Update, proc.Update)
+	return out
+}
+
+// DeployableProcessor processes DeployablePairs off of a DeployableChans channel
+type DeployableProcessor interface {
+	Start(dp *DeployablePair) (*DeployablePair, *DiffResolution)
+	Stop(dp *DeployablePair) (*DeployablePair, *DiffResolution)
+	Stable(dp *DeployablePair) (*DeployablePair, *DiffResolution)
+	Update(dp *DeployablePair) (*DeployablePair, *DiffResolution)
+}
+
+// DeployablePassThrough implements DeployableProcessor trivially: each method simply passes its argument on
+// It is intended as an anonymous embed for Processors that e.g. don't care about Stable
+type DeployablePassThrough struct{}
+
+// Start returns its argument
+func (DeployablePassThrough) Start(dp *DeployablePair) (*DeployablePair, *DiffResolution) {
+	return dp, nil
+}
+
+// Stop returns its argument
+func (DeployablePassThrough) Stop(dp *DeployablePair) (*DeployablePair, *DiffResolution) {
+	return dp, nil
+}
+
+// Stable returns its argument
+func (DeployablePassThrough) Stable(dp *DeployablePair) (*DeployablePair, *DiffResolution) {
+	return dp, nil
+}
+
+// Update returns its argument
+func (DeployablePassThrough) Update(dp *DeployablePair) (*DeployablePair, *DiffResolution) {
+	return dp, nil
+}

--- a/lib/pipeline.go
+++ b/lib/pipeline.go
@@ -26,18 +26,18 @@ func (d *DeployableChans) Pipeline(ctx context.Context, proc DeployableProcessor
 			select {
 			case <-ctx.Done():
 				return
-			case dp, ok := <-from:
-				if ok {
-					proked, rez := doProc(dp)
-					if rez != nil {
-						handle(rez)
-						out.Errs <- rez
-					}
-					if proked != nil {
-						to <- proked
-					}
-				} else {
+			case dp, open := <-from:
+				if !open {
 					return
+				}
+
+				proked, rez := doProc(dp)
+				if rez != nil {
+					handle(rez)
+					out.Errs <- rez
+				}
+				if proked != nil {
+					to <- proked
 				}
 			}
 		}

--- a/lib/pipeline.go
+++ b/lib/pipeline.go
@@ -32,7 +32,7 @@ func (d *DeployableChans) Pipeline(ctx context.Context, proc DeployableProcessor
 				if ok {
 					proked, rez := doProc(dp)
 					if rez != nil {
-						spew.Printf("Pipeline rez: %v", rez)
+						spew.Printf("Pipeline rez: %v\n", rez)
 						handle(rez)
 						out.Errs <- rez
 					}
@@ -49,6 +49,7 @@ func (d *DeployableChans) Pipeline(ctx context.Context, proc DeployableProcessor
 	go func() {
 		for rez := range d.Errs {
 			handle(rez)
+			spew.Printf("Passthrough rez: %v\n", rez)
 			out.Errs <- rez
 		}
 		wg.Wait()

--- a/lib/pipeline.go
+++ b/lib/pipeline.go
@@ -31,6 +31,7 @@ func (d *DeployableChans) Pipeline(ctx context.Context, proc DeployableProcessor
 			case dp, ok := <-from:
 				if ok {
 					proked, rez := doProc(dp)
+					spew.Dump(doProc, proked, rez)
 					if rez != nil {
 						handle(rez)
 						out.Errs <- rez
@@ -63,7 +64,7 @@ func (d *DeployableChans) Pipeline(ctx context.Context, proc DeployableProcessor
 }
 
 func nullHandler(err *DiffResolution) {
-	spew.Dump(err)
+	spew.Dump("nullHandler", err)
 }
 
 // DeployableProcessor processes DeployablePairs off of a DeployableChans channel

--- a/lib/pipeline.go
+++ b/lib/pipeline.go
@@ -3,8 +3,6 @@ package sous
 import (
 	"context"
 	"sync"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 // Pipeline attaches a DeployableProcessor to the DeployableChans, and returns a new DeployableChans.
@@ -32,7 +30,6 @@ func (d *DeployableChans) Pipeline(ctx context.Context, proc DeployableProcessor
 				if ok {
 					proked, rez := doProc(dp)
 					if rez != nil {
-						spew.Printf("Pipeline rez: %v\n", rez)
 						handle(rez)
 						out.Errs <- rez
 					}
@@ -49,7 +46,6 @@ func (d *DeployableChans) Pipeline(ctx context.Context, proc DeployableProcessor
 	go func() {
 		for rez := range d.Errs {
 			handle(rez)
-			spew.Printf("Passthrough rez: %v\n", rez)
 			out.Errs <- rez
 		}
 		wg.Wait()

--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -121,7 +121,8 @@ func (r *Resolver) Begin(intended Deployments, clusters Clusters) *ResolveRecord
 		recorder.performGuaranteedPhase("rectification", func() {
 			r.rectify(logger, recorder.Log)
 		})
+		spew.Dump("Waiting for logger")
 		logger.Wait()
-		spew.Dump("done resolving")
+		spew.Dump("logger is done")
 	})
 }

--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/opentable/sous/util/logging"
 )
 
@@ -121,5 +122,6 @@ func (r *Resolver) Begin(intended Deployments, clusters Clusters) *ResolveRecord
 			r.rectify(logger, recorder.Log)
 		})
 		logger.Wait()
+		spew.Dump("done resolving")
 	})
 }

--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -109,10 +109,12 @@ func (r *Resolver) Begin(intended Deployments, clusters Clusters) *ResolveRecord
 			logger = namer.Log(ctx, r.ls)
 			logger.Add(1)
 			go func() {
-				for err := range namer.Errs {
+				for err := range logger.Errs {
+					spew.Printf("resolver copy err: %v\n", err)
 					recorder.Log <- *err
 					//DiffResolution{Error: &ErrorWrapper{error: err}}
 				}
+				spew.Printf("logger.Errs closed\n")
 				logger.Done()
 			}()
 			// TODO: ResolveNames should take rs.Log instead of errs.

--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -94,20 +94,19 @@ func (r *Resolver) Begin(intended Deployments, clusters Clusters) *ResolveRecord
 		//	ds.Status = DeployStatusPending
 		//})
 
-		namer := NewDeployableChans(10)
+		var namer *DeployableChans
 		var wg sync.WaitGroup
 		recorder.performGuaranteedPhase("resolving deployment artifacts", func() {
-			errs := make(chan *DiffResolution)
+			namer = diffs.ResolveNames(r.Registry)
 			wg.Add(1)
 			go func() {
-				for err := range errs {
+				for err := range namer.Errs {
 					recorder.Log <- *err
 					//DiffResolution{Error: &ErrorWrapper{error: err}}
 				}
 				wg.Done()
 			}()
 			// TODO: ResolveNames should take rs.Log instead of errs.
-			namer.ResolveNames(r.Registry, diffs, errs)
 		})
 
 		recorder.performGuaranteedPhase("rectification", func() {

--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -102,18 +102,17 @@ func (r *Resolver) Begin(intended Deployments, clusters Clusters) *ResolveRecord
 		//})
 
 		var logger *DeployableChans
-		var wg sync.WaitGroup
 		ctx := context.Background()
 		recorder.performGuaranteedPhase("resolving deployment artifacts", func() {
 			namer := diffs.ResolveNames(ctx, r.Registry)
 			logger = namer.Log(ctx, r.ls)
-			wg.Add(1)
+			logger.Add(1)
 			go func() {
 				for err := range namer.Errs {
 					recorder.Log <- *err
 					//DiffResolution{Error: &ErrorWrapper{error: err}}
 				}
-				wg.Done()
+				logger.Done()
 			}()
 			// TODO: ResolveNames should take rs.Log instead of errs.
 		})
@@ -121,6 +120,6 @@ func (r *Resolver) Begin(intended Deployments, clusters Clusters) *ResolveRecord
 		recorder.performGuaranteedPhase("rectification", func() {
 			r.rectify(logger, recorder.Log)
 		})
-		wg.Wait()
+		logger.Wait()
 	})
 }

--- a/lib/resolver_test.go
+++ b/lib/resolver_test.go
@@ -17,7 +17,7 @@ func TestGuardImageMissing(t *testing.T) {
 	missing := Deployment{ClusterName: `x`, SourceID: svOne, DeployConfig: config, Cluster: clusterX}
 
 	dr.FeedArtifact(nil, fmt.Errorf("dummy error"))
-	_, err := GuardImage(dr, &missing)
+	_, err := guardImage(dr, &missing)
 	assert.Error(err)
 }
 
@@ -32,7 +32,7 @@ func TestGuardImageRejected(t *testing.T) {
 
 	dr.FeedArtifact(&BuildArtifact{"ot-docker/one", "docker", []Quality{{"ephemeral_tag", "advisory"}}}, nil)
 
-	_, err := GuardImage(dr, &rejected)
+	_, err := guardImage(dr, &rejected)
 	assert.Error(err)
 
 }
@@ -47,7 +47,7 @@ func TestAllowUndeployedUglies(t *testing.T) {
 
 	dr.FeedArtifact(nil, fmt.Errorf("dummy error"))
 
-	_, err := GuardImage(dr, &borken)
+	_, err := guardImage(dr, &borken)
 	assert.NoError(err)
 }
 
@@ -61,7 +61,7 @@ func TestAllowsWhitelistedAdvisories(t *testing.T) {
 
 	dr.FeedArtifact(&BuildArtifact{"ot-docker/one", "docker", []Quality{{"ephemeral_tag", "advisory"}}}, nil)
 
-	art, err := GuardImage(dr, &intoCI)
+	art, err := guardImage(dr, &intoCI)
 	assert.NoError(err)
 	assert.NotNil(art)
 }

--- a/lib/resolvestatus.go
+++ b/lib/resolvestatus.go
@@ -92,15 +92,16 @@ func NewResolveRecorder(intended Deployments, f func(*ResolveRecorder)) *Resolve
 
 	go func() {
 		for rez := range rr.Log {
-			spew.Dump("resolve recorder", rez)
 			rr.write(func() {
 				rr.status.Log = append(rr.status.Log, rez)
 				if rez.Error != nil {
+					spew.Dump("rez Error", rez.Error)
 					rr.status.Errs.Causes = append(rr.status.Errs.Causes, ErrorWrapper{error: rez.Error})
 					logging.Log.Debug.Printf("resolve error = %+v\n", rez.Error)
 				}
 			})
 		}
+		spew.Dump("closing finished")
 		close(rr.finished)
 	}()
 
@@ -151,6 +152,7 @@ func (rr *ResolveRecorder) Done() bool {
 // Wait blocks until the resolution is finished.
 func (rr *ResolveRecorder) Wait() error {
 	<-rr.finished
+	spew.Dump("finished closed")
 	var err error
 	rr.read(func() {
 		err = rr.err

--- a/lib/resolvestatus.go
+++ b/lib/resolvestatus.go
@@ -49,6 +49,7 @@ type (
 	}
 
 	// ResolutionType marks the kind of a DiffResolution
+	// XXX should be made an int and generate with gostringer
 	ResolutionType string
 )
 

--- a/lib/resolvestatus.go
+++ b/lib/resolvestatus.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/opentable/sous/util/logging"
 )
 
@@ -95,13 +94,11 @@ func NewResolveRecorder(intended Deployments, f func(*ResolveRecorder)) *Resolve
 			rr.write(func() {
 				rr.status.Log = append(rr.status.Log, rez)
 				if rez.Error != nil {
-					spew.Printf("rez Error %v", rez.Error)
 					rr.status.Errs.Causes = append(rr.status.Errs.Causes, ErrorWrapper{error: rez.Error})
 					logging.Log.Debug.Printf("resolve error = %+v\n", rez.Error)
 				}
 			})
 		}
-		spew.Dump("closing finished")
 		close(rr.finished)
 	}()
 
@@ -112,9 +109,7 @@ func NewResolveRecorder(intended Deployments, f func(*ResolveRecorder)) *Resolve
 			if rr.err == nil {
 				rr.status.Phase = "finished"
 			}
-			spew.Dump("closing Log")
 			close(rr.Log)
-			spew.Dump("Log closed")
 		})
 	}()
 	return rr
@@ -122,7 +117,6 @@ func NewResolveRecorder(intended Deployments, f func(*ResolveRecorder)) *Resolve
 
 // Err returns any collected error from the course of resolution
 func (rs *ResolveStatus) Err() error {
-	spew.Dump("resolve status Err", rs.Errs, len(rs.Errs.Causes))
 	if len(rs.Errs.Causes) > 0 {
 		return &rs.Errs
 	}
@@ -154,7 +148,6 @@ func (rr *ResolveRecorder) Done() bool {
 // Wait blocks until the resolution is finished.
 func (rr *ResolveRecorder) Wait() error {
 	<-rr.finished
-	spew.Dump("finished closed")
 	var err error
 	rr.read(func() {
 		err = rr.err

--- a/lib/resolvestatus.go
+++ b/lib/resolvestatus.go
@@ -95,7 +95,7 @@ func NewResolveRecorder(intended Deployments, f func(*ResolveRecorder)) *Resolve
 			rr.write(func() {
 				rr.status.Log = append(rr.status.Log, rez)
 				if rez.Error != nil {
-					spew.Dump("rez Error", rez.Error)
+					spew.Printf("rez Error %v", rez.Error)
 					rr.status.Errs.Causes = append(rr.status.Errs.Causes, ErrorWrapper{error: rez.Error})
 					logging.Log.Debug.Printf("resolve error = %+v\n", rez.Error)
 				}
@@ -112,7 +112,9 @@ func NewResolveRecorder(intended Deployments, f func(*ResolveRecorder)) *Resolve
 			if rr.err == nil {
 				rr.status.Phase = "finished"
 			}
+			spew.Dump("closing Log")
 			close(rr.Log)
+			spew.Dump("Log closed")
 		})
 	}()
 	return rr

--- a/util/logging/graphiteconfigmessage.go
+++ b/util/logging/graphiteconfigmessage.go
@@ -34,6 +34,6 @@ func (gcm graphiteConfigMessage) EachField(f FieldReportFn) {
 		return
 	}
 	f("sous-successful-connection", true)
-	f("server-addr", gcm.cfg.Addr)
-	f("flush-interval", gcm.cfg.FlushInterval)
+	f("graphite-server-address", gcm.cfg.Addr)
+	f("graphite-flush-interval", gcm.cfg.FlushInterval)
 }

--- a/util/logging/graphiteconfigmessage.go
+++ b/util/logging/graphiteconfigmessage.go
@@ -30,10 +30,10 @@ func (gcm graphiteConfigMessage) EachField(f FieldReportFn) {
 	f("@loglov3-otl", "sous-graphite-config-v1")
 	gcm.CallerInfo.EachField(f)
 	if gcm.cfg == nil {
-		f("connected", false)
+		f("sous-successful-connection", false)
 		return
 	}
-	f("connected", true)
+	f("sous-successful-connection", true)
 	f("server-addr", gcm.cfg.Addr)
 	f("flush-interval", gcm.cfg.FlushInterval)
 }

--- a/util/logging/kafkaconfigurationmessage.go
+++ b/util/logging/kafkaconfigurationmessage.go
@@ -34,12 +34,12 @@ func (kcm kafkaConfigurationMessage) EachField(f FieldReportFn) {
 	f("@loglov3-otl", "sous-kafka-config-v1")
 	kcm.CallerInfo.EachField(f)
 	if kcm.hook == nil {
-		f("connected", false)
+		f("sous-successful-connection", false)
 		return
 	}
-	f("connected", true)
-	f("logging-topic", kcm.topic)
-	f("brokers", kcm.brokers)
-	f("logger-id", kcm.hook.Id())
-	f("levels", kcm.hook.Levels())
+	f("sous-successful-connection", true)
+	f("kafka-logging-topic", kcm.topic)
+	f("kafka-brokers", kcm.brokers)
+	f("kafka-logger-id", kcm.hook.Id())
+	f("kafka-logging-levels", kcm.hook.Levels())
 }

--- a/util/logging/testsupport.go
+++ b/util/logging/testsupport.go
@@ -161,6 +161,9 @@ func AssertMessageFields(t *testing.T, msg eachFielder, variableFields []string,
 
 	assert.Equal(t, fixedFields, actualFields)
 
+	// If the test passes, write a proposed OTL to a tempfile and report the path.
+	// These are super useful for updating the logging schemas,
+	// and get us a long way toward aligning our fields with theirs.
 	if _, hasOTL := actualFields["@loglov3-otl"]; !t.Failed() && hasOTL {
 		tmpfile, err := ioutil.TempFile("", actualFields["@loglov3-otl"].(string))
 		if err != nil {


### PR DESCRIPTION
Includes a shift in architecture around how DeployableChans work:

The differs produce DeployableChans, on which Pipeline() gets called to add
processors. ResolveNames is now a specialization of Pipeline().

Logging is handled by a pipeline processor.

Also included: the logging.AssertMessageFormat helper emits propsed OTLs to $TMPDIR.
They're not ready for immediate inclusion, but they sure save a lot of work.