### PR TITLE
Adding Schedule field #SOUS-8 #SOUS-753

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.53...HEAD)
+### Added
+* All: a Schedule field on Manifests, which should publish to Singularity to allow for scheduled tasks.
+
 ## [0.5.53](//github.com/opentable/sous/compare/0.5.52...0.5.53)
 
 ### Fixed

--- a/doc/developer_adding_manifest_fields.md
+++ b/doc/developer_adding_manifest_fields.md
@@ -1,0 +1,52 @@
+# Adding Fields to Manifests
+
+As central parts of the Sous model,
+the Manifest and Delployment structs
+tend to be key to many new features in Sous.
+For the same reason,
+it's very important
+to make sure that
+those changes are made in the right way.
+
+## Add to Deployment
+
+Make you first change to the Deployment struct
+(or one of it's embedded structs)
+in `lib/deployment.go`.
+```diff
+--- a/lib/deployment.go
++++ b/lib/deployment.go
+@@ -38,6 +38,8 @@ type (
+                Owners OwnerSet
+                // Kind is the kind of software that SourceRepo represents.
+                Kind ManifestKind
++               // Schedule is a cronjob-format schedule for jobs.
++               Schedule string
+        }
+```
+Basically, just add the field you need.
+If you run tests
+Tip: you can focus like:
+```shell
+⮀ go test ./lib -run TestDeploymentDiffAnalysis
+--- FAIL: TestDeploymentDiffAnalysis (0.03s)
+        Error Trace:    deployment_test.go:50
+        Error:          Should be empty, but was [Deployment.Schedule]
+FAIL
+FAIL    github.com/opentable/sous/lib   0.032s
+```
+The failure will look like that.
+It means that
+the `Deployment.Diff` method doesn't consider your field.
+(in this case Deployment.Schedule.)
+
+## Fix Diff
+
+
+
+* fix Diff
+* Deployment <-> Manifest
+* SingReq/SingDep <-> Deployment
+* SingRep/Dep -> Deployment: deployment_builder
+* Deployment -> SingReq/Dep: recti-agent, deployer
+    * changesReq & changesDep

--- a/doc/developer_adding_manifest_fields.md
+++ b/doc/developer_adding_manifest_fields.md
@@ -42,9 +42,30 @@ the `Deployment.Diff` method doesn't consider your field.
 
 ## Fix Diff
 
+Add code to `Deployment.Diff` to consider your field across Deployments.
+```diff
+--- a/lib/deployment.go
++++ b/lib/deployment.go
+@@ -231,6 +231,13 @@ func (d *Deployment) Diff(o *Deployment) (bool, Differences) {
+                diff("kind; this: %q; other: %q", d.Kind, o.Kind)
+        }
 
++       // Schedule is only significant for Scheduled Jobs
++       if d.Kind == ScheduledJob {
++               if d.Schedule != o.Schedule {
++                       diff("schedule; this: %q, other: %q", d.Schedule, o.Schedule)
++               }
++       }
++
+```
 
-* fix Diff
+Run the test again:
+
+```shell
+⮀ go test ./lib -run TestDeploymentDiffAnalysis
+ok      github.com/opentable/sous/lib   0.032s
+```
+
 * Deployment <-> Manifest
 * SingReq/SingDep <-> Deployment
 * SingRep/Dep -> Deployment: deployment_builder

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -263,7 +263,9 @@ func (r *deployer) RectifySingleModification(pair *sous.DeployablePair) (err err
 // could report ("deploy required because of %v", diffs)
 
 func changesReq(pair *sous.DeployablePair) bool {
-	return pair.Prior.NumInstances != pair.Post.NumInstances
+	return (pair.Prior.Kind == sous.ManifestKindScheduled && pair.Prior.Schedule != pair.Post.Schedule) ||
+		pair.Prior.Kind != pair.Post.Kind ||
+		pair.Prior.NumInstances != pair.Post.NumInstances
 }
 
 func changesDep(pair *sous.DeployablePair) bool {

--- a/ext/singularity/deployment_builder.go
+++ b/ext/singularity/deployment_builder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/opentable/go-singularity/dtos"
 	"github.com/opentable/sous/ext/docker"
 	"github.com/opentable/sous/lib"
@@ -131,6 +132,7 @@ func (db *deploymentBuilder) completeConstruction() error {
 		wrapError(db.restoreFromMetadata, "Could not determine cluster name based on SingularityDeploy Metadata."),
 		wrapError(db.unpackDeployConfig, "Could not convert data from a SingularityDeploy to a sous.Deployment."),
 		wrapError(db.determineManifestKind, "Could not determine SingularityRequestType."),
+		wrapError(db.extractSchedule, "Could not determine Singularity schedule."),
 	)
 }
 
@@ -435,6 +437,18 @@ func (db *deploymentBuilder) determineManifestKind() error {
 		db.Target.Kind = sous.ManifestKindScheduled
 	case dtos.SingularityRequestRequestTypeRUN_ONCE:
 		db.Target.Kind = sous.ManifestKindOnce
+	}
+	return nil
+}
+
+func (db *deploymentBuilder) extractSchedule() error {
+	spew.Dump(db.Target.Kind)
+	if db.Target.Kind == sous.ManifestKindScheduled {
+		if db.request == nil {
+			return fmt.Errorf("Request is nil!")
+		}
+		spew.Dump(db.request.Schedule)
+		db.Target.DeployConfig.Schedule = db.request.Schedule
 	}
 	return nil
 }

--- a/ext/singularity/deployment_builder.go
+++ b/ext/singularity/deployment_builder.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/opentable/go-singularity/dtos"
 	"github.com/opentable/sous/ext/docker"
 	"github.com/opentable/sous/lib"
@@ -442,12 +441,10 @@ func (db *deploymentBuilder) determineManifestKind() error {
 }
 
 func (db *deploymentBuilder) extractSchedule() error {
-	spew.Dump(db.Target.Kind)
 	if db.Target.Kind == sous.ManifestKindScheduled {
 		if db.request == nil {
 			return fmt.Errorf("Request is nil!")
 		}
-		spew.Dump(db.request.Schedule)
 		db.Target.DeployConfig.Schedule = db.request.Schedule
 	}
 	return nil

--- a/ext/singularity/recti-agent.go
+++ b/ext/singularity/recti-agent.go
@@ -206,12 +206,22 @@ func singRequestFromDeployment(dep *sous.Deployment, reqID string) (string, *dto
 	if err != nil {
 		return "", nil, err
 	}
-	req, err := swaggering.LoadMap(&dtos.SingularityRequest{}, dtoMap{
+	reqFields := dtoMap{
 		"Id":          reqID,
 		"RequestType": reqType,
 		"Instances":   int32(instanceCount),
 		"Owners":      swaggering.StringList(owners.Slice()),
-	})
+	}
+	if reqType == dtos.SingularityRequestRequestTypeSCHEDULED {
+		reqFields["Schedule"] = dep.Schedule
+
+		// until and unless someone asks
+		reqFields["ScheduleType"] = dtos.SingularityRequestScheduleTypeCRON
+
+		// also present but not addressed:
+		// taskExecutionTimeLimitMillis
+	}
+	req, err := swaggering.LoadMap(&dtos.SingularityRequest{}, reqFields)
 
 	if err != nil {
 		return "", nil, err

--- a/ext/storage/testdata/in/manifests/github.com/opentable/sous.yaml
+++ b/ext/storage/testdata/in/manifests/github.com/opentable/sous.yaml
@@ -16,4 +16,5 @@ Deployments:
     Startup:
       CheckReadyProtocol: HTTPS
       CheckReadyURIPath: /health
+    Schedule: ""
     Version: 1.0.0-rc.1+deadbeef

--- a/ext/storage/testdata/in/manifests/github.com/user/project.yaml
+++ b/ext/storage/testdata/in/manifests/github.com/user/project.yaml
@@ -15,4 +15,5 @@ Deployments:
     Startup:
       CheckReadyProtocol: HTTPS
       CheckReadyURIPath: /health
+    Schedule: ""
     Version: 0.3.1-beta+b4d455ee

--- a/lib/deploy_config.go
+++ b/lib/deploy_config.go
@@ -35,6 +35,8 @@ type (
 		Volumes Volumes
 		// Startup containts healthcheck options for this deploy.
 		Startup Startup `yaml:",omitempty"`
+		// Schedule is a cronjob-format schedule for jobs.
+		Schedule string
 	}
 
 	// A DeployConfigs is a map from cluster name to DeployConfig
@@ -171,6 +173,7 @@ func (dc DeployConfig) Clone() (c DeployConfig) {
 	}
 	c.Volumes = dc.Volumes.Clone()
 	c.Startup = dc.Startup
+	c.Schedule = dc.Schedule
 
 	return
 }
@@ -238,6 +241,12 @@ func flattenDeployConfigs(dcs []DeployConfig) DeployConfig {
 	for _, c := range dcs {
 		if len(c.Volumes) != 0 {
 			dc.Volumes = c.Volumes
+			break
+		}
+	}
+	for _, c := range dcs {
+		if c.Schedule != "" {
+			dc.Schedule = c.Schedule
 			break
 		}
 	}

--- a/lib/deploy_spec.go
+++ b/lib/deploy_spec.go
@@ -28,8 +28,6 @@ type (
 		//     2. The metadata field is the full revision ID of the commit
 		//        which the tag in 1. points to.
 		Version semv.Version `validate:"nonzero"`
-		// For scheduled jobs, they need a schedule
-		Schedule string
 		// clusterName is the name of the cluster this deployment belongs to. Upon
 		// parsing the Manifest, this will be set to the key in
 		// Manifests.Deployments which points at this Deployment.

--- a/lib/deploy_spec.go
+++ b/lib/deploy_spec.go
@@ -28,6 +28,8 @@ type (
 		//     2. The metadata field is the full revision ID of the commit
 		//        which the tag in 1. points to.
 		Version semv.Version `validate:"nonzero"`
+		// For scheduled jobs, they need a schedule
+		Schedule string
 		// clusterName is the name of the cluster this deployment belongs to. Upon
 		// parsing the Manifest, this will be set to the key in
 		// Manifests.Deployments which points at this Deployment.

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -38,6 +38,8 @@ type (
 		Owners OwnerSet
 		// Kind is the kind of software that SourceRepo represents.
 		Kind ManifestKind
+		// Schedule is a cronjob-format schedule for jobs.
+		Schedule string
 	}
 
 	// A DeploymentID identifies a deployment.

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -232,7 +232,7 @@ func (d *Deployment) Diff(o *Deployment) (bool, Differences) {
 	}
 
 	// Schedule is only significant for Scheduled Jobs
-	if d.Kind == ScheduledJob {
+	if d.Kind == ManifestKindScheduled {
 		if d.Schedule != o.Schedule {
 			diff("schedule; this: %q, other: %q", d.Schedule, o.Schedule)
 		}

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -231,6 +231,13 @@ func (d *Deployment) Diff(o *Deployment) (bool, Differences) {
 		diff("kind; this: %q; other: %q", d.Kind, o.Kind)
 	}
 
+	// Schedule is only significant for Scheduled Jobs
+	if d.Kind == ScheduledJob {
+		if d.Schedule != o.Schedule {
+			diff("schedule; this: %q, other: %q", d.Schedule, o.Schedule)
+		}
+	}
+
 	if len(d.Owners) != len(o.Owners) {
 		diff("number of owners; this: %+v; other: %+v", len(d.Owners), len(o.Owners))
 	}

--- a/lib/deployment.go
+++ b/lib/deployment.go
@@ -38,8 +38,6 @@ type (
 		Owners OwnerSet
 		// Kind is the kind of software that SourceRepo represents.
 		Kind ManifestKind
-		// Schedule is a cronjob-format schedule for jobs.
-		Schedule string
 	}
 
 	// A DeploymentID identifies a deployment.

--- a/lib/map_state_to_deployments.go
+++ b/lib/map_state_to_deployments.go
@@ -222,14 +222,5 @@ func flattenDeploySpecs(dss []DeploySpec) DeploySpec {
 			break
 		}
 	}
-	/*
-		DSs have to be unique by clusterName, nicht war?
-			for _, s := range dss {
-				if s.clusterName != "" {
-					ds.clusterName = s.clusterName
-					break
-				}
-			}
-	*/
 	return ds
 }

--- a/lib/map_state_to_deployments_test.go
+++ b/lib/map_state_to_deployments_test.go
@@ -141,10 +141,10 @@ func makeTestManifests() Manifests {
 			Source: project2,
 			Kind:   ManifestKindScheduled,
 			Deployments: DeploySpecs{
-				"cluster-1": {
-					Version:  semv.MustParse("0.2.4"),
-					Schedule: "* */2 * * *",
+				"cluster-2": {
+					Version: semv.MustParse("0.2.4"),
 					DeployConfig: DeployConfig{
+						Schedule: "* */2 * * *",
 						Resources: Resources{
 							"cpus": "0.4",
 							"mem":  "256",
@@ -254,11 +254,14 @@ var expectedDeployments = NewDeployments(
 		ClusterName: "cluster-2",
 		Cluster:     cluster2,
 		Kind:        ManifestKindScheduled,
-		Schedule:    "* */2 * * *",
 		DeployConfig: DeployConfig{
+			Schedule: "* */2 * * *",
 			Resources: Resources{
 				"cpus": "0.4",
 				"mem":  "256",
+			},
+			Env: Env{
+				"CLUSTER_LONG_NAME": "Cluster Two",
 			},
 		},
 	},
@@ -533,8 +536,8 @@ func compareDeployments(t *testing.T, expectedDeployments, actualDeployments Dep
 			t.Errorf("missing deployment %q", id)
 			continue
 		}
-		if !actual.Equal(expected) {
-			t.Errorf("\n\ngot:\n%v\n\nwant:\n%v\n", jsonDump(actual), jsonDump(expected))
+		if different, diffs := actual.Diff(expected); different {
+			t.Errorf("\n\ngot:\n%v\ndifferences:\n%s\n", jsonDump(actual), strings.Join(diffs, "\n"))
 		}
 	}
 }

--- a/lib/map_state_to_deployments_test.go
+++ b/lib/map_state_to_deployments_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/samsalisbury/semv"
 	"github.com/stretchr/testify/assert"
 )
@@ -276,7 +275,6 @@ func TestState_DeploymentsCloned(t *testing.T) {
 
 	exSnap := expectedDeployments.Snapshot()
 	if len(actualDeployments.Snapshot()) != len(exSnap) {
-		spew.Dump(actualDeployments.Snapshot())
 		t.Errorf("deployments different lengths: expected %d, got %d", len(exSnap), len(actualDeployments.Snapshot()))
 	}
 	for id, expected := range exSnap {


### PR DESCRIPTION
Manifests now get a Schedule field for cron-style scheduled tasks.
Note that because of how serialization works, this field will be added to all manifests -
watch for "more than one file"  errors during deploy.
(The GDM may need to be renormalized.)

Also appearing: a lightly annotated diff-log of the changes required,
and the change/test process I go through to add a field.
Should make adding other fields more reasonable.