### PR TITLE
Poll full resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ with respect to its command line interface and HTTP interface.
 * Client: 'sous deploy' now waits for a complete resolution to take place before
   reporting failure. This avoids a race condition where earlier failures could
   be misreported as failures with the current deployment.
+* Client: 'sous deploy' now bails out if no changes are detected after the present
+  resolve cycle has completed, or if the latest version in the GDM does not match that
+  expected. This solves an issue where deployments would appear to hang for a long time 
+  and eventually fail with a confusing error message, often due to conflicting updates.
 * Client: commands 'sous deploy', 'sous manifest get' and 'sous manifest set' now receive the correct auto-detected offset
   so you no longer require the -offset flag in most cases (unless you need to override it).
 * Server: Changing Startup.SkipCheck now correctly results in a re-deploy with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.42..HEAD)
+### Fixed
+* Client: 'sous deploy' now waits for a complete resolution to take place before
+  reporting failure. This avoids a race condition where earlier failures could
+  be misreported as failures with the current deployment.
+
 ## [0.5.42](//github.com/opentable/sous/compare/0.5.41..0.5.42)
 ### Fixed
 * All: Graphite output was like `sous.sous.ci.sfautoresolver.fullcycle-duration.count`, now `sous.ci.sf.auto...`

--- a/lib/dummy_rectification_client.go
+++ b/lib/dummy_rectification_client.go
@@ -45,7 +45,7 @@ func (drc *DummyRectificationClient) Deploy(d Deployable, reqID string) error {
 
 // PostRequest (cluster, request id, instance count)
 func (drc *DummyRectificationClient) PostRequest(d Deployable, id string) error {
-	drc.logf("Creating application %#v", d, id)
+	drc.logf("Creating application %#v %s", d, id)
 	drc.Created = append(drc.Created, d)
 	return nil
 }

--- a/lib/resolvestate.go
+++ b/lib/resolvestate.go
@@ -50,3 +50,35 @@ const (
 	// might proceed from states that are complete
 	ResolveTERMINALS = ResolveNotIntended
 )
+
+// XXX we might consider using go generate with `stringer` (c.f.)
+func (rs ResolveState) String() string {
+	switch rs {
+	default:
+		return "unknown (oops)"
+	case ResolveNotPolled:
+		return "ResolveNotPolled"
+	case ResolveNotStarted:
+		return "ResolveNotStarted"
+	case ResolvePendingRequest:
+		return "ResolvePendingRequest"
+	case ResolveNotVersion:
+		return "ResolveNotVersion"
+	case ResolveInProgress:
+		return "ResolveInProgress"
+	case ResolveErredHTTP:
+		return "ResolveErredHTTP"
+	case ResolveErredRez:
+		return "ResolveErredRez"
+	case ResolveTasksStarting:
+		return "ResolveTasksStarting"
+	case ResolveNotIntended:
+		return "ResolveNotIntended"
+	case ResolveFailed:
+		return "ResolveFailed"
+	case ResolveComplete:
+		return "ResolveComplete"
+	case ResolveMAX:
+		return "resolve maximum marker - not a real state, received in error?"
+	}
+}

--- a/lib/resolvestate.go
+++ b/lib/resolvestate.go
@@ -1,0 +1,52 @@
+package sous
+
+// A ResolveState reflects the state of the Sous clusters in regard to
+// resolving a particular SourceID.
+type ResolveState int
+
+const (
+	// ResolveNotPolled is the entry state. It means we haven't received data
+	// from a server yet.
+	ResolveNotPolled ResolveState = iota
+	// ResolveNotStarted conveys the condition that the server is not yet working
+	// to resolve the SourceLocation in question. Granted that a manifest update
+	// has succeeded, expect that once the current auto-resolve cycle concludes,
+	// the resolve-subject GDM will be updated, and we'll move past this state.
+	ResolveNotStarted
+	// ResolveNotVersion conveys that the server knows the SourceLocation
+	// already, but is resolving a different version. Again, expect that on the
+	// next auto-resolve cycle we'll move past this state.
+	ResolveNotVersion
+	// ResolvePendingRequest conveys that, while the server has registered the
+	// intent for the current resolve cycle, no request has yet been made to
+	// Singularity.
+	ResolvePendingRequest
+	// ResolveInProgress conveys a resolve action has been taken by the server,
+	// which implies that the server's intended version (which we've confirmed is
+	// the same as our intended version) is different from the
+	// Mesos/Singularity's version.
+	ResolveInProgress
+	// ResolveTasksStarting is the state when the resolution is complete from
+	// Sous' point of view, but awaiting tasks starting in the cluster.
+	ResolveTasksStarting
+	// ResolveErredHTTP  conveys that the HTTP request to the server returned an error
+	ResolveErredHTTP
+	// ResolveErredRez conveys that the resolving server reported a transient error
+	ResolveErredRez
+	// ResolveNotIntended indicates that a particular cluster does not intend to
+	// deploy the given deployment(s)
+	ResolveNotIntended
+	// ResolveComplete is the success state: the server knows about our intended
+	// deployment, and that deployment has returned as having been stable.
+	ResolveComplete
+	// ResolveFailed indicates that a particular cluster is in a failed state
+	// regarding resolving the deployments, and that resolution cannot proceed.
+	ResolveFailed
+	// ResolveMAX is not a state itself: it marks the top end of resolutions. All
+	// other states belong before it.
+	ResolveMAX
+
+	// ResolveTERMINALS is not a state itself: it demarks resolution states that
+	// might proceed from states that are complete
+	ResolveTERMINALS = ResolveNotIntended
+)

--- a/lib/status_poller.go
+++ b/lib/status_poller.go
@@ -321,9 +321,6 @@ func (sub *subPoller) start(rs chan pollResult, done chan struct{}) {
 	ticker := time.NewTicker(PollTimeout)
 	defer ticker.Stop()
 	for {
-		//if sub.lastCycle && pollResult.stat >= ResolveTERMINALS {
-		//	return
-		//}
 		select {
 		case <-ticker.C:
 			latest := sub.pollOnce()

--- a/lib/status_poller.go
+++ b/lib/status_poller.go
@@ -426,18 +426,18 @@ func (sub *subPoller) computeState(srvIntent *Deployment, current *DiffResolutio
 		// error for operator action, and consider this subpoller done as failed.
 		logging.Log.Vomitf("%#v", current)
 		logging.Log.Vomitf("%#v", current.Error)
-		//subject := ""
-		//if sub.locationFilter == nil {
-		//	subject = "<no filter defined>"
-		//} else {
-		//	sourceLocation, ok := sub.locationFilter.SourceLocation()
-		//	if ok {
-		//		subject = sourceLocation.String()
-		//	} else {
-		//		subject = sub.locationFilter.String()
-		//	}
-		//}
-		//logging.Log.Warn.Printf("Deployment of %s to %s failed: %s", subject, sub.ClusterName, current.Error.String)
+		subject := ""
+		if sub.locationFilter == nil {
+			subject = "<no filter defined>"
+		} else {
+			sourceLocation, ok := sub.locationFilter.SourceLocation()
+			if ok {
+				subject = sourceLocation.String()
+			} else {
+				subject = sub.locationFilter.String()
+			}
+		}
+		logging.Log.Warn.Printf("Deployment of %s to %s failed: %s", subject, sub.ClusterName, current.Error.String)
 		return ResolveFailed, current.Error
 	}
 

--- a/lib/status_poller.go
+++ b/lib/status_poller.go
@@ -19,6 +19,7 @@ type (
 		statePerCluster map[string]*pollerState
 		status          ResolveState
 		logs            logging.LogSink
+		results         chan pollResult
 	}
 
 	pollerState struct {
@@ -65,63 +66,12 @@ type (
 		Completed, InProgress *ResolveStatus
 	}
 
-	// A ResolveState reflects the state of the Sous clusters in regard to
-	// resolving a particular SourceID.
-	ResolveState int
-
 	pollResult struct {
 		url       string
 		stat      ResolveState
 		err       error
 		resolveID string
 	}
-)
-
-const (
-	// ResolveNotPolled is the entry state. It means we haven't received data
-	// from a server yet.
-	ResolveNotPolled ResolveState = iota
-	// ResolveNotStarted conveys the condition that the server is not yet working
-	// to resolve the SourceLocation in question. Granted that a manifest update
-	// has succeeded, expect that once the current auto-resolve cycle concludes,
-	// the resolve-subject GDM will be updated, and we'll move past this state.
-	ResolveNotStarted
-	// ResolveNotVersion conveys that the server knows the SourceLocation
-	// already, but is resolving a different version. Again, expect that on the
-	// next auto-resolve cycle we'll move past this state.
-	ResolveNotVersion
-	// ResolvePendingRequest conveys that, while the server has registered the
-	// intent for the current resolve cycle, no request has yet been made to
-	// Singularity.
-	ResolvePendingRequest
-	// ResolveInProgress conveys a resolve action has been taken by the server,
-	// which implies that the server's intended version (which we've confirmed is
-	// the same as our intended version) is different from the
-	// Mesos/Singularity's version.
-	ResolveInProgress
-	// ResolveTasksStarting is the state when the resolution is complete from
-	// Sous' point of view, but awaiting tasks starting in the cluster.
-	ResolveTasksStarting
-	// ResolveErredHTTP  conveys that the HTTP request to the server returned an error
-	ResolveErredHTTP
-	// ResolveErredRez conveys that the resolving server reported a transient error
-	ResolveErredRez
-	// ResolveNotIntended indicates that a particular cluster does not intend to
-	// deploy the given deployment(s)
-	ResolveNotIntended
-	// ResolveFailed indicates that a particular cluster is in a failed state
-	// regarding resolving the deployments, and that resolution cannot proceed.
-	ResolveFailed
-	// ResolveComplete is the success state: the server knows about our intended
-	// deployment, and that deployment has returned as having been stable.
-	ResolveComplete
-	// ResolveMAX is not a state itself: it marks the top end of resolutions. All
-	// other states belong before it.
-	ResolveMAX
-
-	// ResolveTERMINALS is not a state itself: it demarks resolution states that
-	// might proceed from states that are complete
-	ResolveTERMINALS = ResolveNotIntended
 )
 
 // XXX we might consider using go generate with `stringer` (c.f.)
@@ -211,6 +161,7 @@ func (sp *StatusPoller) Wait(ctx context.Context) (ResolveState, error) {
 }
 
 func (sp *StatusPoller) waitForever() (ResolveState, error) {
+	sp.results = make(chan pollResult)
 	// Retrieve the list of servers known to our main server.
 	clusters := &serverListData{}
 	if _, err := sp.Retrieve("./servers", nil, clusters, sp.User.HTTPHeaders()); err != nil {
@@ -274,12 +225,11 @@ func (sp *StatusPoller) poll(subs []*subPoller) ResolveState {
 	if len(subs) == 0 {
 		return ResolveNotIntended
 	}
-	collect := make(chan pollResult)
 	done := make(chan struct{})
 	go func() {
 		sp.statePerCluster = map[string]*pollerState{}
 		for {
-			sp.nextSubStatus(collect)
+			sp.nextSubStatusBurst()
 			if sp.finished() {
 				close(done)
 				return
@@ -288,20 +238,28 @@ func (sp *StatusPoller) poll(subs []*subPoller) ResolveState {
 	}()
 
 	for _, s := range subs {
-		go s.start(collect, done)
+		go s.start(sp.results, done)
 	}
 
 	<-done
 	return sp.status
 }
 
-func (sp *StatusPoller) nextSubStatus(collect chan pollResult) {
-	update := <-collect
+func (sp *StatusPoller) nextSubStatusBurst() {
+	for {
+		select {
+		case <-time.After(time.Second):
+			return
+		case update := <-sp.results:
+			sp.nextSubStatus(update)
+		}
+	}
+}
+
+func (sp *StatusPoller) nextSubStatus(update pollResult) {
 	if lastState, ok := sp.statePerCluster[update.url]; ok {
 		if lastState.LastResult.resolveID != "" && lastState.LastResult.resolveID != update.resolveID {
-			// TODO: Look at this.
-			panic("LAST_CYCLE_W00t")
-			sp.statePerCluster[update.url].LastCycle = true
+			lastState.LastCycle = true
 		}
 	} else {
 		sp.statePerCluster[update.url] = &pollerState{LastResult: update}
@@ -310,30 +268,49 @@ func (sp *StatusPoller) nextSubStatus(collect chan pollResult) {
 	logging.Log.Debugf("%s reports state: %s", update.url, update.stat)
 }
 
+func minStatus(a, b ResolveState) ResolveState {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxStatus(a, b ResolveState) ResolveState {
+	if a > b {
+		return a
+	}
+	return b
+}
+
 func (sp *StatusPoller) updateStatus() {
-	max := ResolveMAX
+	max := ResolveNotPolled
+	totalMax := ResolveFailed
+	totalMin := ResolveNotPolled
+	allLastCycle := true
 	for u, s := range sp.statePerCluster {
 		logging.Log.Vomitf("Current state from %s: %s", u, s)
-
-		// Discard statuses from the initial resolve cycle, report max status of
-		// 'in progress' until the resolveID has changed thus LastCycle == true.
+		//max = maxStatus(max, s.LastResult.stat)
 		if !s.LastCycle {
-			// Quick math.Min impl for integers...
-			if ResolveTERMINALS <= s.LastResult.stat {
-				max = ResolveInProgress
-			} else {
-				max = s.LastResult.stat
-			}
-			break
+			allLastCycle = false
 		}
-
-		//if max is already > EJECT, we can quit without waiting for other subs
-		if s.LastResult.stat <= max {
-			max = s.LastResult.stat
+		if s.LastResult.stat <= ResolveTERMINALS {
+			totalMax = minStatus(totalMax, ResolveTERMINALS)
 		}
+		max = maxStatus(max, s.LastResult.stat)
+		//max = minStatus(max, totalMax)
+		//max = maxStatus(max, totalMin)
 	}
 
-	sp.status = max
+	if allLastCycle {
+		totalMin = maxStatus(totalMin, ResolveInProgress)
+	} else {
+		totalMax = minStatus(totalMax, ResolveInProgress)
+	}
+
+	max = maxStatus(max, totalMin)
+	max = minStatus(max, totalMax)
+
+	sp.status = maxStatus(sp.status, max)
 }
 
 func (sp *StatusPoller) finished() bool {

--- a/lib/status_poller.go
+++ b/lib/status_poller.go
@@ -267,6 +267,12 @@ func (sp *StatusPoller) computeStatus() ResolveState {
 		if s.LastCycle {
 			lastCycleMax = maxStatus(lastCycleMax, s.LastResult.stat)
 			lastCycleMin = minStatus(lastCycleMin, s.LastResult.stat)
+			if s.LastResult.stat == ResolveNotVersion {
+				return ResolveFailed
+			}
+			if s.LastResult.stat == ResolveNotStarted {
+				return ResolveFailed
+			}
 		} else {
 			firstCycleMax = maxStatus(firstCycleMax, s.LastResult.stat)
 			firstCycleMin = minStatus(firstCycleMin, s.LastResult.stat)

--- a/lib/status_poller.go
+++ b/lib/status_poller.go
@@ -315,11 +315,11 @@ func (sp *StatusPoller) updateStatus() {
 	for u, s := range sp.statePerCluster {
 		logging.Log.Vomitf("Current state from %s: %s", u, s)
 
-		// Discard statuses from the initial resolve cycle, just report
+		// Discard statuses from the initial resolve cycle, report max status of
 		// 'in progress' until the resolveID has changed thus LastCycle == true.
 		if !s.LastCycle {
 			// Quick math.Min impl for integers...
-			if ResolveTERMINALS < s.LastResult.stat {
+			if ResolveTERMINALS <= s.LastResult.stat {
 				max = ResolveInProgress
 			} else {
 				max = s.LastResult.stat

--- a/lib/status_poller_test.go
+++ b/lib/status_poller_test.go
@@ -115,8 +115,11 @@ func TestStatusPoller_updateState(t *testing.T) {
 		status: ResolveNotStarted,
 	}
 
-	assertStatus := func(status ResolveState) {
-		assert.Equal(sp.status, status, "StatusPoller total state was %s, expected %s", sp.status, status)
+	assertStatus := func(expected ResolveState) {
+		actual := sp.status
+		if actual != expected {
+			t.Errorf("got %s; want %s", actual, expected)
+		}
 	}
 
 	/// TODO: tests for "competing states"

--- a/lib/status_poller_test.go
+++ b/lib/status_poller_test.go
@@ -203,7 +203,7 @@ func TestStatusPoller_updateState(t *testing.T) {
 	// Two moves to ResolveNotStarted (second resolveID).
 	// Overall still ResolveInProgress because two still on first resolveID.
 	result("two", second, ResolveNotStarted)
-	expect(ResolveInProgress, notFinished)
+	expect(ResolveFailed, finished)
 
 	// One and two both move to ResolveNotPolled (second resolveID).
 	// Overall still ResolveInProgress because that's the highest
@@ -216,15 +216,31 @@ func TestStatusPoller_updateState(t *testing.T) {
 	result("one", second, ResolveFailed)
 	expect(ResolveFailed, finished)
 
-	// One moves to ResolveComplete in last cycle, still in progress.
+	// One moves to ResolveComplete in last cycle, still in progress
+	// because "two" still in ResolveNotPolled, second cycle.
 	result("one", second, ResolveComplete)
 	expect(ResolveInProgress, notFinished)
 
+	// Two moves to ResolveFailed in last cycle, finished failed
+	// because one complete.
 	result("two", second, ResolveFailed)
 	expect(ResolveFailed, finished)
 
+	// Two moves to ResolveComplete in last cycle, finished complete
+	// because one and two both complete in second cycle.
 	result("two", second, ResolveComplete)
 	expect(ResolveComplete, finished)
+
+	// Two moves to ResolveNotVersion in last cycle, finished failed
+	// because this means the change was never received by the GDM.
+	result("two", second, ResolveNotVersion)
+	expect(ResolveFailed, finished)
+
+	// Two moves to ResolveNotStarted in last cycle, finished failed
+	// because this means the change has been missed and will not be
+	// deployed.
+	result("two", second, ResolveNotStarted)
+	expect(ResolveFailed, finished)
 }
 
 func TestStatusPoller(t *testing.T) {

--- a/lib/status_poller_test.go
+++ b/lib/status_poller_test.go
@@ -613,7 +613,7 @@ func TestStatusPoller_MesosFailed(t *testing.T) {
 		testCh <- rState
 	}()
 
-	timeout := 10 * PollTimeout
+	timeout := 3 * PollTimeout
 	select {
 	case <-time.After(timeout):
 		t.Errorf("Happy path polling took more than %s", timeout)

--- a/lib/status_poller_test.go
+++ b/lib/status_poller_test.go
@@ -79,7 +79,7 @@ func TestSubPoller_ComputeState(t *testing.T) {
 				Tag: NewResolveFieldMatcher(version),
 			},
 		}
-		if actual := sub.computeState(intent, current); expected != actual {
+		if actual, _ := sub.computeState(intent, current); expected != actual {
 			t.Errorf("sub.computeState(%v, %v) -> %v != %v", intent, current, actual, expected)
 		}
 	}

--- a/util/logging/applicationid_test.go
+++ b/util/logging/applicationid_test.go
@@ -27,7 +27,7 @@ func TestApplicationIdMessageFields(t *testing.T) {
 			"singularity-task-id": "cabbage",
 			"service-type":        "sous",
 			"instance-no":         uint(17),
-			"sequence-number":     uint(1), // a little fragile
+			"sequence-number":     uint64(1), // a little fragile
 		}
 
 		AssertMessageFields(t, apid, variableFields, fixedFields)


### PR DESCRIPTION
The crucial part of this PR is the rather verbose `computeStatus` function. Because we have different rules to handle `ResolveComplete` vs `ResolveFailed` simple comparison with `ResolveTERMINALS` isn't very helpful for this method. The test `TestStatusPoller_updateState` reveals the new spec for computing this state.

Other changes include making `ResolveFailed` greater than `ResolveComplete` since when computing `maxStatus` we want failed states to take precedence over successful ones (although this may not now be important with the latest implementation of `computeStatus`.

I was using the race detector to check for anything fishy that might be affecting these tests, as a result this PR includes a couple of fixes for race conditions which were probably not relevant to the eventual solution but nonetheless were worth addressing.

`ResolveState` is now in its own file.