### PR TITLE
Optional injection #trivial

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opentable/sous/util/logging"
 	"github.com/opentable/sous/util/yaml"
 	"github.com/pkg/errors"
+	"github.com/samsalisbury/psyringe/experiment"
 )
 
 // Func aliases, for convenience returning from commands.
@@ -140,6 +141,7 @@ func NewSousCLI(di *graph.SousGraph, s *Sous, logsink logging.LogSink, out, erro
 
 	// Before Execute is called on any command, inject its dependencies.
 	cli.Hooks.PreExecute = func(cmd cmdr.Command) error {
+		cli.graph.Hooks.NoValueForStructField = experiment.OptionalFieldHandler()
 		return errors.Wrapf(cli.graph.Inject(cmd), "setup for execute")
 	}
 

--- a/cli/sous.go
+++ b/cli/sous.go
@@ -13,15 +13,15 @@ type Sous struct {
 	CLI *CLI
 	graph.LogSink
 	// Err is the error message stream.
-	Err *graph.ErrOut
+	Err *graph.ErrOut `inject:"optional"`
 	// Version is the version of Sous itself.
 	Version semv.Version
 	// OS is the OS this Sous is running on.
-	OS string
+	OS string `inject:"optional"`
 	// Arch is the architecture this Sous is running on.
-	Arch string
+	Arch string `inject:"optional"`
 	// GoVersion is the version of Go this sous was built with.
-	GoVersion string
+	GoVersion string `inject:"optional"`
 	// flags holds the values of flags passed to this command
 	flags struct {
 		Help bool

--- a/cli/sous_build.go
+++ b/cli/sous_build.go
@@ -12,8 +12,8 @@ type (
 	// SousBuild is the command description for `sous build`
 	// Implements cmdr.Command, cmdr.Executor and cmdr.AddFlags
 	SousBuild struct {
-		config.DeployFilterFlags
-		config.PolicyFlags
+		config.DeployFilterFlags `inject:"optional"`
+		config.PolicyFlags       `inject:"optional"`
 
 		*sous.BuildManager
 	}

--- a/cli/sous_context.go
+++ b/cli/sous_context.go
@@ -10,7 +10,7 @@ import (
 
 // SousContext is the 'sous context' command.
 type SousContext struct {
-	config.DeployFilterFlags
+	config.DeployFilterFlags `inject:"optional"`
 	*sous.SourceContext
 }
 
@@ -36,8 +36,6 @@ func (sc *SousContext) RegisterOn(psy Addable) {
 // AddFlags adds flags to the context command.
 func (sc *SousContext) AddFlags(fs *flag.FlagSet) {
 	MustAddFlags(fs, &sc.DeployFilterFlags, SourceFlagsHelp)
-	//fs.BoolVar(&sb.PolicyFlags.ForceClone, "force-clone", false, "force a shallow clone of the codebase before build")
-	// above is commented prior to impl.
 }
 
 // Execute prints the detected sous context.

--- a/cli/sous_deploy.go
+++ b/cli/sous_deploy.go
@@ -15,8 +15,8 @@ type SousDeploy struct {
 
 	Config            graph.LocalSousConfig
 	CLI               *CLI
-	DeployFilterFlags config.DeployFilterFlags
-	OTPLFlags         config.OTPLFlags
+	DeployFilterFlags config.DeployFilterFlags `inject:"optional"`
+	OTPLFlags         config.OTPLFlags         `inject:"optional"`
 	dryrunOption      string
 	waitStable        bool
 }

--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -11,10 +11,10 @@ import (
 
 // SousInit is the command description for `sous init`
 type SousInit struct {
-	DeployFilterFlags config.DeployFilterFlags
-	Flags             config.OTPLFlags
+	DeployFilterFlags config.DeployFilterFlags `inject:"optional"`
+	Flags             config.OTPLFlags         `inject:"optional"`
 	// DryRunFlag prints out the manifest but does not save it.
-	DryRunFlag  bool
+	DryRunFlag  bool `inject:"optional"`
 	Target      graph.TargetManifest
 	WD          graph.LocalWorkDirShell
 	GDM         graph.CurrentGDM

--- a/cli/sous_manifest_get.go
+++ b/cli/sous_manifest_get.go
@@ -13,8 +13,8 @@ import (
 )
 
 type SousManifestGet struct {
-	config.DeployFilterFlags
-	ResolveFilter *graph.RefinedResolveFilter
+	config.DeployFilterFlags `inject:"optional"`
+	ResolveFilter            *graph.RefinedResolveFilter `inject:"optional"`
 	graph.TargetManifestID
 	graph.HTTPClient
 	graph.LogSink

--- a/cli/sous_manifest_set.go
+++ b/cli/sous_manifest_set.go
@@ -14,11 +14,11 @@ import (
 )
 
 type SousManifestSet struct {
-	config.DeployFilterFlags
+	config.DeployFilterFlags `inject:"optional"`
 	graph.TargetManifestID
 	graph.HTTPClient
 	graph.InReader
-	ResolveFilter graph.RefinedResolveFilter
+	ResolveFilter graph.RefinedResolveFilter `inject:"optional"`
 	graph.LogSink
 	User sous.User
 }

--- a/cli/sous_metadata_get.go
+++ b/cli/sous_metadata_get.go
@@ -14,7 +14,7 @@ import (
 )
 
 type SousMetadataGet struct {
-	config.DeployFilterFlags
+	config.DeployFilterFlags `inject:"optional"`
 	*sous.ResolveFilter
 	graph.TargetManifestID
 	graph.HTTPClient

--- a/cli/sous_metadata_set.go
+++ b/cli/sous_metadata_set.go
@@ -11,7 +11,7 @@ import (
 )
 
 type SousMetadataSet struct {
-	config.DeployFilterFlags
+	config.DeployFilterFlags `inject:"optional"`
 	*sous.ResolveFilter
 	graph.TargetManifestID
 	graph.HTTPClient

--- a/cli/sous_plumbing_status.go
+++ b/cli/sous_plumbing_status.go
@@ -13,7 +13,7 @@ type SousPlumbingStatus struct {
 	SousGraph *graph.SousGraph
 	Config    graph.LocalSousConfig
 
-	DeployFilterFlags config.DeployFilterFlags
+	DeployFilterFlags config.DeployFilterFlags `inject:"optional"`
 }
 
 func init() { PlumbingSubcommands["status"] = &SousPlumbingStatus{} }

--- a/cli/sous_rectify.go
+++ b/cli/sous_rectify.go
@@ -14,7 +14,7 @@ type SousRectify struct {
 	Config            graph.LocalSousConfig
 	dryrun            string
 	SousGraph         *graph.SousGraph
-	DeployFilterFlags config.DeployFilterFlags
+	DeployFilterFlags config.DeployFilterFlags `inject:"optional"`
 	SourceHostChooser sous.SourceHostChooser
 }
 

--- a/cli/sous_server.go
+++ b/cli/sous_server.go
@@ -17,7 +17,7 @@ import (
 // A SousServer represents the `sous server` command.
 type SousServer struct {
 	Sous              *Sous
-	DeployFilterFlags config.DeployFilterFlags
+	DeployFilterFlags config.DeployFilterFlags `inject:"optional"`
 	Log               graph.LogSink
 
 	*config.Config

--- a/cli/sous_update.go
+++ b/cli/sous_update.go
@@ -10,8 +10,8 @@ import (
 
 // SousUpdate is the command description for `sous update`
 type SousUpdate struct {
-	DeployFilterFlags config.DeployFilterFlags
-	OTPLFlags         config.OTPLFlags
+	DeployFilterFlags config.DeployFilterFlags `inject:"optional"`
+	OTPLFlags         config.OTPLFlags         `inject:"optional"`
 	SousGraph         *graph.SousGraph
 }
 

--- a/vendor/github.com/samsalisbury/psyringe/experiment/optionalfieldshandler.go
+++ b/vendor/github.com/samsalisbury/psyringe/experiment/optionalfieldshandler.go
@@ -7,14 +7,15 @@ import (
 	"github.com/samsalisbury/psyringe"
 )
 
-// OptionalFieldHandler  validates that all fields in an injected struct must be
-// filled unless they are marked optional by a field tag `inject:"optional"`.
+// OptionalFieldHandler validates that all injectable fields in a struct value
+// must be filled
+// unless they are marked optional by a field tag `inject:"optional"`.
 func OptionalFieldHandler() psyringe.NoValueForStructFieldFunc {
 	return func(parentType string, field reflect.StructField) error {
 		if field.Tag.Get("inject") == "optional" {
 			return nil
 		}
-		return fmt.Errorf("unable to inject field %s.%s (%s)",
-			parentType, field.Name, field.Type)
+		return fmt.Errorf("no constructor or value of type %s available (for field %s.%s)",
+			field.Type, parentType, field.Name)
 	}
 }

--- a/vendor/github.com/samsalisbury/psyringe/experiment/optionalfieldshandler.go
+++ b/vendor/github.com/samsalisbury/psyringe/experiment/optionalfieldshandler.go
@@ -1,0 +1,20 @@
+package experiment
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/samsalisbury/psyringe"
+)
+
+// OptionalFieldHandler  validates that all fields in an injected struct must be
+// filled unless they are marked optional by a field tag `inject:"optional"`.
+func OptionalFieldHandler() psyringe.NoValueForStructFieldFunc {
+	return func(parentType string, field reflect.StructField) error {
+		if field.Tag.Get("inject") == "optional" {
+			return nil
+		}
+		return fmt.Errorf("unable to inject field %s.%s (%s)",
+			parentType, field.Name, field.Type)
+	}
+}

--- a/vendor/github.com/samsalisbury/psyringe/hooks.go
+++ b/vendor/github.com/samsalisbury/psyringe/hooks.go
@@ -1,0 +1,30 @@
+package psyringe
+
+import "reflect"
+
+// Hooks describe a set of event hooks which are called under certain
+// circumstances during injection.
+//
+// All hooks may be called concurrently.
+type Hooks struct {
+	NoValueForStructField NoValueForStructFieldFunc
+}
+
+// NoValueForStructFieldFunc is called for each field in a struct passed to
+// Inject for which there is no value or constructor in the graph.
+//
+// parentTypeName is the name of the type of struct that owns the field.
+//
+// field is the field in question.
+//
+// If you return an error, that is an injection error and returned by
+// Inject.
+type NoValueForStructFieldFunc func(parentTypeName string, field reflect.StructField) error
+
+// newHooks returns noop hooks to avoid the need to check for nil during
+// injection.
+func newHooks() Hooks {
+	return Hooks{
+		NoValueForStructField: func(string, reflect.StructField) error { return nil },
+	}
+}

--- a/vendor/github.com/samsalisbury/psyringe/psyringe.go
+++ b/vendor/github.com/samsalisbury/psyringe/psyringe.go
@@ -69,30 +69,37 @@ type Psyringe struct {
 	ctors              map[reflect.Type]*ctor
 	injectionTypes     map[reflect.Type]struct{}
 	debugAddedLocation map[reflect.Type]string
+	Hooks              Hooks
 }
 
 // New creates a new Psyringe, and adds the provided constructors and values to
 // it. New will panic if any two arguments have the same injection type. See
 // package level documentation for definition of "injection type".
 func New(constructorsAndValues ...interface{}) *Psyringe {
-	p, err := NewErr(constructorsAndValues...)
-	if err != nil {
+	p := newPsyringe()
+	if err := p.addErr(constructorsAndValues...); err != nil {
 		panic(err)
 	}
 	return p
 }
 
-// NewErr is similar to New, but returns an error instead of panicking. This is
-// useful if you are dynamically generating the arguments.
-func NewErr(constructorsAndValues ...interface{}) (*Psyringe, error) {
-	p := &Psyringe{
+// newPsyringe is used to initialise a new Psyringe.
+func newPsyringe() *Psyringe {
+	return &Psyringe{
 		scope:              "<root>",
 		values:             map[reflect.Type]reflect.Value{},
 		ctors:              map[reflect.Type]*ctor{},
 		injectionTypes:     map[reflect.Type]struct{}{},
 		debugAddedLocation: map[reflect.Type]string{},
+		Hooks:              newHooks(),
 	}
-	return p, errors.Wrap(p.addErr(constructorsAndValues...), "Add failed")
+}
+
+// NewErr is similar to New, but returns an error instead of panicking. This is
+// useful if you are dynamically generating the arguments.
+func NewErr(constructorsAndValues ...interface{}) (*Psyringe, error) {
+	p := newPsyringe()
+	return p, p.addErr(constructorsAndValues...)
 }
 
 // Add adds constructors and values to the Psyringe. It panics if any
@@ -105,7 +112,7 @@ func NewErr(constructorsAndValues ...interface{}) (*Psyringe, error) {
 // of reflect.Values ready to be used by a call to Inject. As such, Add is a
 // relatively expensive call. See Clone for how to avoid calling Add too often.
 func (p *Psyringe) Add(constructorsAndValues ...interface{}) {
-	if err := p.AddErr(constructorsAndValues...); err != nil {
+	if err := p.addErr(constructorsAndValues...); err != nil {
 		panic(err)
 	}
 }
@@ -247,6 +254,7 @@ func (p *Psyringe) Scope(name string) (child *Psyringe) {
 	q := New()
 	q.parent = p
 	q.scope = name
+	q.Hooks = q.parent.Hooks
 	return q
 }
 
@@ -300,21 +308,23 @@ func (p *Psyringe) inject(target interface{}) error {
 		close(errs)
 	}()
 	for i := 0; i < nfs; i++ {
-		go func(f reflect.Value, fieldName string) {
+		go func(f reflect.Value, field reflect.StructField) {
 			defer wg.Done()
-			fieldType := f.Type()
-			debugf("injecting field %s.%s (%s)", ptr, fieldName, fieldType)
-			if fv, ok, err := p.getValueForStructField(fieldType, fieldName); ok && err == nil {
+			debugf("injecting field %s.%s (%s)", ptr, field.Name, field.Type)
+			parentName := fmt.Sprintf("%T", target)
+			if fv, ok, err := p.getValueForStructField(p.Hooks, parentName, field); ok && err == nil {
 				f.Set(fv)
 			} else if err != nil {
 				errs <- err
 			}
-		}(v.Elem().Field(i), t.Field(i).Name)
+		}(v.Elem().Field(i), t.Field(i))
 	}
 	return <-errs
 }
 
-func (p *Psyringe) getValueForStructField(t reflect.Type, name string) (reflect.Value, bool, error) {
+func (p *Psyringe) getValueForStructField(leafHooks Hooks, parentTypeName string, field reflect.StructField) (reflect.Value, bool, error) {
+	t := field.Type
+	name := field.Name
 	if v, ok := p.values[t]; ok {
 		// We have a value, return it.
 		return v, true, nil
@@ -324,12 +334,13 @@ func (p *Psyringe) getValueForStructField(t reflect.Type, name string) (reflect.
 		v, err := c.getValue(p)
 		return v, true, errors.Wrapf(err, "getting field %s (%s) failed", name, t)
 	}
+	// Look in higher scopes.
 	if p.parent != nil {
 		// We have a parent, so try to get the value from there.
-		return p.parent.getValueForStructField(t, name)
+		return p.parent.getValueForStructField(leafHooks, parentTypeName, field)
 	}
 	// We have no value, constructor, nor parent. Give up.
-	return reflect.Value{}, false, nil
+	return reflect.Value{}, false, leafHooks.NoValueForStructField(parentTypeName, field)
 }
 
 func (p *Psyringe) getValueForConstructor(forCtor *ctor, paramIndex int, t reflect.Type) (reflect.Value, error) {
@@ -360,12 +371,12 @@ func (p *Psyringe) injectionTypeIsRegisteredAtThisScope(t reflect.Type) bool {
 	return registered
 }
 
-func (p *Psyringe) injectionTypeRegistrationScope(t reflect.Type) (string, bool) {
+func (p *Psyringe) injectionTypeRegistrationScope(t reflect.Type) (*Psyringe, bool) {
 	if p.injectionTypeIsRegisteredAtThisScope(t) {
-		return p.scope, true
+		return p, true
 	}
 	if p.parent == nil {
-		return "", false
+		return nil, false
 	}
 	return p.parent.injectionTypeRegistrationScope(t)
 }
@@ -381,15 +392,16 @@ func (p *Psyringe) scopeNameInUse(name string) bool {
 }
 
 func (p *Psyringe) registerInjectionType(t reflect.Type) error {
-	if scope, registered := p.injectionTypeRegistrationScope(t); registered {
-		message := fmt.Sprintf("injection type %s already registered at %s", t, p.debugAddedLocation[t])
-		if scope == p.scope {
+	if scopedPsyringe, registered := p.injectionTypeRegistrationScope(t); registered {
+		message := fmt.Sprintf("injection type %s already registered at %s",
+			t, scopedPsyringe.debugAddedLocation[t])
+		if scopedPsyringe.scope == p.scope {
 			return errors.New(message)
 		}
-		return fmt.Errorf("%s (scope %s)", message, scope)
+		return fmt.Errorf("%s (scope %s)", message, scopedPsyringe.scope)
 	}
 	p.injectionTypes[t] = struct{}{}
-	_, file, line, _ := runtime.Caller(6)
+	_, file, line, _ := runtime.Caller(5)
 	p.debugAddedLocation[t] = fmt.Sprintf("%s:%d", file, line)
 
 	return nil

--- a/vendor/github.com/samsalisbury/psyringe/psyringe.go
+++ b/vendor/github.com/samsalisbury/psyringe/psyringe.go
@@ -310,6 +310,10 @@ func (p *Psyringe) inject(target interface{}) error {
 	for i := 0; i < nfs; i++ {
 		go func(f reflect.Value, field reflect.StructField) {
 			defer wg.Done()
+			if field.PkgPath != "" {
+				debugf("not injecting unexported field %s.%s (%s)", ptr, field.Name, field.Type)
+				return
+			}
 			debugf("injecting field %s.%s (%s)", ptr, field.Name, field.Type)
 			parentName := fmt.Sprintf("%T", target)
 			if fv, ok, err := p.getValueForStructField(p.Hooks, parentName, field); ok && err == nil {

--- a/vendor/github.com/samsalisbury/psyringe/testpsyringe.go
+++ b/vendor/github.com/samsalisbury/psyringe/testpsyringe.go
@@ -1,0 +1,46 @@
+package psyringe
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// TestPsyringe is a Psyringe for use in testing only.
+// It allows individual constructors to be replaced,
+// which can be useful in testing scenarios.
+type TestPsyringe struct {
+	*Psyringe
+}
+
+// Replace replaces a constructor or value in the graph.
+// Note that if this injection type is not already registered, it panics.
+// Replace breaks the singleton semantics of Psyringe, and is not recommended
+// outside of testing scenarios.
+//
+// When replacing a constructor that has already been called, the old value that
+// was generated is blown away and the replacement constructor will be called
+// next time it's called on to inject.
+func (tp *TestPsyringe) Replace(constructorsAndValues ...interface{}) {
+	for _, thing := range constructorsAndValues {
+		t := testGetInjectionType(thing)
+		if _, exists := tp.Psyringe.injectionTypes[t]; !exists {
+			panic(fmt.Errorf("attempt to replace injection type %s; but no such type added", t))
+		}
+		delete(tp.Psyringe.injectionTypes, t)
+		delete(tp.Psyringe.values, t)
+		delete(tp.Psyringe.debugAddedLocation, t)
+		delete(tp.Psyringe.ctors, t)
+		if err := tp.Psyringe.add(thing); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func testGetInjectionType(constructorOrValue interface{}) reflect.Type {
+	v := reflect.ValueOf(constructorOrValue)
+	t := v.Type()
+	if c := newCtor(t, v); c != nil {
+		return c.outType
+	}
+	return t
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -284,10 +284,16 @@
 			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
-			"checksumSHA1": "1NYZYmUwbLKq9jCmi6hoCyQSNRI=",
+			"checksumSHA1": "4Ow6Yfthni3EXXnuC+6ubVfWpW4=",
 			"path": "github.com/samsalisbury/psyringe",
-			"revision": "d86040408013723ebd5715c2f2334457a3237b8f",
-			"revisionTime": "2017-10-25T16:24:18Z"
+			"revision": "ef39b9191afcd7b305ac79ee64333359582ba236",
+			"revisionTime": "2017-11-07T15:53:00Z"
+		},
+		{
+			"checksumSHA1": "zprkUAO5TOdRyPgfJHJyfcxeAmo=",
+			"path": "github.com/samsalisbury/psyringe/experiment",
+			"revision": "ef39b9191afcd7b305ac79ee64333359582ba236",
+			"revisionTime": "2017-11-07T15:53:00Z"
 		},
 		{
 			"checksumSHA1": "IRgb8yeKkWGY5gp1TLk9rpGitB0=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -284,16 +284,16 @@
 			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
-			"checksumSHA1": "4Ow6Yfthni3EXXnuC+6ubVfWpW4=",
+			"checksumSHA1": "CDWp282Ptobg47PAog1h7mbyyzk=",
 			"path": "github.com/samsalisbury/psyringe",
-			"revision": "ef39b9191afcd7b305ac79ee64333359582ba236",
-			"revisionTime": "2017-11-07T15:53:00Z"
+			"revision": "3f6ed6399db3e83068aec459996d893d257ab954",
+			"revisionTime": "2017-11-08T12:26:49Z"
 		},
 		{
-			"checksumSHA1": "zprkUAO5TOdRyPgfJHJyfcxeAmo=",
+			"checksumSHA1": "HlLNyPqfD8bdWbEjcV3wPzTemc8=",
 			"path": "github.com/samsalisbury/psyringe/experiment",
-			"revision": "ef39b9191afcd7b305ac79ee64333359582ba236",
-			"revisionTime": "2017-11-07T15:53:00Z"
+			"revision": "3f6ed6399db3e83068aec459996d893d257ab954",
+			"revisionTime": "2017-11-08T12:26:49Z"
 		},
 		{
 			"checksumSHA1": "IRgb8yeKkWGY5gp1TLk9rpGitB0=",


### PR DESCRIPTION
Injection is now mandatory for all struct fields injected into in the CLI.

You can add `inject:"optional"` tag to any field to disable this.

Trivial because this is dev-facing change only. We should run the CLI tests if poss to verify this doesn't break anything. Integration + unit tests passing, and casual use of this build verifies it's at least mostly working still.