### PR TITLE
'sous config' allows fixing broken config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ with respect to its command line interface and HTTP interface.
 
 ### Fixed
 * Client: a panic would occur if the remote server wasn't available or responded with a 500.
+* Attempting to fix invalid config using 'sous config' was not possible because we
+  were validating config as a precondition to executing the command. We now only
+  validate config for commands that rely on a valid config, so 'sous config' can be
+  used to correct issues.
 
 ## [0.5.44](//github.com/opentable/sous/compare/0.5.43..0.5.44)
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 
 	"github.com/opentable/sous/config"
 	"github.com/opentable/sous/graph"
@@ -135,9 +136,12 @@ func NewSousCLI(di *graph.SousGraph, s *Sous, out, errout io.Writer) (*CLI, erro
 	}
 
 	rootGraph := BuildCLIGraph(s, cli, out, errout)
+	addVerbosityOnce := sync.Once{}
 
 	cli.Hooks.Parsed = func(cmd cmdr.Command) error {
-		rootGraph.Add(&verbosity)
+		addVerbosityOnce.Do(func() {
+			rootGraph.Add(&verbosity)
+		})
 		if registrant, ok := cmd.(interface {
 			RegisterOn(Addable)
 		}); ok {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -73,15 +73,13 @@ func (cli *CLI) Plumbing(from cmdr.Command, cmd cmdr.Executor, args []string) cm
 	return cmd.Execute(args)
 }
 
-// Plumb injects a lists of commands with the currect psyringe, returning early in the event of an error
+// Plumb injects a lists of commands with the current psyringe,
+// returning early in the event of an error
 func (cli *CLI) Plumb(from cmdr.Command, cmds ...cmdr.Executor) error {
 	for _, cmd := range cmds {
 		if err := cli.baseGraph.Inject(cmd); err != nil {
 			return err
 		}
-		//if err := cli.scopedGraph(from, nil).Inject(cmd); err != nil {
-		//	return err
-		//}
 	}
 	return nil
 }
@@ -101,22 +99,6 @@ func BuildCLIGraph(root *Sous, cli *CLI, out, err io.Writer) *graph.SousGraph {
 
 	return cli.SousGraph
 }
-
-//func (cli *CLI) scopedGraph(cmd, under cmdr.Command) *graph.SousGraph {
-//	if g, ok := cli.scopedGraphs[cmd]; ok {
-//		return g
-//	}
-
-//
-//	parent := cli.scopedGraphs[under]
-//
-//	g := &graph.SousGraph{Psyringe: parent.Clone()}
-//	if r, ok := cmd.(Registrant); ok {
-//		r.RegisterOn(g)
-//	}
-//	cli.scopedGraphs[cmd] = g
-//	return g
-//}
 
 // NewSousCLI creates a new Sous cli app.
 func NewSousCLI(di *graph.SousGraph, s *Sous, out, errout io.Writer) (*CLI, error) {
@@ -152,16 +134,8 @@ func NewSousCLI(di *graph.SousGraph, s *Sous, out, errout io.Writer) (*CLI, erro
 		baseGraph: di,
 	}
 
-	//chain := []cmdr.Command{}
 	rootGraph := BuildCLIGraph(s, cli, out, errout)
-	//s.RegisterOn(rootGraph)
 
-	//cli.scopedGraphs = map[cmdr.Command]*graph.SousGraph{s: rootGraph}
-
-	//cli.Hooks.Parsed = func(cmd cmdr.Command) error {
-	//	chain = append(chain, cmd)
-	//	return nil
-	//}
 	cli.Hooks.Parsed = func(cmd cmdr.Command) error {
 		rootGraph.Add(&verbosity)
 		if registrant, ok := cmd.(interface {
@@ -172,26 +146,9 @@ func NewSousCLI(di *graph.SousGraph, s *Sous, out, errout io.Writer) (*CLI, erro
 		return nil
 	}
 
-	// Before Execute is called on any command, inject it with values from the
-	// graph.
+	// Before Execute is called on any command, inject its dependencies.
 	cli.Hooks.PreExecute = func(cmd cmdr.Command) error {
-
-		// Create the CLI dependency graph.
-		if err := rootGraph.Inject(cmd); err != nil {
-			return err
-		}
-
-		//for n, c := range chain {
-		//	var under cmdr.Command
-		//	if n > 0 {
-		//		under = chain[n-1]
-		//	}
-		//	g := cli.scopedGraph(c, under)
-		//	if err := g.Inject(c); err != nil {
-		//		return errors.Wrapf(err, "setup for execute")
-		//	}
-		//}
-		return nil
+		return rootGraph.Inject(cmd)
 	}
 
 	cli.Hooks.PreFail = func(err error) cmdr.ErrorResult {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -48,6 +48,11 @@ type (
 	Addable interface {
 		Add(...interface{})
 	}
+
+	// A Registrant is able to add values to an Addable (implicitly: a Psyringe)
+	Registrant interface {
+		RegisterOn(Addable)
+	}
 )
 
 // SuccessYAML lets you return YAML on the command line.
@@ -134,9 +139,7 @@ func NewSousCLI(di *graph.SousGraph, s *Sous, out, errout io.Writer) (*CLI, erro
 		addVerbosityOnce.Do(func() {
 			cli.graph.Add(&verbosity)
 		})
-		if registrant, ok := cmd.(interface {
-			RegisterOn(Addable)
-		}); ok {
+		if registrant, ok := cmd.(Registrant); ok {
 			registrant.RegisterOn(cli.graph)
 		}
 		return nil

--- a/cli/sous.go
+++ b/cli/sous.go
@@ -71,20 +71,11 @@ pull requests are welcome.
 func (*Sous) Help() string { return sousHelp }
 
 // AddFlags adds sous' flags.
-func (s *Sous) AddFlags(fs *flag.FlagSet) {
-	fs.BoolVar(&s.flags.Verbosity.Silent, "s", false,
-		"silent: silence all non-essential output")
-	fs.BoolVar(&s.flags.Verbosity.Quiet, "q", false,
-		"quiet: output only essential error messages")
-	fs.BoolVar(&s.flags.Verbosity.Loud, "v", false,
-		"loud: output extra info, including all shell commands")
-	fs.BoolVar(&s.flags.Verbosity.Debug, "d", false,
-		"debug: output detailed logs of internal operations")
-}
+func (s *Sous) AddFlags(fs *flag.FlagSet) {}
 
 // RegisterOn adds the Sous object itself to the Psyringe
 func (s *Sous) RegisterOn(psy Addable) {
-	psy.Add(&s.flags.Verbosity)
+	//psy.Add(&s.flags.Verbosity)
 }
 
 // Execute exists to present a helpful error to the user, in the case they just

--- a/cli/sous.go
+++ b/cli/sous.go
@@ -1,9 +1,6 @@
 package cli
 
 import (
-	"flag"
-
-	"github.com/opentable/sous/config"
 	"github.com/opentable/sous/ext/docker"
 	"github.com/opentable/sous/graph"
 	"github.com/opentable/sous/util/cmdr"
@@ -13,8 +10,7 @@ import (
 
 // Sous is the main sous command.
 type Sous struct {
-	// CLI is a reference to the CLI singleton. We use it here to set global
-	// verbosity.
+	// CLI is a reference to the CLI singleton.
 	CLI *CLI
 	graph.LogSink
 	// Err is the error message stream.
@@ -30,7 +26,6 @@ type Sous struct {
 	// flags holds the values of flags passed to this command
 	flags struct {
 		Help bool
-		config.Verbosity
 	}
 
 	/*
@@ -69,14 +64,6 @@ pull requests are welcome.
 
 // Help returns the top-level help for Sous.
 func (*Sous) Help() string { return sousHelp }
-
-// AddFlags adds sous' flags.
-func (s *Sous) AddFlags(fs *flag.FlagSet) {}
-
-// RegisterOn adds the Sous object itself to the Psyringe
-func (s *Sous) RegisterOn(psy Addable) {
-	//psy.Add(&s.flags.Verbosity)
-}
 
 // Execute exists to present a helpful error to the user, in the case they just
 // run 'sous' with not subcommand.

--- a/cli/sous.go
+++ b/cli/sous.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"github.com/opentable/sous/ext/docker"
 	"github.com/opentable/sous/graph"
 	"github.com/opentable/sous/util/cmdr"
 	"github.com/opentable/sous/util/whitespace"
@@ -27,16 +26,6 @@ type Sous struct {
 	flags struct {
 		Help bool
 	}
-
-	/*
-		This ensures the singularity of the field types - otherwise, if they're
-		injected twice and we have issues.
-
-		This is a temporary fix ahead of transitioning to a simpler DI.
-		 - jdl 9/28/17
-	*/
-	// added as a field here so that it will be singleton for the app
-	SingletonNameCache *docker.NameCache
 }
 
 // TopLevelCommands is populated once per command file (beginning sous_) in this

--- a/cli/sous_manifest.go
+++ b/cli/sous_manifest.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"github.com/opentable/sous/graph"
 	"github.com/opentable/sous/util/cmdr"
 )
 
@@ -18,11 +17,6 @@ const sousManifestHelp = `query and manipulate deployment manifests`
 // Subcommands implements Subcommander on SousManifest
 func (SousManifest) Subcommands() cmdr.Commands {
 	return ManifestSubcommands
-}
-
-// RegisterOn implements Registrant on SousManifest
-func (sm *SousManifest) RegisterOn(psy Addable) {
-	psy.Add(graph.DryrunNeither)
 }
 
 // Help implements Command on SousManifest

--- a/cli/sous_manifest_get.go
+++ b/cli/sous_manifest_get.go
@@ -32,6 +32,7 @@ func (smg *SousManifestGet) AddFlags(fs *flag.FlagSet) {
 }
 
 func (smg *SousManifestGet) RegisterOn(psy Addable) {
+	psy.Add(graph.DryrunNeither)
 	psy.Add(&smg.DeployFilterFlags)
 }
 

--- a/cli/sous_manifest_set.go
+++ b/cli/sous_manifest_set.go
@@ -38,6 +38,7 @@ func (smg *SousManifestSet) AddFlags(fs *flag.FlagSet) {
 }
 
 func (smg *SousManifestSet) RegisterOn(psy Addable) {
+	psy.Add(graph.DryrunNeither)
 	psy.Add(&smg.DeployFilterFlags)
 }
 

--- a/cli/sous_metadata_get.go
+++ b/cli/sous_metadata_get.go
@@ -32,6 +32,7 @@ func (smg *SousMetadataGet) AddFlags(fs *flag.FlagSet) {
 }
 
 func (smg *SousMetadataGet) RegisterOn(psy Addable) {
+	psy.Add(graph.DryrunNeither)
 	psy.Add(&smg.DeployFilterFlags)
 }
 

--- a/cli/sous_metadata_set.go
+++ b/cli/sous_metadata_set.go
@@ -30,6 +30,7 @@ func (smg *SousMetadataSet) AddFlags(fs *flag.FlagSet) {
 }
 
 func (smg *SousMetadataSet) RegisterOn(psy Addable) {
+	psy.Add(graph.DryrunNeither)
 	psy.Add(&smg.DeployFilterFlags)
 }
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -545,12 +545,6 @@ func NewCurrentState(sr StateReader, log LogSink) (*sous.State, error) {
 
 // NewCurrentGDM returns the current GDM.
 func NewCurrentGDM(state *sous.State) (CurrentGDM, error) {
-	if state == nil {
-		// XXX Sometimes, regardless of an error returned by NewCurrentState, this
-		// function is still called with a nil State, resulting in a panic. Race
-		// condition in psyringe?
-		return CurrentGDM{}, errors.New("nil state! (often this means there was a problem connecting to the Sous server")
-	}
 	deployments, err := state.Deployments()
 	if err != nil {
 		return CurrentGDM{}, initErr(err, "expanding state")

--- a/util/cmdr/cli.go
+++ b/util/cmdr/cli.go
@@ -194,7 +194,9 @@ func (c *CLI) prepare(cmd Command, cmdArgs []string, flagAddFuncs []func(*flag.F
 			flagAddFuncs = []func(*flag.FlagSet){}
 		}
 		// add these flags to the agglomeration
-		flagAddFuncs = append(flagAddFuncs, cmdWithFlags.AddFlags)
+		//flagAddFuncs = append(flagAddFuncs, cmdWithFlags.AddFlags)
+		// Just add the bottom level flags.
+		flagAddFuncs = []func(*flag.FlagSet){cmdWithFlags.AddFlags}
 	}
 	// If this command has subcommands, first try to descend into one of them.
 	if cmdWithSubcmd, ok := cmd.(Subcommander); ok && len(cmdArgs) != 0 {

--- a/util/cmdr/cli.go
+++ b/util/cmdr/cli.go
@@ -190,9 +190,6 @@ func (c *CLI) prepare(cmd Command, cmdArgs []string, flagAddFuncs []func(*flag.F
 	cmdArgs = cmdArgs[1:]
 	// Add and parse flags for this command.
 	if cmdWithFlags, ok := cmd.(AddsFlags); ok {
-		if flagAddFuncs == nil {
-			flagAddFuncs = []func(*flag.FlagSet){}
-		}
 		// Just add the bottom level flags.
 		flagAddFuncs = []func(*flag.FlagSet){cmdWithFlags.AddFlags}
 	}

--- a/util/cmdr/cli.go
+++ b/util/cmdr/cli.go
@@ -119,12 +119,12 @@ func (c *CLI) InvokeAndExit(args []string) {
 // which is usually a nicer user experience than having to remember strictly
 // which subcommand a flag is applicable to.
 func (c *CLI) Prepare(args []string) (*PreparedExecution, error) {
-	base, ff := c.Root, c.GlobalFlagSetFuncs
+	base := c.Root
 	if c.Hooks.Startup != nil {
 		c.Hooks.Startup(c)
 		c.Hooks.Startup = nil
 	}
-	return c.prepare(base, args, ff)
+	return c.prepare(base, args, nil)
 }
 
 // runHook runs the hook if it's not nil, and returns the hook's error.

--- a/util/cmdr/cli.go
+++ b/util/cmdr/cli.go
@@ -203,9 +203,9 @@ func (c *CLI) prepare(cmd Command, cmdArgs []string, flagAddFuncs []func(*flag.F
 		subcommandName := cmdArgs[0]
 		subcommands := cmdWithSubcmd.Subcommands()
 		if cmdWithSubCmd, ok := subcommands[subcommandName]; ok {
-			if err := c.runHook(c.Hooks.Parsed, cmd); err != nil {
-				return nil, EnsureErrorResult(err)
-			}
+			//if err := c.runHook(c.Hooks.Parsed, cmd); err != nil {
+			//	return nil, EnsureErrorResult(err)
+			//}
 			return c.prepare(cmdWithSubCmd, cmdArgs, flagAddFuncs)
 		}
 	}

--- a/util/cmdr/cli.go
+++ b/util/cmdr/cli.go
@@ -193,8 +193,6 @@ func (c *CLI) prepare(cmd Command, cmdArgs []string, flagAddFuncs []func(*flag.F
 		if flagAddFuncs == nil {
 			flagAddFuncs = []func(*flag.FlagSet){}
 		}
-		// add these flags to the agglomeration
-		//flagAddFuncs = append(flagAddFuncs, cmdWithFlags.AddFlags)
 		// Just add the bottom level flags.
 		flagAddFuncs = []func(*flag.FlagSet){cmdWithFlags.AddFlags}
 	}
@@ -203,9 +201,6 @@ func (c *CLI) prepare(cmd Command, cmdArgs []string, flagAddFuncs []func(*flag.F
 		subcommandName := cmdArgs[0]
 		subcommands := cmdWithSubcmd.Subcommands()
 		if cmdWithSubCmd, ok := subcommands[subcommandName]; ok {
-			//if err := c.runHook(c.Hooks.Parsed, cmd); err != nil {
-			//	return nil, EnsureErrorResult(err)
-			//}
 			return c.prepare(cmdWithSubCmd, cmdArgs, flagAddFuncs)
 		}
 	}

--- a/util/cmdr/help.go
+++ b/util/cmdr/help.go
@@ -49,14 +49,15 @@ func formatSubcommands(c Command) string {
 }
 
 func (cli *CLI) formatFlags(command Command) string {
-	addsFlags, ok := command.(AddsFlags)
-	if !ok {
-		return ""
+	fs := flag.NewFlagSet("help", flag.ContinueOnError)
+	for _, globalFlagFunc := range cli.GlobalFlagSetFuncs {
+		globalFlagFunc(fs)
 	}
 	b := &bytes.Buffer{}
 	b.WriteString("\n\noptions:\n")
-	fs := flag.NewFlagSet("help", flag.ContinueOnError)
-	addsFlags.AddFlags(fs)
+	if addsFlags, ok := command.(AddsFlags); ok {
+		addsFlags.AddFlags(fs)
+	}
 	fs.SetOutput(b)
 	fs.PrintDefaults()
 	return b.String()

--- a/vendor/github.com/samsalisbury/psyringe/README.md
+++ b/vendor/github.com/samsalisbury/psyringe/README.md
@@ -211,6 +211,10 @@ func newFunc() func(int) (int, error) {
 }
 ```
 
+## Troubleshooting
+
+You can get debug output about which types, fields and constructor arguments are being injected into by setting `PSYRINGE_DEBUG_FILE` to a file path you want to write this data to. If this is not set, or is empty then no debug logs are written anywhere.
+
 # TODO
 
 - Remove support for adding non-constructors to the psyringe. This is the biggest

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -284,10 +284,10 @@
 			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
-			"checksumSHA1": "6Gp81ayxMY6z5YVqOzS9IF+boSE=",
+			"checksumSHA1": "1NYZYmUwbLKq9jCmi6hoCyQSNRI=",
 			"path": "github.com/samsalisbury/psyringe",
-			"revision": "668966cb5d773f44750c6dd85a28b22eedcb9aef",
-			"revisionTime": "2017-10-24T14:00:05Z"
+			"revision": "d86040408013723ebd5715c2f2334457a3237b8f",
+			"revisionTime": "2017-10-25T16:24:18Z"
 		},
 		{
 			"checksumSHA1": "IRgb8yeKkWGY5gp1TLk9rpGitB0=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -284,10 +284,10 @@
 			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
-			"checksumSHA1": "MPzOOIKBzAz8il3ng/fgbdxBJGM=",
+			"checksumSHA1": "6Gp81ayxMY6z5YVqOzS9IF+boSE=",
 			"path": "github.com/samsalisbury/psyringe",
-			"revision": "afa419dfe20cdfb9c1ed69eb5ea6e400f32954ec",
-			"revisionTime": "2017-10-05T11:45:37Z"
+			"revision": "668966cb5d773f44750c6dd85a28b22eedcb9aef",
+			"revisionTime": "2017-10-24T14:00:05Z"
 		},
 		{
 			"checksumSHA1": "IRgb8yeKkWGY5gp1TLk9rpGitB0=",


### PR DESCRIPTION
The issue was that NameCache was being injected unconditionally, and it requires a valid config, so validation was running and causing sous to barf with invalid config on all commands (including 'sous config' which should tolerate invalid config so it can be fixed).

The unconditional injection of the name cache has been removed, and changes made to both `cli` and `cmdr` packages. `cmdr` no longer forwards flags from commands higher up the tree, and now only calls the `Parsed` hook once, for the final command in the invocation. This means that where we relied on things being added to the graph by 'RegisterOn' methods higher in the tree, we now need to add them directly to the leaf command. Flags from the `Sous` command which were passed down are now implemented as global flags using a mechanism already present in cmdr package. Help output has been fixed to additionally show all global flags.

Some more work may be necessary to guarantee the singleton nature of the name cache, so this is work in progress until that problem is solved, which I'm working on presently. The aim is to simplify construction of the graph to happen exactly once in the `Parse` hook with no further `Add` calls.

**EDIT** This change also includes a couple of tweaks to psyringe:

* When calling `Add` and getting panic because the injection type is already added, the panic message now includes the file and line number where the type was already added previously.
* Set the env var `PSYRINGE_DEBUG_FILE=psyringe.debug` to have all injections in a sous invocation logged in that file, namely which structs and constructors are being injected into with which types.