### PR TITLE
Fix validate check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,14 @@ with respect to its command line interface and HTTP interface.
 
 ### Added
 * Server: If don't set a valid default log level, use Extreme and print out a message
-* Server: storage module for Postgres. Uses placeholders correctly. As yet, not connected up.
+* Server: Storage module for Postgres. Uses placeholders correctly. As yet, not connected up.
 
 ### Fixed:
 * All: Creating a manifest with Owners field not sorted alphabetically was preventing
   any updates to other manifests because the field was being sorted and thus creating
   additional diffs (we disallow changed to the GDM that affect multiple manifests.)
   Now the Owners field is always ordered alphabetically on write fixing this issue.
-
+* Server: Validation when Kafka Cfg was enabled did not correctly check if brokers were specified.
 
 ## [0.5.61](//github.com/opentable/sous/compare/0.5.60...0.5.61)
 

--- a/util/logging/config.go
+++ b/util/logging/config.go
@@ -85,11 +85,22 @@ func (cfg Config) getLogrusLevel() logrus.Level {
 	}
 }
 
+func deleteEmpty(s []string) []string {
+	var r []string
+	for _, str := range s {
+		if str != "" {
+			r = append(r, str)
+		}
+	}
+	return r
+}
+
 func (cfg Config) getBrokers() []string {
 	if len(cfg.Kafka.Brokers) != 0 {
-		return cfg.Kafka.Brokers
+		return deleteEmpty(cfg.Kafka.Brokers)
 	}
-	return strings.Split(cfg.Kafka.BrokerList, ",")
+
+	return deleteEmpty(strings.Split(cfg.Kafka.BrokerList, ","))
 }
 
 func (cfg Config) getKafkaLevel() Level {

--- a/util/logging/config_test.go
+++ b/util/logging/config_test.go
@@ -31,6 +31,20 @@ func TestLoggingConfig(t *testing.T) {
 		assert.Equal(t, cfg.getBrokers(), []string{"127.0.0.1:5000", "127.0.0.2:5000"})
 	})
 
+	t.Run("empty kafka brokers list", func(t *testing.T) {
+		cfg := pangramConfig()
+		cfg.Kafka.Enabled = true
+		cfg.Kafka.BrokerList = ""
+		assert.Error(t, cfg.validateKafka(), "Error should have occurred, must have broker list")
+	})
+
+	t.Run("no kafka topic", func(t *testing.T) {
+		cfg := pangramConfig()
+		cfg.Kafka.Enabled = true
+		cfg.Kafka.Topic = ""
+		assert.Error(t, cfg.validateKafka(), "Error should have occurred, must have topic")
+	})
+
 	t.Run("graphite server", func(t *testing.T) {
 		cfg := pangramConfig()
 		assert.Equal(t, cfg.getGraphiteServer(), "graphite.example.com:2003")


### PR DESCRIPTION
If you don't specify brokers for kafka, the validation never actually catches error.

https://stackoverflow.com/questions/35866221/why-does-an-empty-array-returned-from-strings-split-have-a-length-of-1-in-golang


