### PR TITLE
Using placeholders for data-sourced values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ with respect to its command line interface and HTTP interface.
 
 ### Added
 * Server: If don't set a valid default log level, use Extreme and print out a message
-* Server: storage module for Postgres. As yet, not connected up.
+* Server: storage module for Postgres. Uses placeholders correctly. As yet, not connected up.
 
 ### Fixed:
 * All: Creating a manifest with Owners field not sorted alphabetically was preventing

--- a/ext/storage/postgresstatemanager_test.go
+++ b/ext/storage/postgresstatemanager_test.go
@@ -58,9 +58,9 @@ func SetupTest(t *testing.T) *PostgresStateManagerSuite {
 		Host:     "localhost",
 		Port:     port,
 		SSL:      false,
-	}, logging.SilentLogSet())
-	//}, logging.Log)
-	//logging.Log.BeChatty()
+		//}, logging.SilentLogSet())
+	}, logging.Log)
+	logging.Log.BeChatty()
 
 	if err != nil {
 		suite.FailNow("Setting up", "error: %v", err)
@@ -73,7 +73,7 @@ func SetupTest(t *testing.T) *PostgresStateManagerSuite {
 	return suite
 }
 
-func TestWriteState_success(t *testing.T) {
+func TestPostgresStateManagerWriteState_success(t *testing.T) {
 	suite := SetupTest(t)
 
 	s := exampleState()


### PR DESCRIPTION
Things like table and column names are still being interpolated, since those
are all controlled by the program and known at compile/testing time.

Tests exercise ~30 placeholder parameters. I guess we'll see if there's a hard
upper limit. I wasn't able to find an documentation to the effect.