### PR TITLE
Output from status polling SOUS-259

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ with respect to its command line interface and HTTP interface.
 
 ## [Unreleased](//github.com/opentable/sous/compare/0.5.48..HEAD)
 ### Fixed
-* Server: at least one bootched log message type has been caught and corrected.
+* Server: at least one botched log message type has been caught and corrected.
+
+### Added
+* Client: more descriptive output from 'sous deploy' and 'sous update' commands.
 
 ## [0.5.48](//github.com/opentable/sous/compare/0.5.47..0.5.48)
 

--- a/cli/actions/messages.go
+++ b/cli/actions/messages.go
@@ -82,5 +82,9 @@ func (msg updateMessage) EachField(fn logging.FieldReportFn) {
 func (msg updateMessage) WriteToConsole(console io.Writer) {
 	if msg.err != nil {
 		console.Write([]byte(msg.err.Error()))
+		return
+	}
+	if msg.interval.Complete() {
+		console.Write([]byte("Updated global manifest"))
 	}
 }

--- a/cli/actions/messages.go
+++ b/cli/actions/messages.go
@@ -85,6 +85,6 @@ func (msg updateMessage) WriteToConsole(console io.Writer) {
 		return
 	}
 	if msg.interval.Complete() {
-		console.Write([]byte("Updated global manifest"))
+		console.Write([]byte("Updated global manifest\n"))
 	}
 }

--- a/cli/sous_deploy.go
+++ b/cli/sous_deploy.go
@@ -70,7 +70,7 @@ func (sd *SousDeploy) Execute(args []string) cmdr.Result {
 		if err := poll.Do(); err != nil {
 			return cmdr.EnsureErrorResult(err)
 		}
-		return cmdr.Success("Deploy complete")
+		return cmdr.Success("")
 	}
 	return cmdr.Successf("Deploy in process.")
 

--- a/cli/sous_deploy.go
+++ b/cli/sous_deploy.go
@@ -53,7 +53,6 @@ func (sd *SousDeploy) Execute(args []string) cmdr.Result {
 	if err := update.Do(); err != nil {
 		return cmdr.EnsureErrorResult(err)
 	}
-	sd.CLI.OutputResult(cmdr.Success("Updated global manifest."))
 
 	// Running serverless, so run rectify.
 	if sd.Config.Server == "" {
@@ -73,6 +72,6 @@ func (sd *SousDeploy) Execute(args []string) cmdr.Result {
 		}
 		return cmdr.Success("Deploy complete")
 	}
-	return cmdr.Successf("Updated the global deploy manifest. Deploy in process.")
+	return cmdr.Successf("Deploy in process.")
 
 }

--- a/lib/messages.go
+++ b/lib/messages.go
@@ -1,6 +1,11 @@
 package sous
 
-import "github.com/opentable/sous/util/logging"
+import (
+	"fmt"
+	"io"
+
+	"github.com/opentable/sous/util/logging"
+)
 
 type (
 	pollerStartMessage struct {
@@ -15,8 +20,9 @@ type (
 	}
 
 	pollerStatusMessage struct {
-		callerInfo logging.CallerInfo
-		poller     *StatusPoller
+		callerInfo    logging.CallerInfo
+		poller        *StatusPoller
+		previousState ResolveState
 	}
 
 	pollerResolvedMessage struct {
@@ -150,11 +156,14 @@ func (msg *pollerStatusMessage) EachField(f logging.FieldReportFn) {
 }
 
 func (msg *pollerStatusMessage) WriteToConsole(console io.Writer) {
-	if msg.poller.status == msg.oldStatus {
+	if msg.poller.status == msg.previousState {
 		console.Write([]byte{'.'})
 		return
 	}
-	fmt.Fprintf(console, "\n%s", msg.poller.status)
+	fmt.Fprintf(console, "\n%s", msg.poller.status.Prose())
+	if msg.poller.finished() {
+		console.Write([]byte{'\n'})
+	}
 }
 
 //	reportSubreport(sp.logs, sp, update)

--- a/lib/messages_test.go
+++ b/lib/messages_test.go
@@ -149,7 +149,7 @@ func TestPollerStatusMessage(t *testing.T) {
 		status: 0,
 	}
 
-	msg := newPollerStatusMessage(poller)
+	msg := newPollerStatusMessage(poller, ResolveInProgress)
 
 	fixedFields := []string{
 		"@timestamp",

--- a/lib/resolvestate.go
+++ b/lib/resolvestate.go
@@ -113,7 +113,7 @@ func (rs ResolveState) Prose() string {
 	case ResolveTasksStarting:
 		return "waiting for instances to start on Singularity"
 	case ResolveNotIntended:
-		return "not intending to perform this deployment (attempting to deploy a different version)"
+		return "not intending to perform this deployment (another request to deploy this may have been received)"
 	case ResolveFailed:
 		return "giving up because the deployment failed"
 	case ResolveHTTPFailed:

--- a/lib/resolvestate.go
+++ b/lib/resolvestate.go
@@ -88,6 +88,40 @@ func (rs ResolveState) String() string {
 	}
 }
 
+// Prose returns a string that explains what the state means.
+func (rs ResolveState) Prose() string {
+	switch rs {
+	default:
+		return "unknown (oops)"
+	case ResolveNotPolled:
+		return "No data from server yet"
+	case ResolveNotStarted:
+		return "Waiting for server to begin resolution"
+	case ResolvePendingRequest:
+		return "Waiting for request to be made to cluster"
+	case ResolveNotVersion:
+		return "Waiting for server to acknowledge new version"
+	case ResolveInProgress:
+		return "Waiting for cluster to acknowledge deploy request"
+	case ResolveErredHTTP:
+		return "HTTP request to Sous server errored"
+	case ResolveErredRez:
+		return "Transient error on server, retrying"
+	case ResolveTasksStarting:
+		return "Cluster has accepted deploy request, awaiting service boot"
+	case ResolveNotIntended:
+		return "Sous server does not intend to deploy this version - probably another deploy request received"
+	case ResolveFailed:
+		return "The attempt to resolve this service failed"
+	case ResolveHTTPFailed:
+		return "HTTP connection to the Sous server has failed"
+	case ResolveComplete:
+		return "Deployment resolution is complete"
+	case ResolveMAX:
+		return "resolve maximum marker - not a real state, received in error?"
+	}
+}
+
 func minStatus(a, b ResolveState) ResolveState {
 	if a < b {
 		return a

--- a/lib/resolvestate.go
+++ b/lib/resolvestate.go
@@ -1,5 +1,7 @@
 package sous
 
+import "fmt"
+
 // A ResolveState reflects the state of the Sous clusters in regard to
 // resolving a particular SourceID.
 type ResolveState int
@@ -91,34 +93,35 @@ func (rs ResolveState) String() string {
 // Prose returns a string that explains what the state means.
 func (rs ResolveState) Prose() string {
 	switch rs {
+	// Sous is...
 	default:
-		return "unknown (oops)"
+		return fmt.Sprintf("returning an impossible status (%d), please report this error", rs)
 	case ResolveNotPolled:
-		return "No data from server yet"
+		return "waiting for data from Sous server"
 	case ResolveNotStarted:
-		return "Waiting for server to begin resolution"
+		return "waiting for Sous server to begin deployment"
 	case ResolvePendingRequest:
-		return "Waiting for request to be made to cluster"
+		return "queueing instructions to Singularity"
 	case ResolveNotVersion:
-		return "Waiting for server to acknowledge new version"
+		return "waiting for Sous server to acknowledge intended version"
 	case ResolveInProgress:
-		return "Waiting for cluster to acknowledge deploy request"
+		return "waiting for Singularity to complete deployments"
 	case ResolveErredHTTP:
-		return "HTTP request to Sous server errored"
+		return "receiving an unexpected HTTP response from Sous server"
 	case ResolveErredRez:
-		return "Transient error on server, retrying"
+		return "re-trying after experiencing a transient error"
 	case ResolveTasksStarting:
-		return "Cluster has accepted deploy request, awaiting service boot"
+		return "waiting for instances to start on Singularity"
 	case ResolveNotIntended:
-		return "Sous server does not intend to deploy this version - probably another deploy request received"
+		return "not intending to perform this deployment (attempting to deploy a different version)"
 	case ResolveFailed:
-		return "The attempt to resolve this service failed"
+		return "giving up because the deployment failed"
 	case ResolveHTTPFailed:
-		return "HTTP connection to the Sous server has failed"
+		return "giving up because the HTTP connection to Sous server has failed"
 	case ResolveComplete:
-		return "Deployment resolution is complete"
+		return "finished deploying"
 	case ResolveMAX:
-		return "resolve maximum marker - not a real state, received in error?"
+		return "returning an impossible status (ResolveMAX), please report this issue"
 	}
 }
 

--- a/lib/status_poller.go
+++ b/lib/status_poller.go
@@ -211,8 +211,9 @@ func (sp *StatusPoller) finished() bool {
 }
 
 func (sp *StatusPoller) updateStatus() {
+	oldStatus := sp.status
 	sp.status = sp.computeStatus()
-	reportPollerStatus(sp.logs, sp)
+	reportPollerStatus(sp.logs, sp, oldStatus)
 }
 
 func (sp *StatusPoller) computeStatus() ResolveState {

--- a/lib/status_poller.go
+++ b/lib/status_poller.go
@@ -166,7 +166,9 @@ func (sp *StatusPoller) poll(subs []*subPoller) ResolveState {
 	go func() {
 		sp.statePerCluster = map[string]*pollerState{}
 		for {
-			sp.nextSubStatusBurst()
+			update := <-sp.results
+			sp.nextSubStatus(update)
+
 			if sp.finished() {
 				close(done)
 				return
@@ -180,17 +182,6 @@ func (sp *StatusPoller) poll(subs []*subPoller) ResolveState {
 
 	<-done
 	return sp.status
-}
-
-func (sp *StatusPoller) nextSubStatusBurst() {
-	for {
-		select {
-		default:
-			return
-		case update := <-sp.results:
-			sp.nextSubStatus(update)
-		}
-	}
 }
 
 func (sp *StatusPoller) nextSubStatus(update pollResult) {


### PR DESCRIPTION
The Update action and the Status pollers now emit console messages,
which means that `sous deploy` is much more descriptive of what it's doing.

Note that I also found and fixed a bug where status was checked in a very tight loop
and was issuing far too many update messages on kafka.