### PR TITLE
Make targets and liquibase scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /usr/bin/env bash
 
 XDG_DATA_HOME ?= $(HOME)/.local/share
-DEV_POSTGRES_DIR ?= $(XDG_DATA_HOME)/postgres
+DEV_POSTGRES_DIR ?= $(XDG_DATA_HOME)/sous/postgres
 DEV_POSTGRES_DATA_DIR ?= $(DEV_POSTGRES_DIR)/data
 
 SQLITE_URL := https://sqlite.org/2017/sqlite-autoconf-3160200.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,9 @@ postgres-stop:
 postgres-connect:
 	psql -h localhost -p $(PGPORT) sous
 
+postgres-update-schema: postgres-start
+	liquibase --url jdbc:postgresql://localhost:$(PGPORT)/sous --changeLogFile=database/changelog.xml update
+
 .PHONY: artifactory clean clean-containers clean-container-certs clean-running-containers clean-container-images coverage deb-build install-fpm install-jfrog install-ggen install-build-tools legendary release semvertagchk test test-gofmt test-integration setup-containers test-unit reject-wip wip staticcheck postgres-start postgres-stop postgres-connect
 
 #liquibase --url jdbc:postgresql://127.0.0.1:6543/sous --changeLogFile=database/changelog.xml update

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SHELL := /usr/bin/env bash
 XDG_DATA_HOME ?= $(HOME)/.local/share
 DEV_POSTGRES_DIR ?= $(XDG_DATA_HOME)/sous/postgres
 DEV_POSTGRES_DATA_DIR ?= $(DEV_POSTGRES_DIR)/data
+PGPORT ?= 6543
 
 SQLITE_URL := https://sqlite.org/2017/sqlite-autoconf-3160200.tar.gz
 GO_VERSION := 1.7.3
@@ -238,15 +239,15 @@ $(DEV_POSTGRES_DATA_DIR)/postgresql.conf: $(DEV_POSTGRES_DATA_DIR) dev_support/p
 
 postgres-start: $(DEV_POSTGRES_DATA_DIR)/postgresql.conf
 	if ! (pg_isready -h $(DEV_POSTGRES_DIR)); then \
-		postgres -D $(DEV_POSTGRES_DATA_DIR) -k $(DEV_POSTGRES_DIR) & \
+		postgres -D $(DEV_POSTGRES_DATA_DIR) -p $(PGPORT) & \
 	fi
-	until pg_isready -h $(DEV_POSTGRES_DIR); do sleep 1; done
-	createdb -h $(DEV_POSTGRES_DIR) sous > /dev/null 2>&1 || true
+	until pg_isready -h localhost -p $(PGPORT); do sleep 1; done
+	createdb -h localhost -p $(PGPORT) sous > /dev/null 2>&1 || true
 
 postgres-stop:
 	pg_ctl stop -D $(DEV_POSTGRES_DATA_DIR)
 
 postgres-connect:
-	psql -h $(DEV_POSTGRES_DIR) sous
+	psql -h localhost -p $(PGPORT) sous
 
 .PHONY: artifactory clean clean-containers clean-container-certs clean-running-containers clean-container-images coverage deb-build install-fpm install-jfrog install-ggen install-build-tools legendary release semvertagchk test test-gofmt test-integration setup-containers test-unit reject-wip wip staticcheck postgres-start postgres-stop postgres-connect

--- a/Makefile
+++ b/Makefile
@@ -241,12 +241,12 @@ postgres-start: $(DEV_POSTGRES_DATA_DIR)/postgresql.conf
 		postgres -D $(DEV_POSTGRES_DATA_DIR) -k $(DEV_POSTGRES_DIR) & \
 	fi
 	until pg_isready -h $(DEV_POSTGRES_DIR); do sleep 1; done
-	createdb -h $(DEV_POSTGRES_DIR) > /dev/null 2>&1 || true
+	createdb -h $(DEV_POSTGRES_DIR) sous > /dev/null 2>&1 || true
 
 postgres-stop:
 	pg_ctl stop -D $(DEV_POSTGRES_DATA_DIR)
 
 postgres-connect:
-	psql -h $(DEV_POSTGRES_DIR)
+	psql -h $(DEV_POSTGRES_DIR) sous
 
 .PHONY: artifactory clean clean-containers clean-container-certs clean-running-containers clean-container-images coverage deb-build install-fpm install-jfrog install-ggen install-build-tools legendary release semvertagchk test test-gofmt test-integration setup-containers test-unit reject-wip wip staticcheck postgres-start postgres-stop postgres-connect

--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,7 @@ postgres-start: $(DEV_POSTGRES_DATA_DIR)/postgresql.conf
 	fi
 	until pg_isready -h localhost -p $(PGPORT); do sleep 1; done
 	createdb -h localhost -p $(PGPORT) sous > /dev/null 2>&1 || true
+	liquibase --url jdbc:postgresql://localhost:$(PGPORT)/sous --changeLogFile=database/changelog.xml update
 
 postgres-stop:
 	pg_ctl stop -D $(DEV_POSTGRES_DATA_DIR)
@@ -251,3 +252,5 @@ postgres-connect:
 	psql -h localhost -p $(PGPORT) sous
 
 .PHONY: artifactory clean clean-containers clean-container-certs clean-running-containers clean-container-images coverage deb-build install-fpm install-jfrog install-ggen install-build-tools legendary release semvertagchk test test-gofmt test-integration setup-containers test-unit reject-wip wip staticcheck postgres-start postgres-stop postgres-connect
+
+#liquibase --url jdbc:postgresql://127.0.0.1:6543/sous --changeLogFile=database/changelog.xml update

--- a/database/changelog.xml
+++ b/database/changelog.xml
@@ -48,7 +48,7 @@
             <column name="crdef_port_index" type="INT">
                 <constraints nullable="false"/>
             </column>
-            <column name="crdef_failure_statuses" type="_INT4(10)">
+            <column name="crdef_failure_statuses" type="_INT4">
                 <constraints nullable="false"/>
             </column>
             <column name="crdef_url_timeout" type="INT">
@@ -135,7 +135,7 @@
             <column name="cr_retries" type="INT">
                 <constraints nullable="false"/>
             </column>
-            <column name="cr_failure_statuses" type="_INT4(10)">
+            <column name="cr_failure_statuses" type="_INT4">
                 <constraints nullable="false"/>
             </column>
             <column name="cr_skip" type="BOOLEAN">

--- a/database/changelog.xml
+++ b/database/changelog.xml
@@ -1,0 +1,319 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <changeSet author="judson (generated)" id="1513627199847-1">
+        <createTable tableName="cluster_qualities">
+            <column autoIncrement="true" name="cluster_quality_id" type="SERIAL">
+                <constraints primaryKey="true" primaryKeyName="cluster_qualities_pkey"/>
+            </column>
+            <column name="cluster_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="quality_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-2">
+        <createTable tableName="clusters">
+            <column autoIncrement="true" name="cluster_id" type="SERIAL">
+                <constraints primaryKey="true" primaryKeyName="clusters_pkey"/>
+            </column>
+            <column name="name" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="kind" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="base_url" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="crdef_skip" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="crdef_connect_delay" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="crdef_timeout" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="crdef_connect_interval" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="crdef_proto" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="crdef_path" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="crdef_port_index" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="crdef_failure_statuses" type="_INT4(10)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="crdef_url_timeout" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="crdef_interval" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="crdef_retries" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-3">
+        <createTable tableName="component_owners">
+            <column autoIncrement="true" name="component_owner_id" type="SERIAL">
+                <constraints primaryKey="true" primaryKeyName="component_owners_pkey"/>
+            </column>
+            <column name="component_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="owner_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-4">
+        <createTable tableName="components">
+            <column autoIncrement="true" name="component_id" type="SERIAL">
+                <constraints primaryKey="true" primaryKeyName="components_pkey"/>
+            </column>
+            <column name="repo" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="dir" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="flavor" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="kind" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-5">
+        <createTable tableName="deployments">
+            <column autoIncrement="true" name="deployment_id" type="SERIAL">
+                <constraints primaryKey="true" primaryKeyName="deployments_pkey"/>
+            </column>
+            <column name="versionstring" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="num_instances" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="schedule_string" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cr_proto" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cr_path" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cr_connect_delay" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cr_timeout" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cr_connect_interval" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cr_port_index" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cr_uri_timeout" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cr_interval" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cr_retries" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cr_failure_statuses" type="_INT4(10)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cr_skip" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cluster_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="components_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-6">
+        <createTable tableName="env_defaults">
+            <column autoIncrement="true" name="env_default_id" type="SERIAL">
+                <constraints primaryKey="true" primaryKeyName="env_defaults_pkey"/>
+            </column>
+            <column name="key" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cluster_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-7">
+        <createTable tableName="env_fdefs">
+            <column autoIncrement="true" name="env_fdef_id" type="SERIAL">
+                <constraints primaryKey="true" primaryKeyName="env_fdefs_pkey"/>
+            </column>
+            <column name="field_name" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="var_type" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="default_value" type="TEXT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-8">
+        <createTable tableName="envs">
+            <column autoIncrement="true" name="env_id" type="SERIAL">
+                <constraints primaryKey="true" primaryKeyName="envs_pkey"/>
+            </column>
+            <column name="key" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="deployment_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-9">
+        <createTable tableName="metadatas">
+            <column autoIncrement="true" name="metadata_id" type="SERIAL">
+                <constraints primaryKey="true" primaryKeyName="metadatas_pkey"/>
+            </column>
+            <column name="name" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="deployment_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-10">
+        <createTable tableName="owners">
+            <column autoIncrement="true" name="owner_id" type="SERIAL">
+                <constraints primaryKey="true" primaryKeyName="owners_pkey"/>
+            </column>
+            <column name="email" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-11">
+        <createTable tableName="qualities">
+            <column autoIncrement="true" name="quality_id" type="SERIAL">
+                <constraints primaryKey="true" primaryKeyName="qualities_pkey"/>
+            </column>
+            <column name="name" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="kind" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-12">
+        <createTable tableName="resource_fdefs">
+            <column autoIncrement="true" name="resource_fdef_id" type="SERIAL">
+                <constraints primaryKey="true" primaryKeyName="resource_fdefs_pkey"/>
+            </column>
+            <column name="field_name" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="var_type" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="default_value" type="TEXT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-13">
+        <createTable tableName="resources">
+            <column autoIncrement="true" name="resource_id" type="SERIAL">
+                <constraints primaryKey="true" primaryKeyName="resources_pkey"/>
+            </column>
+            <column name="resource_name" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="resource_value" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="deployment_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-14">
+        <createTable tableName="volumes">
+            <column autoIncrement="true" name="volume_id" type="SERIAL">
+                <constraints primaryKey="true" primaryKeyName="volumes_pkey"/>
+            </column>
+            <column name="host" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="container" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="mode" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="deployment_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-15">
+        <addForeignKeyConstraint baseColumnNames="cluster_id" baseTableName="cluster_qualities" constraintName="cluster_qualities_cluster_id_fkey" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="cluster_id" referencedTableName="clusters"/>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-16">
+        <addForeignKeyConstraint baseColumnNames="quality_id" baseTableName="cluster_qualities" constraintName="cluster_qualities_quality_id_fkey" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="quality_id" referencedTableName="qualities"/>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-17">
+        <addForeignKeyConstraint baseColumnNames="component_id" baseTableName="component_owners" constraintName="component_owners_component_id_fkey" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="component_id" referencedTableName="components"/>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-18">
+        <addForeignKeyConstraint baseColumnNames="owner_id" baseTableName="component_owners" constraintName="component_owners_owner_id_fkey" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="owner_id" referencedTableName="owners"/>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-19">
+        <addForeignKeyConstraint baseColumnNames="cluster_id" baseTableName="deployments" constraintName="deployments_cluster_id_fkey" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="cluster_id" referencedTableName="clusters"/>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-20">
+        <addForeignKeyConstraint baseColumnNames="components_id" baseTableName="deployments" constraintName="deployments_components_id_fkey" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="component_id" referencedTableName="components"/>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-21">
+        <addForeignKeyConstraint baseColumnNames="cluster_id" baseTableName="env_defaults" constraintName="env_defaults_cluster_id_fkey" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="cluster_id" referencedTableName="clusters"/>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-22">
+        <addForeignKeyConstraint baseColumnNames="deployment_id" baseTableName="envs" constraintName="envs_deployment_id_fkey" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="deployment_id" referencedTableName="deployments"/>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-23">
+        <addForeignKeyConstraint baseColumnNames="deployment_id" baseTableName="metadatas" constraintName="metadatas_deployment_id_fkey" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="deployment_id" referencedTableName="deployments"/>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-24">
+        <addForeignKeyConstraint baseColumnNames="deployment_id" baseTableName="resources" constraintName="resources_deployment_id_fkey" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="deployment_id" referencedTableName="deployments"/>
+    </changeSet>
+    <changeSet author="judson (generated)" id="1513627199847-25">
+        <addForeignKeyConstraint baseColumnNames="deployment_id" baseTableName="volumes" constraintName="volumes_deployment_id_fkey" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="deployment_id" referencedTableName="deployments"/>
+    </changeSet>
+</databaseChangeLog>

--- a/dev_support/postgres/postgresql.conf
+++ b/dev_support/postgres/postgresql.conf
@@ -1,2 +1,3 @@
 log_destination = 'stderr'
+logging_collector = true
 listen_addresses = ''

--- a/dev_support/postgres/postgresql.conf
+++ b/dev_support/postgres/postgresql.conf
@@ -1,0 +1,2 @@
+log_destination = 'stderr'
+listen_addresses = ''

--- a/dev_support/postgres/postgresql.conf
+++ b/dev_support/postgres/postgresql.conf
@@ -1,3 +1,2 @@
 log_destination = 'stderr'
 logging_collector = true
-listen_addresses = ''

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,5 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import ~/dev/nixpkgs {} }:
+#{ pkgs ? import <nixpkgs> {} }:
 let
   inherit (pkgs) lib stdenv ruby rake bundler bundlerEnv postgresql100 liquibase;
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 { pkgs ? import <nixpkgs> {} }:
 let
-  inherit (pkgs) lib stdenv ruby rake bundler bundlerEnv;
+  inherit (pkgs) lib stdenv ruby rake bundler bundlerEnv postgresql100 liquibase;
 
   rubyEnv = bundlerEnv {
     name = "sous-danger";
@@ -8,4 +8,13 @@ let
     gemdir = ./.;
   };
 in
-  rubyEnv.env
+  stdenv.mkDerivation {
+    name = "sous-env";
+    src = ./.;
+
+    buildInputs = [
+      rubyEnv
+      postgresql100
+      liquibase
+    ];
+  }


### PR DESCRIPTION
This PR adds make targets that allow for a development database to be set up quickly.

It currently requires that you have Postgres 10 and Liquibase installed (with
the 42.1 version of the Postgres JDBC driver). I'm afraid this requirement will
be onerous for other devs, so I want to check that assumption.

Once you have the required software installed, these commands should work:

`make postgres-start`
This is not only start development Postgres server,
it will also build the requisite data directory,
and use the Liquibase changelog to update its schema.

`make postgres-connect`
Connects psql to the dev database. Just a convenience -
it means you don't have to know or remember the connection parameters.

`make postgres-stop`
Shuts down the development server.