### PR TITLE
Logging: CLI respects Logging.Basic.Level SOUS-756

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.54...master)
+### Changed
+* CLI: Quieter output for local operators. Previously many log messages were
+  emitted to stderr which made CLI use difficult due to information overload.
+
 ## [0.5.54](//github.com/opentable/sous/compare/0.5.53...0.5.54)
 ### Added
 * All: a Schedule field on Manifests, which should publish to Singularity to allow for scheduled tasks.

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,7 @@ test-unit:
 
 test-integration: setup-containers
 	SOUS_QA_DESC=$(QA_DESC) go test -timeout 30m $(EXTRA_GO_FLAGS)  $(TEST_VERBOSE) ./integration --tags=integration
+	@date
 
 $(QA_DESC): sous-qa-setup
 	./sous_qa_setup --compose-dir ./integration/test-registry/ --out-path=$(QA_DESC)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -22,9 +22,14 @@ func prepareCommand(t *testing.T, cl []string) (*CLI, *cmdr.PreparedExecution, f
 
 	s := &Sous{Version: semv.MustParse(`1.2.3`)}
 	di := graph.BuildTestGraph(semv.Version{}, stdin, stdout, stderr)
-	ls := logging.SilentLogSet()
-	c, err := NewSousCLI(di, s, ls, stdout, stderr)
+	type logSetScoop struct {
+		*logging.LogSet
+	}
+	lss := &logSetScoop{}
+	di.MustInject(lss)
+	c, err := NewSousCLI(di, s, stdout, stderr)
 	require.NoError(err)
+	c.LogSink = lss.LogSet
 
 	exe, err := c.Prepare(cl)
 	require.NoError(err)
@@ -301,6 +306,7 @@ options:
 */
 
 func TestInvokeWithUnknownFlags(t *testing.T) {
+
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -310,8 +316,7 @@ func TestInvokeWithUnknownFlags(t *testing.T) {
 
 	s := &Sous{Version: semv.MustParse(`1.2.3`)}
 	di := graph.BuildTestGraph(semv.Version{}, stdin, stdout, stderr)
-	ls := logging.SilentLogSet()
-	c, err := NewSousCLI(di, s, ls, stdout, stderr)
+	c, err := NewSousCLI(di, s, stdout, stderr)
 	require.NoError(err)
 
 	c.Invoke([]string{`sous`, `-cobblers`})

--- a/cli/tests/terminal.go
+++ b/cli/tests/terminal.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/opentable/sous/cli"
 	"github.com/opentable/sous/graph"
-	"github.com/opentable/sous/util/logging"
 	"github.com/samsalisbury/semv"
 	"github.com/xrash/smetrics"
 )
@@ -45,8 +44,7 @@ func NewTerminal(t *testing.T, vstr string) *Terminal {
 
 	s := &cli.Sous{Version: v}
 	di := graph.BuildTestGraph(v, in, out, err)
-	ls := logging.SilentLogSet()
-	c, er := cli.NewSousCLI(di, s, ls, out, err)
+	c, er := cli.NewSousCLI(di, s, out, err)
 	if er != nil {
 		panic(er)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -51,7 +51,7 @@ func checkURL(URL string) error {
 		return errors.Wrapf(err, "%q is not a valid URL", URL)
 	}
 	if u.Scheme != "http" && u.Scheme != "https" {
-		return errors.Errorf("%q must begin with http:// or https://", URL)
+		return errors.Errorf("URL %q must begin with http:// or https://", URL)
 	}
 	return nil
 }

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -46,7 +46,7 @@ func TestNewStatusPoller(t *testing.T) {
 
 func TestBuildGraph(t *testing.T) {
 	log.SetFlags(log.Flags() | log.Lshortfile)
-	g := BuildGraph(semv.MustParse("0.0.0"), logging.SilentLogSet(), &bytes.Buffer{}, ioutil.Discard, ioutil.Discard)
+	g := BuildGraph(semv.MustParse("0.0.0"), &bytes.Buffer{}, ioutil.Discard, ioutil.Discard)
 	g.Add(DryrunBoth)
 	g.Add(&config.Verbosity{})
 	g.Add(&config.DeployFilterFlags{})

--- a/graph/local_config.go
+++ b/graph/local_config.go
@@ -158,7 +158,7 @@ func (c *LocalSousConfig) GetValue(name string) (string, error) {
 
 // SetValue stores a particular value on the config
 func (c *LocalSousConfig) SetValue(path, name, value string) error {
-	if err := configloader.New().SetValue(c.Config, name, value); err != nil {
+	if err := configloader.New().SetValidValue(c.Config, name, value); err != nil {
 		return err
 	}
 	return c.Save(path)

--- a/graph/local_config.go
+++ b/graph/local_config.go
@@ -40,17 +40,9 @@ func newPossiblyInvalidLocalSousConfig(u config.LocalUser, defaultConfig Default
 	return v, initErr(err, "getting configuration")
 }
 
-func newLocalSousConfig(pic PossiblyInvalidConfig, ls *logging.LogSet, notReallyButPsyringeSequencingDep LogSink) (v LocalSousConfig, err error) {
+func newLocalSousConfig(pic PossiblyInvalidConfig) (v LocalSousConfig, err error) {
 	v.Config, err = pic.Config, pic.Validate()
-	if err != nil {
-		return LocalSousConfig{}, errors.Wrapf(err, "tip: run 'sous config' to see and manipulate your configuration")
-	}
-	cerr := ls.Configure(v.Config.Logging)
-	if cerr != nil {
-		return v, initErr(cerr, "validating configuration")
-	}
-	cerr = logging.Log.Configure(v.Config.Logging)
-	return v, initErr(cerr, "validating configuration")
+	return v, errors.Wrapf(err, "tip: run 'sous config' to see and manipulate your configuration")
 }
 
 func newConfigLoader() *ConfigLoader {

--- a/graph/testsupport.go
+++ b/graph/testsupport.go
@@ -38,12 +38,16 @@ func BuildTestGraph(v semv.Version, in io.Reader, out, err io.Writer) *SousGraph
 // TestGraphWithConfig accepts a custom Sous config string
 func TestGraphWithConfig(v semv.Version, in io.Reader, out, err io.Writer, cfg string) *SousGraph {
 
-	graph := BuildGraph(v, logging.SilentLogSet(), in, out, err)
+	graph := BuildGraph(v, in, out, err)
 
 	// testGraph methods affect graph as well.
 	testGraph := psyringe.TestPsyringe{Psyringe: graph.Psyringe}
 
 	// Replace things from the real graph.
+	testGraph.Add(func() logging.LogSink {
+		return logging.SilentLogSet()
+	})
+	testGraph.Replace(logging.SilentLogSet())
 	testGraph.Replace(sous.User{Name: "Test User", Email: "testuser@example.com"})
 	testGraph.Replace(NewTestConfigLoader)
 	testGraph.Replace(newDummyDockerClient)

--- a/graph/testsupport.go
+++ b/graph/testsupport.go
@@ -78,3 +78,15 @@ func (cl *testConfigLoader) Load(data interface{}, path string) error {
 	err := yaml.Unmarshal([]byte(cl.configYAML), data)
 	return err
 }
+
+func (cl *testConfigLoader) SetValue(interface{}, string, string) error {
+	panic("testConfigLoader does not implement SetValue")
+}
+
+func (cl *testConfigLoader) SetValidValue(interface{}, string, string) error {
+	panic("testConfigLoader does not implement SetValidValue")
+}
+
+func (cl *testConfigLoader) GetValue(interface{}, string) (interface{}, error) {
+	panic("testConfigLoader does not implement SetValue")
+}

--- a/lib/manifestkind.go
+++ b/lib/manifestkind.go
@@ -17,16 +17,16 @@ const (
 	// and listens and responds to HTTP requests.
 	ManifestKindService ManifestKind = "http-service"
 	// ManifestKindWorker represents a worker process.
-	ManifestKindWorker = "worker"
+	ManifestKindWorker ManifestKind = "worker"
 	// ManifestKindOnDemand represents an on-demand service.
-	ManifestKindOnDemand = "on-demand"
+	ManifestKindOnDemand ManifestKind = "on-demand"
 	// ManifestKindScheduled represents a scheduled task.
-	ManifestKindScheduled = "scheduled"
+	ManifestKindScheduled ManifestKind = "scheduled"
 	// ManifestKindOnce represents a one-off job.
-	ManifestKindOnce = "once"
+	ManifestKindOnce ManifestKind = "once"
 	// ScheduledJob represents a process which starts on some schedule, and
 	// exits when it completes its task.
-	ScheduledJob = "scheduled-job"
+	ScheduledJob ManifestKind = "scheduled-job"
 )
 
 // Validate returns a list of flaws with this ManifestKind.

--- a/main.go
+++ b/main.go
@@ -29,6 +29,10 @@ func main() {
 	os.Exit(action())
 }
 
+// InitializationFailedExitCode (70) is returned when early initialization of
+// Sous fails (e.g. when we can't set up logging or other elementary issues).
+const InitializationFailedExitCode = 70
+
 func action() int {
 	log.SetFlags(log.Flags() | log.Lshortfile)
 
@@ -39,7 +43,7 @@ func action() int {
 	lss := &logSetScoop{}
 	if err := di.Inject(lss); err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		return 70
+		return InitializationFailedExitCode
 	}
 	defer func() {
 		lss.LogSet.AtExit()
@@ -48,7 +52,7 @@ func action() int {
 	c, err := cli.NewSousCLI(di, Sous, os.Stdout, os.Stderr)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		return 70
+		return InitializationFailedExitCode
 	}
 	c.LogSink = lss.LogSet
 

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opentable/sous/cli"
 	"github.com/opentable/sous/graph"
 	"github.com/opentable/sous/util/logging"
+	"github.com/pkg/errors"
 )
 
 // Sous is the Sous CLI root command.
@@ -30,7 +31,10 @@ func main() {
 		*logging.LogSet
 	}
 	lss := &logSetScoop{}
-	di.MustInject(lss)
+	if err := di.Inject(lss); err != nil {
+		cause := errors.Cause(err)
+		die(cause)
+	}
 	defer func() {
 		lss.LogSet.AtExit()
 	}()

--- a/main.go
+++ b/main.go
@@ -19,6 +19,12 @@ var Sous = &cli.Sous{
 }
 
 func main() {
+	// handlePanic will only happen if os.Exit does not get called.
+	// The only way for os.Exit not to get called is if action() panics,
+	// so handlePanic here is panic-specific behaviour.
+	// The reason action is its own method is to allow other deferred calls in
+	// there to also happen in spite of panic or return, and definitely before
+	// os.Exit can be called.
 	defer handlePanic()
 	os.Exit(action())
 }
@@ -53,10 +59,12 @@ func action() int {
 // panic leaks right up to the top of the program. You can disable this message
 // for brevity of output by setting DEBUG=YES
 func handlePanic() {
+	// It is important that this method does not call recover() because we want
+	// the runtime to handle spitting out the default stack trace after the
+	// message is printed.
 	if os.Getenv("DEBUG") == "YES" {
 		return
 	}
-
 	fmt.Println(panicMessage)
 	fmt.Printf("Sous Version: %s\n\n", Version)
 }

--- a/test/http_state_manager_test.go
+++ b/test/http_state_manager_test.go
@@ -69,8 +69,7 @@ func TestWriteState(t *testing.T) {
 		t.Fatal("State manager double is empty")
 	}
 
-	ls := logging.SilentLogSet()
-	di := graph.BuildBaseGraph(semv.Version{}, ls, &bytes.Buffer{}, os.Stderr, os.Stderr)
+	di := graph.BuildBaseGraph(semv.Version{}, &bytes.Buffer{}, os.Stderr, os.Stderr)
 	graph.AddNetwork(di)
 
 	di.Add(

--- a/util/logging/config.go
+++ b/util/logging/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	}
 }
 
+// Equal tests the equality of two configs.
 func (cfg Config) Equal(other Config) bool {
 	if cfg.Kafka.Enabled != other.Kafka.Enabled {
 		return false
@@ -59,12 +60,14 @@ func (cfg Config) Equal(other Config) bool {
 	return true
 }
 
-// Gets the basic level of logging for this configuration.
-// that is, the level of messages that would be logged that should be emitted to the console
-// this is separate from messages that are designed for human consumption
+// GetBasicLevel gets the basic level of logging for this configuration.
+// that is, the level of messages that would be logged that should be emitted to
+// the console this is separate from messages that are designed for human
+// consumption
 func (cfg Config) GetBasicLevel() Level {
 	if cfg.Basic.Level == "" {
-		return CriticalLevel // console output should be via ConsoleMessages, not logging.
+		// Console output should be via ConsoleMessages, not logging.
+		return CriticalLevel
 	}
 	return levelFromString(cfg.Basic.Level)
 }

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -91,7 +91,7 @@ func NewLogSet(version semv.Version, name string, role string, err io.Writer) *L
 
 	bundle := newdb(version, err, lgrs)
 
-	ls := newls(name, role, DebugLevel, bundle) //level constrains Kafka output
+	ls := newls(name, role, CriticalLevel, bundle) //level constrains Kafka output
 	ls.imposeLevel()
 
 	// use sous.<env>.<region>.*, he said

--- a/util/logging/messages.go
+++ b/util/logging/messages.go
@@ -101,7 +101,7 @@ type (
 		Done()
 	}
 
-	// Something like a WriteCloser, but the Done message also asserts that something useful was written
+	// WriteDoner is like a WriteCloser, but the Done message also asserts that something useful was written
 	// After a console message has been written, the Done method is called, so
 	// that the WriteDoner can report about badly formed or missing console
 	// messages.


### PR DESCRIPTION
- Before, we always had a logSet configured to use os.Stderr
- Now we use the graph, including config to create a log set, which therefore respects config: `Logging.Basic.DisableConsole`

