### PR TITLE
Danger: ignore insignificant changes

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -2,6 +2,22 @@
 # including in a project's CHANGELOG for example
 modified_app_files = git.modified_files.grep(/(?<!_test)\.go$/)
 app_changed = !modified_app_files.empty?
+
+p modified_app_files.length
+modified_app_files = modified_app_files.find_all do |file|
+  diff = git.diff_for_file(file)
+  significant_lines = diff.patch.lines[5..-1].grep_v(%r{^(?: |[+-]\s*(?://|$)|@@)})
+
+  if !significant_lines.empty?
+    puts diff.patch
+    p significant_lines
+  end
+
+  !significant_lines.empty?
+end
+p modified_app_files.length
+
+
 declared_trivial = github.pr_title.include? "#trivial" || !app_changed
 
 # Make it more obvious that a PR is a work in progress and shouldn't be merged yet


### PR DESCRIPTION
If a change to a code file only adds or removes:
* a comment
* a blank line

then ignore that file for purposes of PR review.