### PR TITLE
Fix r11n queue race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ with respect to its command line interface and HTTP interface.
 ### Added
 * CLI: If no image is present in runspec, return a fatal flaw in build.
 
+### Fixed
+* All: Data race in rectification queue.
+
 ## [0.5.62](//github.com/opentable/sous/compare/0.5.61...0.5.62)
 
 ### Added


### PR DESCRIPTION
As per title, this fixes a data race picked up by the race detector (between `.init` and `.Start`) and addresses an issue where we would occasionally deadlock due to interaction between `next` and `pop` methods. The `pop` method was not in use and has been removed.