### PR TITLE
Enable profiling environment variable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ with respect to its command line interface and HTTP interface.
 
 ## [Unreleased](//github.com/opentable/sous/compare/0.5.56...master)
 
+### Fixed
+* Server: Profiling configuration - accepts SOUS_PROFILING environment variable correctly.
+
+### Changed
+* Developer: Server action extracted.
+
 ## [0.5.56](//github.com/opentable/sous/compare/0.5.55...0.5.56)
 ### Fixed
 * CLI: No longer panics under normal operation (e.g. when trying to run 'sous deploy'

--- a/cli/actions/server.go
+++ b/cli/actions/server.go
@@ -1,0 +1,79 @@
+package actions
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/opentable/sous/config"
+	"github.com/opentable/sous/ext/git"
+	"github.com/opentable/sous/lib"
+	"github.com/opentable/sous/server"
+	"github.com/opentable/sous/util/logging"
+	"github.com/opentable/sous/util/shell"
+	"github.com/samsalisbury/semv"
+)
+
+// A Server represents the `sous server` command.
+type Server struct {
+	Version           semv.Version
+	DeployFilterFlags config.DeployFilterFlags `inject:"optional"`
+	Log               logging.LogSink
+
+	ListenAddr string
+	GDMRepo    string
+
+	*config.Config
+	ServerHandler http.Handler
+	*sous.AutoResolver
+}
+
+// Execute is part of the cmdr.Command interface(s).
+func (ss *Server) Do() error {
+	if err := ensureGDMExists(ss.GDMRepo, ss.Config.StateLocation, ss.Log.Warnf); err != nil {
+		return err
+	}
+	ss.Log.Warnf("Starting scheduled GDM resolution.")
+	ss.Log.Warnf("Filtering the GDM to resolve on this server to: %v", ss.DeployFilterFlags)
+
+	ss.AutoResolver.Kickoff()
+
+	ss.Log.Warnf("Sous Server v%s running at %s for %s", ss.Version, ss.ListenAddr, ss.DeployFilterFlags.Cluster)
+
+	return server.Run(ss.ListenAddr, ss.ServerHandler)
+}
+
+func ensureGDMExists(repo, localPath string, log func(string, ...interface{})) error {
+	s, err := os.Stat(localPath)
+	if err == nil && s.IsDir() {
+		files, err := ioutil.ReadDir(localPath)
+		if err != nil {
+			return err
+		}
+		if len(files) != 0 {
+			// The directory exists and is not empty, do nothing.
+			if repo != "" {
+				log("not pulling repo %q; directory already exist and is not empty: %q", repo, localPath)
+			}
+			return nil
+		}
+	}
+	if err := config.EnsureDirExists(localPath); err != nil {
+		return err
+	}
+	// xxx Shouldn't this simply fail if there's no GDM available?
+	sh, err := shell.DefaultInDir(localPath)
+	if err != nil {
+		return err
+	}
+	g, err := git.NewClient(sh)
+	if err != nil {
+		return err
+	}
+	log("cloning %q into %q ...", repo, localPath)
+	if err := g.CloneRepo(repo, localPath); err != nil {
+		return err
+	}
+	log("done")
+	return nil
+}

--- a/cli/actions/server_test.go
+++ b/cli/actions/server_test.go
@@ -1,4 +1,4 @@
-package cli
+package actions
 
 import (
 	"io/ioutil"

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -219,10 +219,10 @@ func TestInvokeServer(t *testing.T) {
 	assert.NotNil(t, exe)
 	server, good := exe.Cmd.(*SousServer)
 	require.True(t, good)
-	assert.NotNil(t, server.ServerHandler)
-	assert.NotNil(t, server.ServerHandler.Handler)
-	assert.True(t, server.AutoResolver.ResolveFilter.Offset.All(), "server.AutoResolver.ResolveFilter.Offset.All")
-	assert.True(t, server.AutoResolver.ResolveFilter.Flavor.All(), "server.AutoResolver.ResolveFilter.Flavor.All")
+
+	assert.Equal(t, "test", server.DeployFilterFlags.Cluster)
+	assert.Equal(t, "none", server.dryrun)
+	assert.Equal(t, false, server.profiling)
 }
 
 /*

--- a/cli/sous_query.go
+++ b/cli/sous_query.go
@@ -7,7 +7,6 @@ import (
 )
 
 type SousQuery struct {
-	Sous  *Sous
 	flags struct {
 		target              string
 		rebuild, rebuildAll bool

--- a/cli/sous_server.go
+++ b/cli/sous_server.go
@@ -2,37 +2,20 @@ package cli
 
 import (
 	"flag"
-	"io/ioutil"
-	"os"
 
 	"github.com/opentable/sous/config"
-	"github.com/opentable/sous/ext/git"
 	"github.com/opentable/sous/graph"
-	"github.com/opentable/sous/lib"
-	"github.com/opentable/sous/server"
 	"github.com/opentable/sous/util/cmdr"
-	"github.com/opentable/sous/util/shell"
 )
 
 // A SousServer represents the `sous server` command.
 type SousServer struct {
-	Sous              *Sous
+	SousGraph         *graph.SousGraph
 	DeployFilterFlags config.DeployFilterFlags `inject:"optional"`
-	Log               graph.LogSink
-
-	*config.Config
-	graph.ServerHandler
-	*sous.AutoResolver
-
-	flags struct {
-		dryrun,
-		// laddr is the listen address in the form [host]:port
-		laddr,
-		// gdmRepo is a repository to clone into config.SourceLocation
-		// in the case that config.SourceLocation is empty.
-		gdmRepo string
-		profiling bool
-	}
+	dryrun,
+	laddr,
+	gdmRepo string
+	profiling bool
 }
 
 func init() { TopLevelCommands["server"] = &SousServer{} }
@@ -50,73 +33,23 @@ func (ss *SousServer) Help() string {
 // AddFlags is part of the cmdr.Command interfaces(s).
 func (ss *SousServer) AddFlags(fs *flag.FlagSet) {
 	MustAddFlags(fs, &ss.DeployFilterFlags, ClusterFilterFlagsHelp)
-	fs.StringVar(&ss.flags.dryrun, "dry-run", "none",
+	fs.StringVar(&ss.dryrun, "dry-run", "none",
 		"prevent rectify from actually changing things - "+
 			"values are none,scheduler,registry,both")
-	fs.StringVar(&ss.flags.laddr, `listen`, `:80`, "The address to listen on, like '127.0.0.1:https'")
-	fs.StringVar(&ss.flags.gdmRepo, "gdm-repo", "", "Git repo containing the GDM (cloned into config.SourceLocation)")
-	fs.BoolVar(&ss.flags.profiling, "profiling", false, "Enable profiling in the server.")
-}
-
-// RegisterOn adds the DeploymentConfig to the psyringe to configure the
-// labeller and registrar.
-func (ss *SousServer) RegisterOn(psy Addable) {
-	psy.Add(graph.DryrunOption(ss.flags.dryrun))
-	ss.DeployFilterFlags.Offset = "*"
-	ss.DeployFilterFlags.Flavor = "*"
-	psy.Add(&ss.DeployFilterFlags)
-	psy.Add(graph.ProfilingServer(ss.flags.profiling))
+	fs.StringVar(&ss.laddr, `listen`, `:80`, "The address to listen on, like '127.0.0.1:https'")
+	fs.StringVar(&ss.gdmRepo, "gdm-repo", "", "Git repo containing the GDM (cloned into config.SourceLocation)")
+	fs.BoolVar(&ss.profiling, "profiling", false, "Enable profiling in the server.")
 }
 
 // Execute is part of the cmdr.Command interface(s).
 func (ss *SousServer) Execute(args []string) cmdr.Result {
-	if err := ensureGDMExists(ss.flags.gdmRepo, ss.Config.StateLocation, ss.Log.Warnf); err != nil {
-		return EnsureErrorResult(err)
-	}
-	ss.Log.Warnf("Starting scheduled GDM resolution.")
-	ss.Log.Warnf("Filtering the GDM to resolve on this server to: %v", ss.DeployFilterFlags)
-
-	ss.AutoResolver.Kickoff()
-
-	ss.Log.Warnf("Sous Server v%s running at %s for %s", ss.Sous.Version, ss.flags.laddr, ss.DeployFilterFlags.Cluster)
-
-	if os.Getenv("SOUS_PROFILING") == "enable" {
-		ss.flags.profiling = true
-	}
-
-	return EnsureErrorResult(server.Run(ss.flags.laddr, ss.ServerHandler.Handler))
-}
-
-func ensureGDMExists(repo, localPath string, log func(string, ...interface{})) error {
-	s, err := os.Stat(localPath)
-	if err == nil && s.IsDir() {
-		files, err := ioutil.ReadDir(localPath)
-		if err != nil {
-			return err
-		}
-		if len(files) != 0 {
-			// The directory exists and is not empty, do nothing.
-			if repo != "" {
-				log("not pulling repo %q; directory already exist and is not empty: %q", repo, localPath)
-			}
-			return nil
-		}
-	}
-	if err := config.EnsureDirExists(localPath); err != nil {
-		return EnsureErrorResult(err)
-	}
-	sh, err := shell.DefaultInDir(localPath)
+	server, err := ss.SousGraph.GetServer(ss.DeployFilterFlags, ss.dryrun, ss.laddr, ss.gdmRepo, ss.profiling)
 	if err != nil {
+		return cmdr.EnsureErrorResult(err)
+	}
+
+	if err := server.Do(); err != nil {
 		return EnsureErrorResult(err)
 	}
-	g, err := git.NewClient(sh)
-	if err != nil {
-		return EnsureErrorResult(err)
-	}
-	log("cloning %q into %q ...", repo, localPath)
-	if err := g.CloneRepo(repo, localPath); err != nil {
-		return EnsureErrorResult(err)
-	}
-	log("done")
-	return nil
+	return cmdr.Success("Done serving for Sous.")
 }

--- a/graph/actions.go
+++ b/graph/actions.go
@@ -1,9 +1,12 @@
 package graph
 
 import (
+	"os"
+
 	"github.com/opentable/sous/cli/actions"
 	"github.com/opentable/sous/config"
 	sous "github.com/opentable/sous/lib"
+	"github.com/samsalisbury/semv"
 )
 
 func (di *SousGraph) guardedAdd(guardName string, value interface{}) {
@@ -77,5 +80,38 @@ func (di *SousGraph) GetPollStatus(dryrun string, dff config.DeployFilterFlags) 
 
 	return &actions.PollStatus{
 		StatusPoller: scoop.StatusPoller,
+	}, nil
+}
+
+func (di *SousGraph) GetServer(dff config.DeployFilterFlags, dryrun string, laddr string, gdmRepo string, profiling bool) (actions.Action, error) {
+	dff.Offset = "*"
+	dff.Flavor = "*"
+	profiling = profiling || os.Getenv("SOUS_PROFILING") == "enable"
+
+	di.guardedAdd("DeployFilterFlags", &dff)
+	di.guardedAdd("Dryrun", DryrunOption(dryrun))
+	di.guardedAdd("ProfilingServer", ProfilingServer(profiling))
+
+	scoop := struct {
+		Version       semv.Version
+		LogSink       LogSink
+		Config        *config.Config
+		ServerHandler ServerHandler
+		AutoResolver  *sous.AutoResolver
+	}{}
+
+	if err := di.Inject(&scoop); err != nil {
+		return nil, err
+	}
+
+	return &actions.Server{
+		DeployFilterFlags: dff,
+		GDMRepo:           gdmRepo,
+		ListenAddr:        laddr,
+		Version:           scoop.Version,
+		Log:               scoop.LogSink.LogSink,
+		Config:            scoop.Config,
+		ServerHandler:     scoop.ServerHandler.Handler,
+		AutoResolver:      scoop.AutoResolver,
 	}, nil
 }


### PR DESCRIPTION
The profiling boolean was getting injected by value before checking the environment.
Fixed that, and also extracted Server as an Action while I was there.

I've tested the profiling configuration locally. If we can get this into production ASAP,
we can start experimenting with the profiling output to see if it tells us anything
about the rectification cycle.