### PR TITLE
Defensive programming for panics SOUS-728

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.43..HEAD)
+
+### Fixed
+
+* Server: diff messages could panic when logging them if the diff didn't resolve correctly.
+* All: logging panics would crash the app.
+
 ## [0.5.43](//github.com/opentable/sous/compare/0.5.42..0.5.43)
 
 ### Added
@@ -14,7 +21,7 @@ with respect to its command line interface and HTTP interface.
   without sending it to the server. This flag interacts with the `-flavor`,
   `-use-otpl-deploy` and `-ignore-otpl-deploy` flags as well, so you can check sous'
   intentions in all these scenarios without accidentally creating manifests you don't want.
-  
+
 ### Fixed
 * Server: Changing Startup.SkipCheck now correctly results in a re-deploy with the
   updated value.

--- a/lib/loggingprocessor.go
+++ b/lib/loggingprocessor.go
@@ -92,6 +92,9 @@ func (msg *deployableMessage) EachField(f logging.FieldReportFn) {
 	}
 
 	deployableFields := func(prefix string, d *Deployable) {
+		if d == nil {
+			return
+		}
 		f(prefix+"-status", d.Status.String())
 		f(prefix+"-clustername", d.Deployment.ClusterName)
 		f(prefix+"-repo", d.Deployment.SourceID.Location.Repo)
@@ -124,18 +127,20 @@ func (msg *deployableMessage) EachField(f logging.FieldReportFn) {
 
 	f("@loglov3-otl", "sous-deployment-diff")
 	msg.callerInfo.EachField(f)
-	f("sous-deployment-id", msg.pair.ID().String())
-	f("sous-manifest-id", msg.pair.ID().ManifestID.String())
-	f("sous-diff-disposition", msg.pair.Kind().String())
-	if msg.pair.Kind() == ModifiedKind {
-		f("sous-deployment-diffs", msg.pair.Diffs.String())
-	}
+	if msg.pair != nil {
+		f("sous-deployment-id", msg.pair.ID().String())
+		f("sous-manifest-id", msg.pair.ID().ManifestID.String())
+		f("sous-diff-disposition", msg.pair.Kind().String())
+		if msg.pair.Kind() == ModifiedKind {
+			f("sous-deployment-diffs", msg.pair.Diffs.String())
+		}
 
-	if msg.pair.Prior != nil {
-		deployableFields("sous-prior", msg.pair.Prior)
-	}
-	if msg.pair.Post != nil {
-		deployableFields("sous-post", msg.pair.Post)
+		if msg.pair.Prior != nil {
+			deployableFields("sous-prior", msg.pair.Prior)
+		}
+		if msg.pair.Post != nil {
+			deployableFields("sous-post", msg.pair.Post)
+		}
 	}
 }
 

--- a/lib/loggingprocessor_test.go
+++ b/lib/loggingprocessor_test.go
@@ -134,6 +134,14 @@ func TestDiffMessages_incomplete(t *testing.T) {
 	}
 
 	logging.AssertMessageFields(t, msg, fixedFields, variableFields)
+
+	msg.pair = &DeployablePair{}
+
+	variableFields["sous-diff-disposition"] = "added"
+	variableFields["sous-deployment-id"] = ":"
+	variableFields["sous-manifest-id"] = ""
+
+	logging.AssertMessageFields(t, msg, fixedFields, variableFields)
 }
 
 func TestDiffResolutionMessages(t *testing.T) {

--- a/util/logging/panic_test.go
+++ b/util/logging/panic_test.go
@@ -1,0 +1,34 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type terribadLogMessage struct{}
+
+func (msg terribadLogMessage) DefaultLevel() Level {
+	panic("terribad!")
+}
+
+func (msg terribadLogMessage) Message() string {
+	panic("so much terrible")
+}
+
+func (msg terribadLogMessage) EachField(fn FieldReportFn) {
+	panic("never panic while logging; it's not worth crashing the app!")
+}
+
+func TestLogMessagePanicking(t *testing.T) {
+	log, ctrl := NewLogSinkSpy()
+
+	assert.NotPanics(t, func() {
+		Deliver(terribadLogMessage{}, log)
+	})
+
+	calls := ctrl.CallsTo("LogMessage")
+	if assert.Len(t, calls, 1) {
+		assert.IsType(t, &silentMessageError{}, calls[0].PassedArgs().Get(1))
+	}
+}


### PR DESCRIPTION
There's a test now for the diff messages, such that they omit fields
rather than drill down into nil fields (and thereby panic.)

Futhermore, there's a rescue in Deliver - if there's a panic in the
course of delivering a message, we log a (well tested and simple)
silentMessageErr - which will report the type of the "silent message":
loggingPanicFakeMessage, which is a signal that a log message panicked.

We'll get a log entry to mark the panic, but Sous won't crash because
formatting code related to producing a log message panicked.