### PR TITLE
flags: -s, -q, -v, -d now set verbosity correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ with respect to its command line interface and HTTP interface.
 * CLI: Quieter output for local operators. Previously many log messages were
   emitted to stderr which made CLI use difficult due to information overload.
 
+### Fixed
+* CLI: -s -q -v and -d (silent, quiet, verbose, and debug) flags now set the
+  logging level appropriately. You'll now see a lot more output when using
+  -d and -v flags, and only critical errors from -s, critical and console output
+  from -q.
+
 ## [0.5.54](//github.com/opentable/sous/compare/0.5.53...0.5.54)
 ### Added
 * All: a Schedule field on Manifests, which should publish to Singularity to allow for scheduled tasks.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -133,7 +133,17 @@ func NewSousCLI(di *graph.SousGraph, s *Sous, out, errout io.Writer) (*CLI, erro
 
 	cli.Hooks.Parsed = func(cmd cmdr.Command) error {
 		addVerbosityOnce.Do(func() {
-			cli.graph.Add(&verbosity)
+			if verbosity.Silent ||
+				verbosity.Quiet ||
+				verbosity.Loud ||
+				verbosity.Debug {
+				cli.graph.Add(graph.VerbosityOverride{
+					Overridden: true,
+					Value:      &verbosity,
+				})
+			} else {
+				cli.graph.Add(graph.VerbosityOverride{})
+			}
 		})
 		if registrant, ok := cmd.(Registrant); ok {
 			registrant.RegisterOn(cli.graph)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -114,16 +114,7 @@ func NewSousCLI(di *graph.SousGraph, s *Sous, out, errout io.Writer) (*CLI, erro
 		// this.
 		HelpCommand: os.Args[0] + " help",
 		GlobalFlagSetFuncs: []func(*flag.FlagSet){
-			func(fs *flag.FlagSet) {
-				fs.BoolVar(&verbosity.Silent, "s", false,
-					"silent: silence all non-essential output")
-				fs.BoolVar(&verbosity.Quiet, "q", false,
-					"quiet: output only essential error messages")
-				fs.BoolVar(&verbosity.Loud, "v", false,
-					"loud: output extra info, including all shell commands")
-				fs.BoolVar(&verbosity.Debug, "d", false,
-					"debug: output detailed logs of internal operations")
-			},
+			AddVerbosityFlags(&verbosity),
 		},
 	}
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -72,12 +72,6 @@ func SuccessYAML(v interface{}) cmdr.Result {
 func buildCLIGraph(root *Sous, cli *CLI, g *graph.SousGraph, out, err io.Writer) *graph.SousGraph {
 	g.Add(cli)
 	g.Add(root)
-	g.Add(func(c *CLI) graph.Out {
-		return graph.Out{Output: c.Out}
-	})
-	g.Add(func(c *CLI) graph.ErrOut {
-		return graph.ErrOut{Output: c.Err}
-	})
 	return g
 }
 

--- a/cli/global_flags.go
+++ b/cli/global_flags.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"flag"
+
+	"github.com/opentable/sous/config"
+)
+
+// AddVerbosityFlags adds the -s -q -v -d flags to fs, linking them to the
+// provided config.Verbosity pointer v.
+func AddVerbosityFlags(v *config.Verbosity) func(*flag.FlagSet) {
+	return func(fs *flag.FlagSet) {
+		fs.BoolVar(&v.Silent, "s", false,
+			"silent: silence all non-essential output")
+		fs.BoolVar(&v.Quiet, "q", false,
+			"quiet: output only essential error messages")
+		fs.BoolVar(&v.Loud, "v", false,
+			"loud: output extra info, including all shell commands")
+		fs.BoolVar(&v.Debug, "d", false,
+			"debug: output detailed logs of internal operations")
+	}
+}

--- a/cli/sous.go
+++ b/cli/sous.go
@@ -12,8 +12,6 @@ type Sous struct {
 	// CLI is a reference to the CLI singleton.
 	CLI *CLI
 	graph.LogSink
-	// Err is the error message stream.
-	Err *graph.ErrOut `inject:"optional"`
 	// Version is the version of Sous itself.
 	Version semv.Version
 	// OS is the OS this Sous is running on.

--- a/cli/tests/sous_test.go
+++ b/cli/tests/sous_test.go
@@ -65,7 +65,7 @@ func TestSousConfig_invalidConfig(t *testing.T) {
 
 	defer term.PrintFailureSummary()
 
-	testConfig := graph.PossiblyInvalidConfig{}
+	testConfig := graph.RawConfig{}
 	if err := term.Graph.Realise(&testConfig); err != nil {
 		t.Fatal(err)
 	}
@@ -84,5 +84,6 @@ func TestSousConfig_invalidConfig(t *testing.T) {
 	}
 	term.Stdout.ShouldContain(yamlConfig)
 
-	term.Stderr.ShouldBeEmpty()
+	const configWarning = `WARNING: Invalid configuration: Config.Server: URL "not a valid URL" must begin with http:// or https://`
+	term.Stderr.ShouldContainString(configWarning)
 }

--- a/cli/tests/sous_test.go
+++ b/cli/tests/sous_test.go
@@ -3,6 +3,10 @@ package tests
 import (
 	"log"
 	"testing"
+
+	"github.com/opentable/sous/config"
+	"github.com/opentable/sous/graph"
+	"github.com/opentable/sous/util/yaml"
 )
 
 func TestSous(t *testing.T) {
@@ -29,4 +33,56 @@ func TestSousVersion(t *testing.T) {
 	term.Stderr.ShouldHaveNumLines(0)
 	term.Stdout.ShouldHaveNumLines(1)
 	term.Stdout.ShouldHaveLineContaining("sous version")
+}
+
+func TestSousConfig_validConfig(t *testing.T) {
+	term := NewTerminal(t, "0.0.0")
+
+	defer term.PrintFailureSummary()
+
+	testConfig := &config.Config{}
+	if err := term.Graph.Realise(testConfig); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := testConfig.Validate(); err != nil {
+		t.Fatalf("inconclusive; config was not valid to begin with: %s", err)
+	}
+
+	term.RunCommand("sous config")
+
+	yamlConfig, err := yaml.Marshal(testConfig)
+	if err != nil {
+		t.Fatalf("inconclusive: unable to marshal config to YAML: %s", err)
+	}
+	term.Stdout.ShouldContain(yamlConfig)
+
+	term.Stderr.ShouldBeEmpty()
+}
+
+func TestSousConfig_invalidConfig(t *testing.T) {
+	term := NewTerminal(t, "0.0.0")
+
+	defer term.PrintFailureSummary()
+
+	testConfig := graph.PossiblyInvalidConfig{}
+	if err := term.Graph.Realise(&testConfig); err != nil {
+		t.Fatal(err)
+	}
+	testConfig.Server = "not a valid URL"
+	if err := testConfig.Validate(); err == nil {
+		t.Fatalf("inconclusive; config was not invalid")
+	}
+	// Put the invalid config back in the graph.
+	term.Graph.Replace(testConfig)
+
+	term.RunCommand("sous config")
+
+	yamlConfig, err := yaml.Marshal(testConfig.Config)
+	if err != nil {
+		t.Fatalf("inconclusive: unable to marshal config to YAML: %s", err)
+	}
+	term.Stdout.ShouldContain(yamlConfig)
+
+	term.Stderr.ShouldBeEmpty()
 }

--- a/cli/tests/terminal.go
+++ b/cli/tests/terminal.go
@@ -52,7 +52,15 @@ func NewTerminal(t *testing.T, vstr string) *Terminal {
 	}
 
 	testGraph := psyringe.TestPsyringe{Psyringe: di.Psyringe}
-	return &Terminal{c, baseout, baseerr, combined, []string{}, t, testGraph}
+	return &Terminal{
+		CLI:      c,
+		Stdout:   baseout,
+		Stderr:   baseerr,
+		Combined: combined,
+		History:  []string{},
+		T:        t,
+		Graph:    testGraph,
+	}
 }
 
 // RunCommand takes a command line, turns it into args, and passes it to a CLI
@@ -131,7 +139,14 @@ func (out TestOutput) ShouldBeEmpty() {
 // ShouldContain fails the test if the output does not contain byteSlice.
 func (out TestOutput) ShouldContain(byteSlice []byte) {
 	if !bytes.Contains(out.Buffer.Bytes(), byteSlice) {
-		out.T.Errorf("did not contain %s", byteSlice)
+		out.T.Errorf("did not contain %q", byteSlice)
+	}
+}
+
+// ShouldContainString fails the test if the output does not contain s.
+func (out TestOutput) ShouldContainString(s string) {
+	if !strings.Contains(out.Buffer.String(), s) {
+		out.T.Errorf("did not contain %q", s)
 	}
 }
 

--- a/cli/tests/terminal.go
+++ b/cli/tests/terminal.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/opentable/sous/cli"
 	"github.com/opentable/sous/graph"
+	"github.com/samsalisbury/psyringe"
 	"github.com/samsalisbury/semv"
 	"github.com/xrash/smetrics"
 )
@@ -22,6 +23,7 @@ type (
 		Stdout, Stderr, Combined TestOutput
 		History                  []string
 		T                        *testing.T
+		Graph                    psyringe.TestPsyringe
 	}
 	// TestOutput allows inspection of output streams from the Terminal.
 	TestOutput struct {
@@ -49,7 +51,8 @@ func NewTerminal(t *testing.T, vstr string) *Terminal {
 		panic(er)
 	}
 
-	return &Terminal{c, baseout, baseerr, combined, []string{}, t}
+	testGraph := psyringe.TestPsyringe{Psyringe: di.Psyringe}
+	return &Terminal{c, baseout, baseerr, combined, []string{}, t, testGraph}
 }
 
 // RunCommand takes a command line, turns it into args, and passes it to a CLI
@@ -116,6 +119,20 @@ func (out TestOutput) HasLineMatching(s string) bool {
 		}
 	}
 	return false
+}
+
+// ShouldBeEmpty fails the test if the output is not empty.
+func (out TestOutput) ShouldBeEmpty() {
+	if out.Buffer.Len() != 0 {
+		out.T.Errorf("got length %d; want 0", out.Buffer.Len())
+	}
+}
+
+// ShouldContain fails the test if the output does not contain byteSlice.
+func (out TestOutput) ShouldContain(byteSlice []byte) {
+	if !bytes.Contains(out.Buffer.Bytes(), byteSlice) {
+		out.T.Errorf("did not contain %s", byteSlice)
+	}
 }
 
 // ShouldHaveExactLine fails the test if the output did not contain the line s.

--- a/config/verbosity.go
+++ b/config/verbosity.go
@@ -26,3 +26,21 @@ func (v Verbosity) LoggingConfiguration() logging.Config {
 
 	return cfg
 }
+
+// LoggingConfigurationToVerbosity is the inverse of
+// Verbosity.LoggingConfiguration.
+func LoggingConfigurationToVerbosity(c logging.Config) *Verbosity {
+	switch c.Basic.Level {
+	default:
+		return &Verbosity{}
+	case "critical":
+		if c.Basic.DisableConsole {
+			return &Verbosity{Silent: true}
+		}
+		return &Verbosity{Quiet: true}
+	case "debug":
+		return &Verbosity{Debug: true}
+	case "extradebug1":
+		return &Verbosity{Loud: true}
+	}
+}

--- a/graph/actions_test.go
+++ b/graph/actions_test.go
@@ -24,7 +24,7 @@ func fixtureDeployFilterFlags() config.DeployFilterFlags {
 
 func fixtureGraph() *SousGraph {
 	graph := DefaultTestGraph()
-	graph.Add(&config.Verbosity{})
+	graph.Add(VerbosityOverride{})
 	return graph
 }
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -315,7 +315,7 @@ func newRegistryDumper(r sous.Registry) *sous.RegistryDumper {
 //
 // If handed invalid config, we emit a warning on stderr and proceed with a
 // default LogSet.
-func newLogSet(v semv.Version, config PossiblyInvalidConfig) (*logging.LogSet, error) {
+func newLogSet(v semv.Version, config PossiblyInvalidConfig, verb *config.Verbosity) (*logging.LogSet, error) {
 	ls := logging.NewLogSet(v, "", "", os.Stderr)
 	if configErr := config.Logging.Validate(); configErr != nil {
 		// Direct print to stderr to make sure this gets printed in spite of any
@@ -323,6 +323,10 @@ func newLogSet(v semv.Version, config PossiblyInvalidConfig) (*logging.LogSet, e
 		defer fmt.Fprintf(os.Stderr, "WARNING: Invalid configuration: %s\n", configErr)
 		config.Logging = logging.Config{}
 	}
+
+	verbosityLoggingConfig := verb.LoggingConfiguration()
+	config.Logging.Basic.Level = verbosityLoggingConfig.Basic.Level
+
 	if err := ls.Configure(config.Logging); err != nil {
 		return ls, initErr(err, "validating logging configuration")
 	}

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -56,8 +56,6 @@ type (
 	// ProfilingServer records whether a profiling server was requested
 	ProfilingServer bool
 
-	// XXX one at a time, unexport all these wrapper types
-
 	// LocalSousConfig is the configuration for Sous.
 	LocalSousConfig struct{ *config.Config }
 	// LocalWorkDir is the user's current working directory when they invoke Sous.
@@ -130,8 +128,8 @@ const (
 
 // BuildGraph builds the dependency injection graph, used to populate commands
 // invoked by the user.
-func BuildGraph(vrsn semv.Version, in io.Reader, out, err io.Writer) *SousGraph {
-	graph := BuildBaseGraph(vrsn, in, out, err)
+func BuildGraph(v semv.Version, in io.Reader, out, err io.Writer) *SousGraph {
+	graph := BuildBaseGraph(v, in, out, err)
 	AddFilesystem(graph)
 	AddNetwork(graph)
 	AddState(graph)
@@ -151,12 +149,10 @@ func newSousGraph() *SousGraph {
 }
 
 // BuildBaseGraph constructs a graph with essentials - intended for testing
-func BuildBaseGraph(vrsn semv.Version, in io.Reader, out, err io.Writer) *SousGraph {
+func BuildBaseGraph(version semv.Version, in io.Reader, out, err io.Writer) *SousGraph {
 	graph := newSousGraph()
-	// stdout, stderr
 	graph.Add(
-		vrsn,
-		//ls,
+		version,
 		func() InReader { return in },
 		func() OutWriter { return out },
 		func() ErrWriter { return err },
@@ -339,7 +335,6 @@ func newLogSet(v semv.Version, config PossiblyInvalidConfig) (*logging.LogSet, e
 func newLogSink(v *config.Verbosity, set *logging.LogSet) LogSink {
 	set.Configure(v.LoggingConfiguration())
 
-	//logging.Log.Warn.Println("Normal output enabled")
 	set.Info("Info debugging enabled")
 	set.Vomitf("Verbose debugging enabled")
 	set.Debugf("Regular debugging enabled")
@@ -460,8 +455,6 @@ func newLocalWorkDirShell(verbosity *config.Verbosity, l LocalWorkDir) (v LocalW
 	v.Sh, err = shell.DefaultInDir(string(l))
 	v.TeeEcho = os.Stdout //XXX should use a writer
 	v.Sh.Debug = verbosity.Debug
-	//v.TeeOut = os.Stdout
-	//v.TeeErr = os.Stderr
 	return v, initErr(err, "getting current working directory")
 }
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -16,7 +16,6 @@ import (
 	"github.com/opentable/sous/ext/storage"
 	"github.com/opentable/sous/lib"
 	"github.com/opentable/sous/server"
-	"github.com/opentable/sous/util/cmdr"
 	"github.com/opentable/sous/util/docker_registry"
 	"github.com/opentable/sous/util/logging"
 	"github.com/opentable/sous/util/restful"
@@ -27,23 +26,12 @@ import (
 )
 
 type (
-	// Out is an output used for real data a Command returns. This should only
-	// be used when a command needs to write directly to stdout, using the
-	// formatting options that come with an output. Usually, you should use a
-	// SuccessResult with Data to return data.
-	Out struct{ *cmdr.Output }
-	// ErrOut is an output used for logging from a Command. This should only be
-	// used when a Command needs to write a lot of data to stderr, using the
-	// formatting options that come with and Output. Usually you should use and
-	// ErrorResult to return error messages.
-	ErrOut struct{ *cmdr.Output }
 	// SousGraph is a dependency injector used to flesh out Sous commands
 	// with their dependencies.
 	SousGraph struct {
 		addGuards map[string]bool
 		*psyringe.Psyringe
 	}
-
 	// OutWriter is typically set to os.Stdout.
 	OutWriter io.Writer
 	// ErrWriter is typically set to os.Stderr.

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -212,6 +212,7 @@ func AddConfig(graph adder) {
 		newPossiblyInvalidLocalSousConfig,
 		DefaultConfig{&c},
 		newLocalSousConfig,
+		newVerbosity,
 		newSousConfig,
 		newLocalWorkDir,
 	)

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -197,8 +197,9 @@ func AddFilesystem(graph adder) {
 func AddConfig(graph adder) {
 	c := config.DefaultConfig()
 	graph.Add(
-		newPossiblyInvalidLocalSousConfig,
 		DefaultConfig{&c},
+		newRawConfig,
+		newPossiblyInvalidLocalSousConfig,
 		newLocalSousConfig,
 		newVerbosity,
 		newSousConfig,

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -319,9 +319,7 @@ func newRegistryDumper(r sous.Registry) *sous.RegistryDumper {
 func newLogSet(v semv.Version, config PossiblyInvalidConfig, verb *config.Verbosity) (*logging.LogSet, error) {
 	ls := logging.NewLogSet(v, "", "", os.Stderr)
 	if configErr := config.Logging.Validate(); configErr != nil {
-		// Direct print to stderr to make sure this gets printed in spite of any
-		// other issues with logging.
-		defer fmt.Fprintf(os.Stderr, "WARNING: Invalid configuration: %s\n", configErr)
+		// No need to warn here, this is handled by PIC constructor.
 		config.Logging = logging.Config{}
 	}
 

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -48,7 +48,7 @@ func TestBuildGraph(t *testing.T) {
 	log.SetFlags(log.Flags() | log.Lshortfile)
 	g := BuildGraph(semv.MustParse("0.0.0"), &bytes.Buffer{}, ioutil.Discard, ioutil.Discard)
 	g.Add(DryrunBoth)
-	g.Add(&config.Verbosity{})
+	g.Add(VerbosityOverride{})
 	g.Add(&config.DeployFilterFlags{})
 	g.Add(&config.PolicyFlags{}) //provided by SousBuild
 	g.Add(&config.OTPLFlags{})   //provided by SousInit and SousDeploy

--- a/graph/local_config.go
+++ b/graph/local_config.go
@@ -45,11 +45,12 @@ func newSousConfig(lsc LocalSousConfig) *config.Config {
 
 var printConfigWarningOnce sync.Once
 
-func newPossiblyInvalidLocalSousConfig(u config.LocalUser, defaultConfig DefaultConfig, gcl *ConfigLoader) (PossiblyInvalidConfig, error) {
+func newPossiblyInvalidLocalSousConfig(u config.LocalUser,
+	defaultConfig DefaultConfig, gcl *ConfigLoader, stderr ErrWriter) (PossiblyInvalidConfig, error) {
 	v, err := newPossiblyInvalidConfig(u.ConfigFile(), defaultConfig, gcl)
 	if err := v.Validate(); err != nil {
 		printConfigWarningOnce.Do(func() {
-			fmt.Fprintf(os.Stderr, "WARNING: Invalid configuration: %s\n", err)
+			fmt.Fprintf(stderr, "WARNING: Invalid configuration: %s\n", err)
 		})
 	}
 	return v, initErr(err, "getting configuration")

--- a/graph/testsupport.go
+++ b/graph/testsupport.go
@@ -40,13 +40,16 @@ func TestGraphWithConfig(v semv.Version, in io.Reader, out, err io.Writer, cfg s
 
 	graph := BuildGraph(v, in, out, err)
 
+	// Add missing stuff to the graph (these are things that come from early
+	// initialization in main.go.
+	graph.Add(func() logging.LogSink {
+		return logging.SilentLogSet()
+	})
+
 	// testGraph methods affect graph as well.
 	testGraph := psyringe.TestPsyringe{Psyringe: graph.Psyringe}
 
 	// Replace things from the real graph.
-	testGraph.Add(func() logging.LogSink {
-		return logging.SilentLogSet()
-	})
 	testGraph.Replace(logging.SilentLogSet())
 	testGraph.Replace(sous.User{Name: "Test User", Email: "testuser@example.com"})
 	testGraph.Replace(NewTestConfigLoader)

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/opentable/sous/cli"
 	"github.com/opentable/sous/config"
@@ -86,6 +87,13 @@ func action() int {
 }
 
 func earlyLoggingVerbosityOverride(cliArgs []string) graph.VerbosityOverride {
+	// Filter out probable non-flag args.
+	flagArgs := []string{}
+	for _, arg := range cliArgs {
+		if strings.HasPrefix(arg, "-") {
+			flagArgs = append(flagArgs, arg)
+		}
+	}
 	globalFS := flag.NewFlagSet("verbosity", flag.ContinueOnError)
 	globalFS.SetOutput(ioutil.Discard)
 	var verbosity config.Verbosity
@@ -101,7 +109,7 @@ func earlyLoggingVerbosityOverride(cliArgs []string) graph.VerbosityOverride {
 	// (once we know which command is being run), and a new LogSet is created
 	// based on the result of that, which is therefore guaranteed to be
 	// as accurate as the FlagSet.Parse method.
-	_ = globalFS.Parse(os.Args)
+	_ = globalFS.Parse(flagArgs)
 	// Nothing was overridden by flags as verbosity == zero verbosity.
 	if (verbosity == config.Verbosity{}) {
 		// The zero verbosity override means we defer to config or defaults.

--- a/test/http_state_manager_test.go
+++ b/test/http_state_manager_test.go
@@ -83,9 +83,9 @@ func TestWriteState(t *testing.T) {
 		func() *graph.ServerStateManager { return &graph.ServerStateManager{StateManager: &sm} },
 		func() *graph.ConfigLoader { return graph.NewTestConfigLoader("") },
 	)
-	di.Add(&config.Verbosity{})
 
 	serverScoop := struct{ Handler graph.ServerHandler }{}
+	di.Add(graph.VerbosityOverride{})
 	di.MustInject(&serverScoop)
 	if serverScoop.Handler.Handler == nil {
 		t.Fatalf("Didn't inject http.Handler!")

--- a/test/server_integration_test.go
+++ b/test/server_integration_test.go
@@ -47,8 +47,8 @@ func (suite integrationServerTests) prepare() http.Handler {
 	storage.PrepareTestGitRepo(suite.T(), s, remotepath, outpath)
 
 	g := graph.TestGraphWithConfig(semv.Version{}, &bytes.Buffer{}, os.Stdout, os.Stdout, "StateLocation: '"+outpath+"'\n")
-	g.Add(&config.Verbosity{})
 	g.Add(&config.DeployFilterFlags{})
+	g.Add(graph.VerbosityOverride{})
 	g.Add(graph.DryrunBoth)
 
 	/*

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -61,7 +61,7 @@ func (suite serverTests) prepare(extras ...interface{}) http.Handler {
 	g := graph.TestGraphWithConfig(semv.Version{}, &bytes.Buffer{}, os.Stdout, os.Stdout,
 		"StateLocation: '"+outpath+"'\n")
 	g.Add(extras...)
-	g.Add(&config.Verbosity{})
+	g.Add(graph.VerbosityOverride{})
 	g.Add(&config.DeployFilterFlags{})
 	g.Add(graph.DryrunBoth)
 

--- a/util/configloader/configloader.go
+++ b/util/configloader/configloader.go
@@ -22,7 +22,7 @@ func New() ConfigLoader {
 type (
 	// ConfigLoader loads configuration.
 	ConfigLoader interface {
-		//Loads a YAML formated configuration from path into data.
+		//Loads a YAML formatted configuration from path into data.
 		Load(data interface{}, path string) error
 		// SetValue sets a value at path key, as long as it can convert value to
 		// the correct type for that key. Otherwise it returns an error.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -284,10 +284,10 @@
 			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
-			"checksumSHA1": "CDWp282Ptobg47PAog1h7mbyyzk=",
+			"checksumSHA1": "Ih2XJenHBfEQGO3zE9QzUucpZuk=",
 			"path": "github.com/samsalisbury/psyringe",
-			"revision": "3f6ed6399db3e83068aec459996d893d257ab954",
-			"revisionTime": "2017-11-08T12:26:49Z"
+			"revision": "35c84fe1789e552039aaac08e93af79649c109b2",
+			"revisionTime": "2017-11-15T16:20:39Z"
 		},
 		{
 			"checksumSHA1": "HlLNyPqfD8bdWbEjcV3wPzTemc8=",


### PR DESCRIPTION
CLI flags take precedence over config file options, so the flags should now work as expected.

*Update* now safe to merge.