### PR TITLE
Duplex state storage, copies state out to Postgres DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ with respect to its command line interface and HTTP interface.
 
 ## [Unreleased](//github.com/opentable/sous/compare/0.5.62...HEAD)
 
+* Server: adding duplex state storage, to keep DB in sync until ready to switch over
+
 ## [0.5.62](//github.com/opentable/sous/compare/0.5.61...0.5.62)
 
 ### Added

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,8 @@ type (
 		// considers the master. If this is not set, this node is considered
 		// to be a master. This value must be in URL format.
 		Server string `env:"SOUS_SERVER"`
+		// Database contains configuration for the local Postgresql DB.
+		Database storage.PostgresConfig
 		// SiblingURLs is a temporary measure for setting up a distributed cluster
 		// of sous servers. Each server must be configured with accessible URLs for
 		// all the servers in production, as named by cluster.

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/opentable/sous/ext/docker"
+	"github.com/opentable/sous/ext/storage"
 	"github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/firsterr"
 	"github.com/opentable/sous/util/logging"

--- a/ext/storage/duplexstatemanager.go
+++ b/ext/storage/duplexstatemanager.go
@@ -1,0 +1,41 @@
+package storage
+
+// A DuplexStateManager echoes StateManager operation to a primary StateManager,
+// but also ensures that writes occur to the secondary one.
+type DuplexStateManager struct {
+	primary, secondary sous.StateManager
+	log                logging.LogSink
+}
+
+// NewDuplexStateManager creates a DuplexStateManager
+func NewDuplexStateManager(primary, secondary sous.StateManager, log logging.LogSink) *DuplexStateManager {
+	return &DuplexStateManager{
+		primary:   primary,
+		secondary: secondary,
+		log:       log,
+	}
+}
+
+// ReadState implements StateManager on DuplexStateManager
+func (dup *DuplexStateManager) ReadState() (*sous.State, error) {
+	start := time.Now()
+	state, err := dup.primary.ReadState()
+	if err != nil {
+		if err := dup.secondary.WriteState(state, user); err != nil {
+			logging.ReportError(dup.log, errors.Wrapf(err, "writing to secondary StateManager"))
+		}
+	}
+	reportReading(dup.log, start, state, err)
+	return state, err
+}
+
+// WriteState implements StateManager on DuplexStateManager
+func (dup *DuplexStateManager) WriteState(state *sous.State, user sous.User) error {
+	start := time.Now()
+	if err := dup.secondary.WriteState(state, user); err != nil {
+		logging.ReportError(dup.log, errors.Wrapf(err, "writing to secondary StateManager"))
+	}
+	err := dup.primary.WriteState(state, user)
+	reportWriting(dup.log, start, state, err)
+	return err
+}

--- a/ext/storage/duplexstatemanager.go
+++ b/ext/storage/duplexstatemanager.go
@@ -1,5 +1,13 @@
 package storage
 
+import (
+	"time"
+
+	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/logging"
+	"github.com/pkg/errors"
+)
+
 // A DuplexStateManager echoes StateManager operation to a primary StateManager,
 // but also ensures that writes occur to the secondary one.
 type DuplexStateManager struct {
@@ -18,9 +26,10 @@ func NewDuplexStateManager(primary, secondary sous.StateManager, log logging.Log
 
 // ReadState implements StateManager on DuplexStateManager
 func (dup *DuplexStateManager) ReadState() (*sous.State, error) {
+	user := sous.User{}
 	start := time.Now()
 	state, err := dup.primary.ReadState()
-	if err != nil {
+	if err == nil {
 		if err := dup.secondary.WriteState(state, user); err != nil {
 			logging.ReportError(dup.log, errors.Wrapf(err, "writing to secondary StateManager"))
 		}

--- a/ext/storage/duplexstatemanager_test.go
+++ b/ext/storage/duplexstatemanager_test.go
@@ -1,0 +1,131 @@
+package storage
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/logging"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDuplexWrite(t *testing.T) {
+	s := exampleState()
+
+	clobberDir(t, "testdata/result")
+	PrepareTestGitRepo(t, s, "testdata/remote", "testdata/out")
+
+	db := setupDB(t)
+	defer db.Close()
+
+	log, _ := logging.NewLogSinkSpy()
+	gsm := NewGitStateManager(NewDiskStateManager("testdata/out"))
+	psm := NewPostgresStateManager(db, log)
+	dupsm := NewDuplexStateManager(gsm, psm, log)
+
+	require.NoError(t, dupsm.WriteState(s, testUser))
+
+	pstate, err := psm.ReadState()
+	require.NoError(t, err)
+	assertStatesEqual(t, s, pstate)
+
+	remoteAbs, err := filepath.Abs("testdata/remote")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCmd(t, "testdata", "git", "clone", "file://"+remoteAbs, "result")
+
+	os.RemoveAll("testdata/result/.git")
+
+	d := exec.Command("diff", "-r", "testdata/in", "testdata/result")
+
+	if out, err := d.CombinedOutput(); err != nil {
+		t.Fatalf("Output not as expected: %s;\n%s", err, string(out))
+	}
+}
+
+func TestDuplexReadState(t *testing.T) {
+	s := exampleState()
+	PrepareTestGitRepo(t, s, "testdata/remote", "testdata/out")
+
+	db := setupDB(t)
+	defer db.Close()
+	log, _ := logging.NewLogSinkSpy()
+	gsm := NewGitStateManager(NewDiskStateManager("testdata/out"))
+	psm := NewPostgresStateManager(db, log)
+
+	dupsm := NewDuplexStateManager(gsm, psm, log)
+
+	actual, err := dupsm.ReadState()
+	require.NoError(t, err)
+
+	expected := exampleState()
+
+	sameYAML(t, actual, expected)
+
+	pstate, err := psm.ReadState()
+	require.NoError(t, err)
+	assertStatesEqual(t, expected, pstate)
+}
+
+func setupDB(t *testing.T) *sql.DB {
+	t.Helper()
+	port := "6543"
+	if np, set := os.LookupEnv("PGPORT"); set {
+		port = np
+	}
+	connstr := fmt.Sprintf("dbname=sous_test_template host=localhost port=%s sslmode=disable", port)
+	setupDB, err := sql.Open("postgres", connstr)
+	if err != nil {
+		t.Logf("Error setting up test database Error: %v. Did you already `make postgres-test-prepare`?", err)
+		t.FailNow()
+	}
+	// ignoring error because I think "no such DB is a failure"
+	setupDB.Exec("drop database sous_test")
+	if _, err := setupDB.Exec("create database sous_test template sous_test_template"); err != nil {
+		t.Logf("Error creating test database connstr %q err %v", connstr, err)
+		t.FailNow()
+	}
+	if err := setupDB.Close(); err != nil {
+		t.Logf("Error closing DB manipulation connection connstr %q err %v", connstr, err)
+		t.FailNow()
+	}
+	db, err := PostgresConfig{
+		DBName:   "sous_test",
+		User:     "",
+		Password: "",
+		Host:     "localhost",
+		Port:     port,
+		SSL:      false,
+	}.DB()
+
+	if err != nil {
+		t.Logf("Setting up, error: %v", err)
+		t.FailNow()
+	}
+	return db
+}
+
+func assertStatesEqual(t *testing.T, oldState, newState *sous.State) {
+	t.Helper()
+
+	oldD, err := oldState.Deployments()
+	require.NoError(t, err)
+	newD, err := newState.Deployments()
+	require.NoError(t, err)
+
+	for diff := range oldD.Diff(newD).Pairs {
+		switch diff.Kind() {
+		default:
+			t.Errorf("Difference detected between written and read states: %s %+#v", diff.Kind(), diff)
+		case sous.ModifiedKind:
+			t.Errorf("Difference detected between written and read states: %+#v %+#v", diff, diff.Diffs())
+
+		case sous.SameKind:
+		}
+	}
+}

--- a/ext/storage/duplexstatemanager_test.go
+++ b/ext/storage/duplexstatemanager_test.go
@@ -85,7 +85,10 @@ func setupDB(t *testing.T) *sql.DB {
 		t.FailNow()
 	}
 	// ignoring error because I think "no such DB is a failure"
-	setupDB.Exec("drop database sous_test")
+	if _, err := setupDB.Exec("drop database sous_test"); err != nil && !isNoDBError(err) {
+		t.Logf("Error dropping old test database connstr %q err %v", connstr, err)
+		t.FailNow()
+	}
 	if _, err := setupDB.Exec("create database sous_test template sous_test_template"); err != nil {
 		t.Logf("Error creating test database connstr %q err %v", connstr, err)
 		t.FailNow()
@@ -104,7 +107,7 @@ func setupDB(t *testing.T) *sql.DB {
 	}.DB()
 
 	if err != nil {
-		t.Logf("Setting up, error: %v", err)
+		t.Logf("Creating test sql.DB, error: %v", err)
 		t.FailNow()
 	}
 	return db

--- a/ext/storage/logonlystatemanager.go
+++ b/ext/storage/logonlystatemanager.go
@@ -1,0 +1,32 @@
+package storage
+
+import (
+	"time"
+
+	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/logging"
+)
+
+// A LogOnlyStateManager trivially implements StateManager, simply logging the
+// actions requested of it.
+type LogOnlyStateManager struct {
+	log logging.LogSink
+}
+
+// NewLogOnlyStateManager returns a new LogOnlyStateManager
+func NewLogOnlyStateManager(log logging.LogSink) *LogOnlyStateManager {
+	return &LogOnlyStateManager{log: log}
+}
+
+// ReadState implements StateManager on LogOnlyStateManager
+func (losm LogOnlyStateManager) ReadState() (*sous.State, error) {
+	state := sous.NewState()
+	reportReading(losm.log, time.Now(), state, nil)
+	return state, nil
+}
+
+// WriteState implements StateManager on LogOnlyStateManager
+func (losm LogOnlyStateManager) WriteState(state *sous.State, _ sous.User) error {
+	reportWriting(losm.log, time.Now(), state, nil)
+	return nil
+}

--- a/ext/storage/logonlystatemanager_test.go
+++ b/ext/storage/logonlystatemanager_test.go
@@ -1,0 +1,22 @@
+package storage
+
+import (
+	"testing"
+
+	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/logging"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogOnlyStateManager(t *testing.T) {
+	log, ctrl := logging.NewLogSinkSpy()
+	sm := NewLogOnlyStateManager(log)
+
+	_, err := sm.ReadState()
+	assert.NoError(t, err)
+
+	err = sm.WriteState(sous.NewState(), sous.User{})
+	assert.NoError(t, err)
+
+	assert.Len(t, ctrl.Calls(), 2)
+}

--- a/ext/storage/messages.go
+++ b/ext/storage/messages.go
@@ -33,7 +33,10 @@ func reportSQLMessage(log logging.LogSink, started time.Time, sql string, rowcou
 
 // DefaultLevel implements LogMessage on sqlMessage
 func (msg *sqlMessage) DefaultLevel() logging.Level {
-	return logging.InformationLevel
+	if msg.err == nil {
+		return logging.InformationLevel
+	}
+	return logging.WarningLevel
 }
 
 // Message implements LogMessage on sqlMessage
@@ -96,7 +99,10 @@ func newStoreMessage(started time.Time, dir direction, state *sous.State, err er
 }
 
 func (msg *storeMessage) DefaultLevel() logging.Level {
-	return logging.DebugLevel
+	if msg.err == nil {
+		return logging.DebugLevel
+	}
+	return logging.WarningLevel
 }
 
 func (msg *storeMessage) Message() string {

--- a/ext/storage/messages.go
+++ b/ext/storage/messages.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"time"
 
+	sous "github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/logging"
 )
 
@@ -52,5 +53,78 @@ func (msg *sqlMessage) EachField(fn logging.FieldReportFn) {
 	fn("sous-sql-rows", msg.rowcount)
 	if msg.err != nil {
 		fn("sous-sql-errreturned", msg.err.Error())
+	}
+}
+
+type (
+	storeMessage struct {
+		logging.CallerInfo
+		logging.MessageInterval
+		direction direction
+		state     *sous.State
+		err       error
+	}
+
+	direction uint
+)
+
+const (
+	read direction = iota
+	write
+)
+
+func reportReading(log logging.LogSink, started time.Time, state *sous.State, err error) {
+	msg := newStoreMessage(started, read, state, err)
+	msg.CallerInfo.ExcludeMe()
+	logging.Deliver(msg, log)
+}
+
+func reportWriting(log logging.LogSink, started time.Time, state *sous.State, err error) {
+	msg := newStoreMessage(started, write, state, err)
+	msg.CallerInfo.ExcludeMe()
+	logging.Deliver(msg, log)
+}
+
+func newStoreMessage(started time.Time, dir direction, state *sous.State, err error) *storeMessage {
+	return &storeMessage{
+		CallerInfo:      logging.GetCallerInfo(logging.NotHere()),
+		MessageInterval: logging.NewInterval(started, time.Now()),
+		state:           state,
+		direction:       dir,
+		err:             err,
+	}
+}
+
+func (msg *storeMessage) DefaultLevel() logging.Level {
+	return logging.DebugLevel
+}
+
+func (msg *storeMessage) Message() string {
+	return msg.direction.message()
+}
+
+func (dir direction) message() string {
+	switch dir {
+	default:
+		return "Unknown state storage direction (shouldn't ever occur?)"
+	case read:
+		return "Reading state"
+	case write:
+		return "Writing state"
+	}
+}
+
+func (msg *storeMessage) EachField(fn logging.FieldReportFn) {
+	fn("@loglov3-otl", "sous-storage")
+	msg.CallerInfo.EachField(fn)
+	msg.MessageInterval.EachField(fn)
+	if msg.err != nil {
+		fn("sous-storage-error", msg.err.Error())
+	}
+	deps, err := msg.state.Deployments()
+	if err == nil {
+		fn("sous-storage-deployments", deps.Len())
+	} else {
+		fn("sous-storage-deployments", 0)
 	}
 }

--- a/ext/storage/postgresstatemanager.go
+++ b/ext/storage/postgresstatemanager.go
@@ -4,8 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	// it's a SQL db driver. This is how you do that.
-	_ "github.com/lib/pq"
+	"github.com/lib/pq"
 	"github.com/opentable/sous/util/logging"
 )
 
@@ -58,4 +57,12 @@ func (c PostgresConfig) DB() (*sql.DB, error) {
 		return nil, err
 	}
 	return db, nil
+}
+
+func isNoDBError(err error) bool {
+	pqerr, is := err.(*pq.Error)
+	if !is {
+		return false
+	}
+	return pqerr.Code == "3D000" // invalid_catalog_name per https://www.postgresql.org/docs/current/static/errcodes-appendix.html
 }

--- a/ext/storage/postgresstatemanager.go
+++ b/ext/storage/postgresstatemanager.go
@@ -29,12 +29,8 @@ type (
 )
 
 // NewPostgresStateManager creates a new PostgresStateManager.
-func NewPostgresStateManager(cfg PostgresConfig, log logging.LogSink) (*PostgresStateManager, error) {
-	db, err := sql.Open("postgres", cfg.connStr())
-	if err != nil {
-		return nil, err
-	}
-	return &PostgresStateManager{db: db, log: log}, nil
+func NewPostgresStateManager(db *sql.DB, log logging.LogSink) *PostgresStateManager {
+	return &PostgresStateManager{db: db, log: log}
 }
 
 func (c PostgresConfig) connStr() string {
@@ -50,4 +46,9 @@ func (c PostgresConfig) connStr() string {
 		conn = fmt.Sprintf("%s password=%s", conn, c.Password)
 	}
 	return conn
+}
+
+// DB returns a database connection based on this config
+func (c PostgresConfig) DB() (*sql.DB, error) {
+	return sql.Open("postgres", c.connStr())
 }

--- a/ext/storage/postgresstatemanager.go
+++ b/ext/storage/postgresstatemanager.go
@@ -19,12 +19,12 @@ type (
 
 	// A PostgresConfig describes how to connect to a postgres database
 	PostgresConfig struct {
-		DBName   string
-		User     string
-		Password string
-		Host     string
-		Port     string
-		SSL      bool
+		DBName   string `env:"SOUS_PG_DBNAME"`
+		User     string `env:"SOUS_PG_USER"`
+		Password string `env:"SOUS_PG_PASSWORD"`
+		Host     string `env:"SOUS_PG_HOST"`
+		Port     string `env:"SOUS_PG_PORT"`
+		SSL      bool   `env:"SOUS_PG_SSL"`
 	}
 )
 

--- a/ext/storage/postgresstatemanager.go
+++ b/ext/storage/postgresstatemanager.go
@@ -50,5 +50,12 @@ func (c PostgresConfig) connStr() string {
 
 // DB returns a database connection based on this config
 func (c PostgresConfig) DB() (*sql.DB, error) {
-	return sql.Open("postgres", c.connStr())
+	db, err := sql.Open("postgres", c.connStr())
+	if err != nil {
+		return nil, err
+	}
+	if err := db.Ping(); err != nil {
+		return nil, err
+	}
+	return db, nil
 }

--- a/ext/storage/postgresstatemanager_test.go
+++ b/ext/storage/postgresstatemanager_test.go
@@ -44,7 +44,8 @@ func SetupTest(t *testing.T) *PostgresStateManagerSuite {
 		suite.FailNow("Error setting up test database", "Error: %v. Did you already `make postgres-test-prepare`?", err)
 	}
 	// ignoring error because I think "no such DB is a failure"
-	setupDB.Exec("drop database sous_test")
+	_, err = setupDB.Exec("drop database sous_test")
+	t.Logf("Dropping sous_test DB (no such DB is expected): %v", err)
 	if _, err := setupDB.Exec("create database sous_test template sous_test_template"); err != nil {
 		suite.FailNow("Error creating test database", "connstr %q err %v", connstr, err)
 	}
@@ -86,7 +87,7 @@ func TestPostgresStateManagerWriteState_success(t *testing.T) {
 	suite.require.NoError(suite.manager.WriteState(s, testUser))
 	suite.Equal(int64(2), suite.pluckSQL("select count(*) from deployments"))
 
-	assert.Len(t, suite.logs.CallsTo("LogMessage"), 12)
+	assert.Len(t, suite.logs.CallsTo("LogMessage"), 13)
 	message := suite.logs.CallsTo("LogMessage")[0].PassedArgs().Get(1).(logging.LogMessage)
 	logging.AssertMessageFields(t, message, append(
 		append(logging.StandardVariableFields, logging.IntervalVariableFields...), "sous-sql-query", "sous-sql-rows"),

--- a/ext/storage/postgresstatemanager_test.go
+++ b/ext/storage/postgresstatemanager_test.go
@@ -34,45 +34,18 @@ func SetupTest(t *testing.T) *PostgresStateManagerSuite {
 		require:    require.New(t),
 	}
 
-	port := "6543"
-	if np, set := os.LookupEnv("PGPORT"); set {
-		port = np
-	}
-	connstr := fmt.Sprintf("dbname=sous_test_template host=localhost port=%s sslmode=disable", port)
-	setupDB, err := sql.Open("postgres", connstr)
-	if err != nil {
-		suite.FailNow("Error setting up test database", "Error: %v. Did you already `make postgres-test-prepare`?", err)
-	}
-	// ignoring error because I think "no such DB is a failure"
-	_, err = setupDB.Exec("drop database sous_test")
-	t.Logf("Dropping sous_test DB (no such DB is expected): %v", err)
-	if _, err := setupDB.Exec("create database sous_test template sous_test_template"); err != nil {
-		suite.FailNow("Error creating test database", "connstr %q err %v", connstr, err)
-	}
-	if err := setupDB.Close(); err != nil {
-		suite.FailNow("Error closing DB manipulation connection", "connstr %q err %v", connstr, err)
-	}
+	db := setupDB(t)
 
 	sink, ctrl := logging.NewLogSinkSpy()
-
-	db, err := PostgresConfig{
-		DBName:   "sous_test",
-		User:     "",
-		Password: "",
-		Host:     "localhost",
-		Port:     port,
-		SSL:      false,
-	}.DB()
-
-	if err != nil {
-		suite.FailNow("Setting up", "error: %v", err)
-	}
-
 	suite.manager = NewPostgresStateManager(db, sink)
 
 	suite.logs = ctrl
 
-	connstr = fmt.Sprintf("dbname=sous_test host=localhost port=%s sslmode=disable", port)
+	port := "6543"
+	if np, set := os.LookupEnv("PGPORT"); set {
+		port = np
+	}
+	connstr := fmt.Sprintf("dbname=sous_test host=localhost port=%s sslmode=disable", port)
 	if suite.db, err = sql.Open("postgres", connstr); err != nil {
 		suite.FailNow("Error establishing test-assertion DB connection.", "Error: %v", err)
 	}

--- a/ext/storage/postgresstatemanager_test.go
+++ b/ext/storage/postgresstatemanager_test.go
@@ -54,20 +54,22 @@ func SetupTest(t *testing.T) *PostgresStateManagerSuite {
 
 	sink, ctrl := logging.NewLogSinkSpy()
 
-	suite.manager, err = NewPostgresStateManager(PostgresConfig{
+	db, err := PostgresConfig{
 		DBName:   "sous_test",
 		User:     "",
 		Password: "",
 		Host:     "localhost",
 		Port:     port,
 		SSL:      false,
-	}, sink)
-
-	suite.logs = ctrl
+	}.DB()
 
 	if err != nil {
 		suite.FailNow("Setting up", "error: %v", err)
 	}
+
+	suite.manager = NewPostgresStateManager(db, sink)
+
+	suite.logs = ctrl
 
 	connstr = fmt.Sprintf("dbname=sous_test host=localhost port=%s sslmode=disable", port)
 	if suite.db, err = sql.Open("postgres", connstr); err != nil {

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -560,7 +560,7 @@ func newServerStateManager(c LocalSousConfig, log LogSink) *ServerStateManager {
 func newStateManager(cl HTTPClient, c LocalSousConfig, log LogSink) *StateManager {
 	if c.Server == "" {
 		log.Warnf("Using local state stored at %s", c.StateLocation)
-		return &StateManager{StateManager: newServerStateManager(c).StateManager}
+		return &StateManager{StateManager: newServerStateManager(c, log).StateManager}
 	}
 	hsm := sous.NewHTTPStateManager(cl)
 	return &StateManager{StateManager: hsm}

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -538,9 +538,20 @@ func newHTTPClient(c LocalSousConfig, user sous.User, srvr ServerHandler, log Lo
 	return HTTPClient{HTTPClient: cl}, err
 }
 
-func newServerStateManager(c LocalSousConfig) *ServerStateManager {
+func newServerStateManager(c LocalSousConfig, log LogSink) *ServerStateManager {
+	var secondary sous.StateManager
+	db, err := c.Database.DB()
+	if err == nil {
+		secondary = storage.NewPostgresStateManager(db, log)
+	} else {
+		logging.ReportError(log, errors.Wrapf(err, "connecting to database"))
+		secondary = storage.NewLogOnlyStateManager(log)
+	}
+
 	dm := storage.NewDiskStateManager(c.StateLocation)
-	return &ServerStateManager{StateManager: storage.NewGitStateManager(dm)}
+	gm := storage.NewGitStateManager(dm)
+	duplex := storage.NewDuplexStateManager(gm, secondary, log.LogSink)
+	return &ServerStateManager{StateManager: duplex}
 }
 
 // newStateManager returns a wrapped sous.HTTPStateManager if cl is not nil.

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -139,11 +139,11 @@ func TestStateManagerSelectsServer(t *testing.T) {
 	}
 }
 
-func TestStateManagerSelectsGit(t *testing.T) {
+func TestStateManagerSelectsDuplex(t *testing.T) {
 	smgr := injectedStateManager(t, &config.Config{Server: "", StateLocation: "/tmp/sous"})
 
-	if _, ok := smgr.StateManager.(*storage.GitStateManager); !ok {
-		t.Errorf("Injected %#v which isn't a GitStateManager", smgr.StateManager)
+	if _, ok := smgr.StateManager.(*storage.DuplexStateManager); !ok {
+		t.Errorf("Injected %#v which isn't a DuplexStateManager", smgr.StateManager)
 	}
 }
 

--- a/lib/status_poller_test.go
+++ b/lib/status_poller_test.go
@@ -802,7 +802,7 @@ func TestStatusPoller_NotIntended(t *testing.T) {
 		testCh <- rState
 	}()
 
-	timeout := 100 * time.Millisecond
+	timeout := PollTimeout
 	select {
 	case <-time.After(timeout):
 		t.Errorf("Empty subpoller polling took more than %s", timeout)
@@ -853,7 +853,7 @@ func TestStatusPoller_OldServer(t *testing.T) {
 		testCh <- rState
 	}()
 
-	timeout := 100 * time.Millisecond
+	timeout := PollTimeout
 	select {
 	case <-time.After(timeout):
 		t.Errorf("Sad path polling took more than %s", timeout)

--- a/util/configloader/configloader.go
+++ b/util/configloader/configloader.go
@@ -189,6 +189,13 @@ func (cl *configLoader) overrideField(sf reflect.StructField, originalVal reflec
 	switch originalVal.Interface().(type) {
 	default:
 		return fmt.Errorf("unable to override fields of type %T", originalVal.Interface())
+	case bool:
+		bval, err := strconv.ParseBool(envVal)
+		if err == nil {
+			finalVal = reflect.ValueOf(bval)
+		} else {
+			finalVal = originalVal
+		}
 	case string:
 		finalVal = reflect.ValueOf(envVal)
 	case int:

--- a/util/logging/errors.go
+++ b/util/logging/errors.go
@@ -1,5 +1,7 @@
 package logging
 
+import "fmt"
+
 type errorMessage struct {
 	CallerInfo
 	err error
@@ -16,7 +18,7 @@ func ReportError(sink LogSink, err error) {
 
 func newErrorMessage(err error) *errorMessage {
 	return &errorMessage{
-		CallerInfo: NewCallerInfo(NotHere()),
+		CallerInfo: GetCallerInfo(NotHere()),
 		err:        err,
 	}
 }

--- a/util/logging/errors.go
+++ b/util/logging/errors.go
@@ -1,0 +1,37 @@
+package logging
+
+type errorMessage struct {
+	CallerInfo
+	err error
+}
+
+// ReportError is used to report an error via structured logging.
+// If you need more information than "an error occurred", consider using a
+// different structured message.
+func ReportError(sink LogSink, err error) {
+	msg := newErrorMessage(err)
+	msg.CallerInfo.ExcludeMe()
+	Deliver(msg, sink)
+}
+
+func newErrorMessage(err error) *errorMessage {
+	return &errorMessage{
+		CallerInfo: NewCallerInfo(NotHere()),
+		err:        err,
+	}
+}
+
+func (msg *errorMessage) DefaultLevel() Level {
+	return WarningLevel
+}
+
+func (msg *errorMessage) Message() string {
+	return msg.err.Error()
+}
+
+func (msg *errorMessage) EachField(fn FieldReportFn) {
+	fn("@loglov3-otl", "sous-error-v1")
+	msg.CallerInfo.EachField(fn)
+	fn("sous-error-msg", msg.err.Error())
+	fn("sous-error-backtrace", fmt.Sprintf("%+v", msg.err))
+}

--- a/util/logging/errors_test.go
+++ b/util/logging/errors_test.go
@@ -1,0 +1,16 @@
+package logging
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestErrorMessage(t *testing.T) {
+	msg := newErrorMessage(fmt.Errorf("just an error"))
+	AssertMessageFields(t, msg, StandardVariableFields, map[string]interface{}{
+		//pkg/errors errors will yield a backtrace here
+		"sous-error-backtrace": "just an error",
+		"@loglov3-otl":         "sous-error-v1",
+		"sous-error-msg":       "just an error",
+	})
+}


### PR DESCRIPTION
The goal here is to keep the two states in sync until we're ready to switch over.

Note that if there's a problem connecting to the DB,
or saving state to it, there's only a log entry -
the designed intent here is that the secondary store
not influence the operation of Sous.