### PR TITLE
Very elementary changes to clean up output

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,30 +19,26 @@ var Sous = &cli.Sous{
 }
 
 func main() {
+	exitCode := action()
+	os.Exit(exitCode)
+}
+
+func action() int {
 	defer handlePanic()
-	// Eventually, these should become flags on the top level application
-	//logging.Log.Info.SetOutput(os.Stderr)
-	//logging.Log.Debug.SetOutput(os.Stderr)
 	log.SetFlags(log.Flags() | log.Lshortfile)
 
 	ls := logging.NewLogSet(Sous.Version, "sous", "", os.Stderr)
 	defer ls.AtExit()
+
 	di := graph.BuildGraph(Sous.Version, ls, os.Stdin, os.Stdout, os.Stderr)
 	c, err := cli.NewSousCLI(di, Sous, ls, os.Stdout, os.Stderr)
 	if err != nil {
-		die(err)
+		fmt.Fprintln(os.Stderr, err)
+		return 70
 	}
 
 	result := c.Invoke(os.Args)
-	exitCode := result.ExitCode()
-
-	os.Exit(exitCode)
-}
-
-// die is only used to exit during very early initialisation
-func die(v ...interface{}) {
-	fmt.Fprintln(os.Stderr, v...)
-	os.Exit(70)
+	return result.ExitCode()
 }
 
 // handlePanic gives us one last chance to send a message to the user in case a

--- a/main.go
+++ b/main.go
@@ -48,6 +48,10 @@ func handlePanic() {
 	if os.Getenv("DEBUG") == "YES" {
 		return
 	}
+	if pmsg := recover(); pmsg == nil {
+		return
+	}
+
 	fmt.Println(panicMessage)
 	fmt.Printf("Sous Version: %s\n\n", Version)
 }

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -91,7 +91,7 @@ func NewLogSet(version semv.Version, name string, role string, err io.Writer) *L
 
 	bundle := newdb(version, err, lgrs)
 
-	ls := newls(name, role, DebugLevel, bundle) //level constrains Kafka output
+	ls := newls(name, role, CriticalLevel, bundle) //level constrains Kafka output
 	ls.imposeLevel()
 
 	// use sous.<env>.<region>.*, he said


### PR DESCRIPTION
We need something like #509 so that we can get early logging,
but see comments there.

In the meantime, this change simply increases the unconfigured log level to critical.
Once the config loads, it'll move down to whatever is configured.