### PR TITLE
Corrects itermittant failure in TestResolveRecorder #trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ with respect to its command line interface and HTTP interface.
 
 ### Changed
 * All: error parsing repo from SourceLocation now more informative.
-* Server: small change to private interface of ResolveRecorder
 
 ### Fixed
 * All: Data race in rectification queue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ with respect to its command line interface and HTTP interface.
 
 ### Changed
 * All: error parsing repo from SourceLocation now more informative.
+* Server: small change to private interface of ResolveRecorder
 
 ### Fixed
 * All: Data race in rectification queue.

--- a/ext/singularity/actual_deployment_set.go
+++ b/ext/singularity/actual_deployment_set.go
@@ -110,7 +110,7 @@ func (sc *deployer) RunningDeployments(reg sous.Registry, clusters sous.Clusters
 				sc.log.Debugf("Errors channel closed. Finishing up.")
 				return deps, nil
 			}
-			if isMalformed(sc.log, err) || ignorableDeploy(err) {
+			if isMalformed(sc.log, err) || ignorableDeploy(sc.log, err) {
 				sc.log.Debugf("\n", err)
 				depWait.Done()
 			} else {
@@ -184,7 +184,6 @@ func (sc *deployer) singPipeline(
 	dw, wg *sync.WaitGroup,
 	reqs chan SingReq,
 	errs chan error,
-	//	clusters []string,
 	clusters sous.Clusters,
 ) {
 	sc.log.Vomitf("Starting cluster at %s", url)

--- a/ext/singularity/actual_deployment_set.go
+++ b/ext/singularity/actual_deployment_set.go
@@ -2,8 +2,6 @@ package singularity
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -11,6 +9,7 @@ import (
 	"github.com/opentable/go-singularity"
 	"github.com/opentable/go-singularity/dtos"
 	"github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/logging"
 	"github.com/pkg/errors"
 )
 
@@ -39,14 +38,20 @@ type (
 		ReqParent *dtos.SingularityRequestParent
 	}
 
-	retryCounter map[string]uint
+	retryCounter struct {
+		count map[string]uint
+		log   logging.LogSink
+	}
 )
 
 // RunningDeployments collects data from the Singularity clusters and
 // returns a list of actual deployments.
 func (sc *deployer) RunningDeployments(reg sous.Registry, clusters sous.Clusters) (sous.DeployStates, error) {
 	var deps sous.DeployStates
-	retries := make(retryCounter)
+	retries := retryCounter{
+		count: map[string]uint{},
+		log:   sc.log,
+	}
 	errCh := make(chan error)
 	deps = sous.NewDeployStates()
 	sings := make(map[string]struct{})
@@ -60,7 +65,7 @@ func (sc *deployer) RunningDeployments(reg sous.Registry, clusters sous.Clusters
 
 	var depAssWait, singWait, depWait sync.WaitGroup
 
-	Log.Vomit.Printf("Setting up to wait for %d clusters", len(clusters))
+	sc.log.Vomitf("Setting up to wait for %d clusters", len(clusters))
 	singWait.Add(len(clusters))
 	for _, url := range clusters {
 		url := url.BaseURL
@@ -71,47 +76,47 @@ func (sc *deployer) RunningDeployments(reg sous.Registry, clusters sous.Clusters
 		//sing.Debug = true
 		sings[url] = struct{}{}
 		client := sc.buildSingClient(url)
-		go singPipeline(reg, url, client, &depWait, &singWait, reqCh, errCh, clusters)
+		go sc.singPipeline(reg, url, client, &depWait, &singWait, reqCh, errCh, clusters)
 	}
 
-	go depPipeline(reg, clusters, MaxAssemblers, &depAssWait, reqCh, depCh, errCh)
+	go sc.depPipeline(reg, clusters, MaxAssemblers, &depAssWait, reqCh, depCh, errCh)
 
 	go func() {
-		defer catchAndSend("closing channels", errCh)
+		defer catchAndSend("closing channels", errCh, sc.log)
 
 		singWait.Wait()
-		Log.Debug.Println("All singularities polled for requests")
+		sc.log.Debugf("All singularities polled for requests")
 
 		depWait.Wait()
-		Log.Debug.Println("All deploys processed")
+		sc.log.Debugf("All deploys processed")
 
 		depAssWait.Wait()
-		Log.Debug.Println("All deployments assembled")
+		sc.log.Debugf("All deployments assembled")
 
 		close(reqCh)
-		Log.Debug.Println("Closed reqCh")
+		sc.log.Debugf("Closed reqCh")
 		close(errCh)
-		Log.Debug.Println("Closed errCh")
+		sc.log.Debugf("Closed errCh")
 	}()
 
 	for {
 		select {
 		case dep := <-depCh:
 			deps.Add(dep)
-			Log.Debug.Printf("Deployment #%d: %+v", deps.Len(), dep)
+			sc.log.Debugf("Deployment #%d: %+v", deps.Len(), dep)
 			depWait.Done()
 		case err, cont := <-errCh:
 			if !cont {
-				Log.Debug.Printf("Errors channel closed. Finishing up.")
+				sc.log.Debugf("Errors channel closed. Finishing up.")
 				return deps, nil
 			}
-			if isMalformed(err) || ignorableDeploy(err) {
-				Log.Debug.Print(err)
+			if isMalformed(sc.log, err) || ignorableDeploy(err) {
+				sc.log.Debugf("\n", err)
 				depWait.Done()
 			} else {
 				retryable := retries.maybe(err, reqCh)
 				if !retryable {
-					Log.Notice.Printf("Cannot retry: %v. Exiting", err)
+					sc.log.Warnf("Cannot retry: %v. Exiting", err)
 					return deps, err
 				}
 			}
@@ -127,8 +132,8 @@ func (rc retryCounter) maybe(err error, reqCh chan SingReq) bool {
 		return false
 	}
 
-	Log.Debug.Printf("%T err = %+v\n", errors.Cause(err), errors.Cause(err))
-	count, ok := rc[rt.name()]
+	rc.log.Debugf("%T err = %+v\n", errors.Cause(err), errors.Cause(err))
+	count, ok := rc.count[rt.name()]
 	if !ok {
 		count = 0
 	}
@@ -136,9 +141,9 @@ func (rc retryCounter) maybe(err error, reqCh chan SingReq) bool {
 		return false
 	}
 
-	rc[rt.name()] = count + 1
+	rc.count[rt.name()] = count + 1
 	go func() {
-		defer catchAll("retrying: " + rt.req.SourceURL)
+		defer catchAll("retrying: "+rt.req.SourceURL, rc.log)
 		time.Sleep(time.Millisecond * 50)
 		reqCh <- rt.req
 	}()
@@ -146,9 +151,9 @@ func (rc retryCounter) maybe(err error, reqCh chan SingReq) bool {
 	return true
 }
 
-func catchAll(from string) {
+func catchAll(from string, log logging.LogSink) {
 	if err := recover(); err != nil {
-		Log.Warn.Printf("Recovering from %s where we received %v", from, err)
+		log.Warnf("Recovering from %s where we received %v", from, err)
 	}
 }
 
@@ -156,11 +161,11 @@ func dontrecover() error {
 	return nil
 }
 
-func catchAndSend(from string, errs chan error) {
-	defer catchAll(from)
+func catchAndSend(from string, errs chan error, log logging.LogSink) {
+	defer catchAll(from, log)
 	if err := recover(); err != nil {
-		Log.Debug.Printf("from = %s err = %+v\n", from, err)
-		Log.Debug.Printf("debug.Stack() = %+v\n", string(debug.Stack()))
+		log.Debugf("from = %s err = %+v\n", from, err)
+		log.Debugf("debug.Stack() = %+v\n", string(debug.Stack()))
 		switch err := err.(type) {
 		default:
 			if err != nil {
@@ -172,29 +177,7 @@ func catchAndSend(from string, errs chan error) {
 	}
 }
 
-func logFDs(when string) {
-	defer func() { recover() }() // this is just diagnostic
-	pid := os.Getpid()
-	fdDir, err := ioutil.ReadDir(fmt.Sprintf("/proc/%d/fd", pid))
-	if err != nil {
-		Log.Vomit.Print(err)
-		return
-	}
-	/*
-		for _, f := range fdDir {
-			n, e := os.Readlink(fmt.Sprintf("/proc/%d/fd/%s", pid, f.Name()))
-			if e != nil {
-				n = f.Name()
-			}
-
-			Log.Vomit.Printf("%s: %s", f.Mode(), n)
-		}
-	*/
-
-	Log.Debug.Printf("%s: %d", when, len(fdDir))
-}
-
-func singPipeline(
+func (sc *deployer) singPipeline(
 	reg sous.Registry,
 	url string,
 	client *singularity.Client,
@@ -204,13 +187,13 @@ func singPipeline(
 	//	clusters []string,
 	clusters sous.Clusters,
 ) {
-	Log.Vomit.Printf("Starting cluster at %s", url)
-	defer func() { Log.Vomit.Printf("Completed cluster at %s", url) }()
+	sc.log.Vomitf("Starting cluster at %s", url)
+	defer func() { sc.log.Vomitf("Completed cluster at %s", url) }()
 	defer wg.Done()
-	defer catchAndSend(fmt.Sprintf("get requests: %s", url), errs)
-	srp, err := getSingularityRequestParents(client)
+	defer catchAndSend(fmt.Sprintf("get requests: %s", url), errs, sc.log)
+	srp, err := sc.getSingularityRequestParents(client)
 	if err != nil {
-		Log.Vomit.Print(err) //XXX connection reset by peer should be retried
+		sc.log.Vomitf("%v", err) //XXX connection reset by peer should be retried
 		errs <- errors.Wrap(err, "getting request list")
 		return
 	}
@@ -218,15 +201,13 @@ func singPipeline(
 	rs := convertSingularityRequestParentsToSingReqs(url, client, srp)
 
 	for _, r := range rs {
-		Log.Vomit.Printf("Req: %s %s %d", r.SourceURL, reqID(r.ReqParent), r.ReqParent.Request.Instances)
+		sc.log.Vomitf("Req: %s %s %d", r.SourceURL, reqID(r.ReqParent), r.ReqParent.Request.Instances)
 		dw.Add(1)
 		reqs <- r
 	}
 }
 
-func getSingularityRequestParents(client *singularity.Client) ([]*dtos.SingularityRequestParent, error) {
-	logFDs("before getRequestsFromSingularity")
-	defer logFDs("after getRequestsFromSingularity")
+func (sc *deployer) getSingularityRequestParents(client *singularity.Client) ([]*dtos.SingularityRequestParent, error) {
 	singRequests, err := client.GetRequests(false) // = don't use the 30 second cache
 
 	return singRequests, errors.Wrap(err, "getting request")
@@ -241,7 +222,7 @@ func convertSingularityRequestParentsToSingReqs(url string, client *singularity.
 	return reqs
 }
 
-func depPipeline(
+func (sc *deployer) depPipeline(
 	reg sous.Registry,
 	clusters sous.Clusters,
 	poolCount int,
@@ -250,21 +231,21 @@ func depPipeline(
 	depCh chan *sous.DeployState,
 	errCh chan error,
 ) {
-	defer catchAndSend("dependency building", errCh)
+	defer catchAndSend("dependency building", errCh, sc.log)
 	poolLimit := make(chan struct{}, poolCount)
 	for req := range reqCh {
 		depAssWait.Add(1)
-		Log.Vomit.Printf("starting assembling for %q", reqID(req.ReqParent))
+		sc.log.Vomitf("starting assembling for %q", reqID(req.ReqParent))
 		go func(req SingReq) {
 			defer depAssWait.Done()
-			defer catchAndSend(fmt.Sprintf("dep from req %s", req.SourceURL), errCh)
+			defer catchAndSend(fmt.Sprintf("dep from req %s", req.SourceURL), errCh, sc.log)
 			poolLimit <- struct{}{}
 			defer func() {
-				Log.Vomit.Printf("finished assembling for %q", reqID(req.ReqParent))
+				sc.log.Vomitf("finished assembling for %q", reqID(req.ReqParent))
 				<-poolLimit
 			}()
 
-			dep, err := assembleDeployState(reg, clusters, req)
+			dep, err := sc.assembleDeployState(reg, clusters, req)
 
 			if err != nil {
 				errCh <- errors.Wrap(err, "assembly problem")
@@ -275,9 +256,9 @@ func depPipeline(
 	}
 }
 
-func assembleDeployState(reg sous.Registry, clusters sous.Clusters, req SingReq) (*sous.DeployState, error) {
-	Log.Vomit.Printf("Assembling from: %s %s", req.SourceURL, reqID(req.ReqParent))
-	tgt, err := BuildDeployment(reg, clusters, req)
-	Log.Vomit.Printf("Collected deployment: %#v", tgt)
+func (sc *deployer) assembleDeployState(reg sous.Registry, clusters sous.Clusters, req SingReq) (*sous.DeployState, error) {
+	sc.log.Vomitf("Assembling from: %s %s", req.SourceURL, reqID(req.ReqParent))
+	tgt, err := BuildDeployment(reg, clusters, req, sc.log)
+	sc.log.Vomitf("Collected deployment: %#v", tgt)
 	return &tgt, errors.Wrap(err, "Building deployment")
 }

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -202,7 +202,7 @@ func (r *deployer) RectifySingleDelete(d *sous.DeployablePair) (err error) {
 
 	// TODO: Alert the owner of this request that there is no manifest for it;
 	// they should either delete the request manually, or else add the manifest back.
-	r.log.Warn.Printf("NOT DELETING REQUEST %q (FOR: %q)", requestID, d.ID())
+	r.log.Warnf("NOT DELETING REQUEST %q (FOR: %q)", requestID, d.ID())
 	return nil
 	// The following line deletes requests when it is not commented out.
 	//return r.Client.DeleteRequest(d.Cluster.BaseURL, requestID, "deleting request for removed manifest")

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -202,7 +202,7 @@ func (r *deployer) RectifySingleDelete(d *sous.DeployablePair) (err error) {
 
 	// TODO: Alert the owner of this request that there is no manifest for it;
 	// they should either delete the request manually, or else add the manifest back.
-	logging.Log.Warn.Printf("NOT DELETING REQUEST %q (FOR: %q)", requestID, d.ID())
+	r.log.Warn.Printf("NOT DELETING REQUEST %q (FOR: %q)", requestID, d.ID())
 	return nil
 	// The following line deletes requests when it is not commented out.
 	//return r.Client.DeleteRequest(d.Cluster.BaseURL, requestID, "deleting request for removed manifest")
@@ -212,43 +212,43 @@ func (r *deployer) RectifySingleModification(pair *sous.DeployablePair) (err err
 	different, diffs := pair.Post.Deployment.Diff(pair.Prior.Deployment)
 	if !different {
 		reportDeployerMessage("Attempting to rectify empty diff",
-			pair, &diffs, nil, nil, logging.WarningLevel, logging.Log)
+			pair, &diffs, nil, nil, logging.WarningLevel, r.log)
 	}
 
-	reportDeployerMessage("Rectifying modified diffs", pair, &diffs, nil, nil, logging.InformationLevel, logging.Log)
+	reportDeployerMessage("Rectifying modified diffs", pair, &diffs, nil, nil, logging.InformationLevel, r.log)
 
 	defer rectifyRecover(pair, "RectifySingleModification", &err)
 
 	data, ok := pair.ExecutorData.(*singularityTaskData)
 	if !ok {
 		err := errors.Errorf("Modification record %#v doesn't contain Singularity compatible data: was %T\n\t%#v", pair.ID(), data, pair)
-		reportDeployerMessage("Error modification not compatible with Singularity", pair, &diffs, nil, err, logging.WarningLevel, logging.Log)
+		reportDeployerMessage("Error modification not compatible with Singularity", pair, &diffs, nil, err, logging.WarningLevel, r.log)
 		return err
 	}
 	reqID := data.requestID
 
 	//changesApplied := false
-	reportDeployerMessage("Operating on request", pair, &diffs, data, nil, logging.ExtraDebug1Level, logging.Log)
+	reportDeployerMessage("Operating on request", pair, &diffs, data, nil, logging.ExtraDebug1Level, r.log)
 	if changesReq(pair) {
-		reportDeployerMessage("Updating request", pair, &diffs, data, nil, logging.DebugLevel, logging.Log)
+		reportDeployerMessage("Updating request", pair, &diffs, data, nil, logging.DebugLevel, r.log)
 		if err := r.Client.PostRequest(*pair.Post, reqID); err != nil {
-			reportDeployerMessage("Error posting request to Singularity", pair, &diffs, data, err, logging.WarningLevel, logging.Log)
+			reportDeployerMessage("Error posting request to Singularity", pair, &diffs, data, err, logging.WarningLevel, r.log)
 			return err
 		}
 		//changesApplied = true
 	} else {
-		reportDeployerMessage("No change to Singularity request required", pair, &diffs, data, nil, logging.DebugLevel, logging.Log)
+		reportDeployerMessage("No change to Singularity request required", pair, &diffs, data, nil, logging.DebugLevel, r.log)
 	}
 
 	if changesDep(pair) {
-		reportDeployerMessage("Deploying", pair, &diffs, data, nil, logging.DebugLevel, logging.Log)
+		reportDeployerMessage("Deploying", pair, &diffs, data, nil, logging.DebugLevel, r.log)
 		if err := r.Client.Deploy(*pair.Post, reqID); err != nil {
-			reportDeployerMessage(err.Error(), pair, &diffs, data, nil, logging.WarningLevel, logging.Log)
+			reportDeployerMessage(err.Error(), pair, &diffs, data, nil, logging.WarningLevel, r.log)
 			return err
 		}
 		//changesApplied = true
 	} else {
-		reportDeployerMessage("No change to Singularity deployment required", pair, &diffs, data, nil, logging.DebugLevel, logging.Log)
+		reportDeployerMessage("No change to Singularity deployment required", pair, &diffs, data, nil, logging.DebugLevel, r.log)
 	}
 
 	return nil

--- a/ext/singularity/deployer_test.go
+++ b/ext/singularity/deployer_test.go
@@ -286,9 +286,12 @@ func matchedPair(t *testing.T, startDep *sous.Deployment) *sous.DeployablePair {
 	depReq := &dtos.SingularityDeployRequest{}
 	jsonRoundtrip(t, aDepReq, depReq)
 
+	log, _ := logging.NewLogSinkSpy()
+
 	db := &deploymentBuilder{
 		request: sRequest(req),
 		deploy:  depReq.Deploy,
+		log:     log,
 	}
 
 	assert.NoError(t, db.extractArtifactName(), "Could not extract ArtifactName (Docker image name) from SingularityDeploy.")

--- a/ext/singularity/deployment_builder.go
+++ b/ext/singularity/deployment_builder.go
@@ -55,9 +55,11 @@ func (nsd nonSousError) Error() string {
 	return "Not a Sous SingularityDeploy."
 }
 
-func ignorableDeploy(err error) bool {
+func ignorableDeploy(log logging.LogSink, err error) bool {
+	log.Vomitf("checking to see if %+v is ignorable", err)
 	switch errors.Cause(err).(type) {
 	case nonSousError, notThisClusterError:
+		log.Vomitf("ignorable: %v", err)
 		return true
 	}
 	return false
@@ -99,7 +101,7 @@ func (db *deploymentBuilder) canRetry(err error) error {
 
 func (db *deploymentBuilder) isRetryable(err error) bool {
 	return !isMalformed(db.log, err) &&
-		!ignorableDeploy(err) &&
+		!ignorableDeploy(db.log, err) &&
 		db.req.SourceURL != "" &&
 
 		db.req.ReqParent != nil &&
@@ -264,6 +266,7 @@ func (db *deploymentBuilder) sousDeployCheck() error {
 	if cnl, ok := db.deploy.Metadata[sous.ClusterNameLabel]; ok {
 		for _, cn := range db.clusters.Names() {
 			if cnl == cn {
+				db.log.Vomitf("Deploy cluster %q found in clusters (%#v)", cnl, db.clusters)
 				return nil
 			}
 		}

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -490,7 +490,7 @@ func newDeployer(dryrun DryrunOption, nc lazyNameCache, ls LogSink, c LocalSousC
 		drc.SetLogger(ls.Child("rectify"))
 		return singularity.NewDeployer(
 			drc,
-			ls,
+			ls.Child("deployer"),
 			singularity.OptMaxHTTPReqsPerServer(c.MaxHTTPConcurrencySingularity),
 		), nil
 	}

--- a/integration/deployment_builder_test.go
+++ b/integration/deployment_builder_test.go
@@ -34,7 +34,9 @@ func TestBuildDeployments(t *testing.T) {
 	ResetSingularity()
 	defer ResetSingularity()
 
-	drc := docker_registry.NewClient(logging.SilentLogSet())
+	log, _ := logging.NewLogSinkSpy()
+
+	drc := docker_registry.NewClient(log)
 	drc.BecomeFoolishlyTrusting()
 
 	db, err := docker.GetDatabase(&docker.DBConfig{
@@ -49,7 +51,7 @@ func TestBuildDeployments(t *testing.T) {
 	clusterNick := "tcluster"
 	reqID := appLocation + clusterNick
 
-	nc, err := docker.NewNameCache("", drc, logging.SilentLogSet(), db)
+	nc, err := docker.NewNameCache("", drc, log, db)
 	assert.NoError(err)
 
 	singCl := sing.NewClient(SingularityURL)
@@ -96,7 +98,7 @@ func TestBuildDeployments(t *testing.T) {
 
 	if assert.NoError(err) {
 		clusters := sous.Clusters{clusterNick: {BaseURL: SingularityURL}}
-		dep, err := singularity.BuildDeployment(nc, clusters, req)
+		dep, err := singularity.BuildDeployment(nc, clusters, req, log)
 
 		if assert.NoError(err) {
 			if assert.Len(dep.DeployConfig.Volumes, 1) {

--- a/integration/docker_helpers.go
+++ b/integration/docker_helpers.go
@@ -130,7 +130,25 @@ func WaitForSingularity() {
 		}
 	*/
 
-	var pendingCount int
+	pendingCount := -1
+	for {
+		reqs, err := singClient.GetPendingRequests()
+		if err != nil {
+			panic(err)
+		}
+
+		if len(reqs) == 0 {
+			break
+		}
+
+		if len(reqs) != pendingCount {
+			log.Printf("There are %d pending requests still...", len(reqs))
+			pendingCount = len(reqs)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	pendingCount = -1
 	for {
 		deps, err := singClient.GetPendingDeploys()
 		if err != nil {
@@ -138,6 +156,7 @@ func WaitForSingularity() {
 		}
 
 		if len(deps) == 0 {
+			log.Println("No pending requests or deploys at Singularity")
 			return
 		}
 
@@ -146,7 +165,7 @@ func WaitForSingularity() {
 			log.Printf("There are %d pending deploys still...", len(deps))
 			pendingCount = len(deps)
 		}
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 	}
 }
 

--- a/integration/docker_helpers.go
+++ b/integration/docker_helpers.go
@@ -118,6 +118,9 @@ func ResetSingularity() {
 	panic(fmt.Errorf("singularity not reset after %d * %d tries - %d requests remain", retryLimit, pollLimit, len(reqList)))
 }
 
+// WaitForSingularity polls the test S9y server for pending requests and then pending deploys.
+// The idea is that, having issued requests and deploys to S9y, you can call WaitForSingularity
+// and when it returns you know that the server is in a stable state.
 func WaitForSingularity() {
 	log.Print("Waiting for Singularity to stabilize")
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -41,6 +41,7 @@ func (suite *integrationSuite) deploymentWithRepo(clusterNames []string, repo st
 	for _, name := range clusterNames {
 		clusters[name] = &sous.Cluster{BaseURL: SingularityURL}
 	}
+	suite.T().Logf("Calling RunningDeployments for clusters %#v", clusters)
 	deps, err := suite.deployer.RunningDeployments(suite.nameCache, clusters)
 	if suite.NoError(err) {
 		return deps, suite.findRepo(deps, repo)

--- a/lib/resolvestatus.go
+++ b/lib/resolvestatus.go
@@ -178,10 +178,6 @@ func (rr *ResolveRecorder) performPhase(name string, f func() error) {
 	}
 }
 
-func (rr *ResolveRecorder) performGuaranteedPhase(name string, f func()) {
-	rr.performPhase(name, func() error { f(); return nil })
-}
-
 // setPhase sets the phase of this resolve status.
 func (rr *ResolveRecorder) setPhase(phase string) {
 	rr.write(func() {

--- a/lib/resolvestatus_test.go
+++ b/lib/resolvestatus_test.go
@@ -2,7 +2,6 @@ package sous
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 )
 
@@ -197,99 +196,4 @@ func TestResolveRecorder(t *testing.T) {
 			}
 		}
 	})
-
-	for testNum, test := range resolveStatusTests {
-
-		// block is used to block the func passed to NewResolveRecorder from
-		// completing so we can run assertions that need to happen prior to
-		// completion.
-		block := make(chan struct{})
-
-		// Run all the phases in the test in order.
-		rs := NewResolveRecorder(NewDeployments(), func(rs *ResolveRecorder) {
-			performGuaranteedPhase := func(name string, f func()) {
-				rs.performPhase(name, func() error {
-					f()
-					return nil
-				})
-			}
-			for phaseNum, phase := range test.Phases {
-				// Note 1: 1-indexed phase naming.
-				phaseName := fmt.Sprintf("test %d; phase %d", testNum+1, phaseNum+1)
-				if p, ok := phase.(func()); ok {
-					performGuaranteedPhase(phaseName, p)
-				} else if p, ok := phase.(func() error); ok {
-					rs.performPhase(phaseName, p)
-				} else {
-					t.Fatalf("phase must be either func() or func() error")
-				}
-			}
-
-			for _, rez := range test.Resolutions {
-				rs.Log <- rez
-			}
-
-			// It is the responsibility of f to close the log when done.
-			close(rs.Log)
-
-			<-block // Wait for signal from the test that this func may finish.
-		})
-
-		if rs.Done() {
-			t.Fatalf("Done() == true before func finished")
-		}
-
-		earlyStatus := rs.CurrentStatus()
-
-		close(block) // Unblock the function.
-
-		actualErr := rs.Wait()
-
-		if !rs.Done() {
-			t.Fatalf("Done() == false after Wait() call")
-		}
-
-		lateStatus := rs.CurrentStatus()
-
-		// Assert error is correct.
-		{
-			expected := test.Error
-			if expected == "" && actualErr != nil {
-				t.Errorf("got error %q; want nil", actualErr)
-			} else if expected != "" && actualErr == nil {
-				t.Errorf("got nil; want error %q", expected)
-			} else if actualErr != nil {
-				if actual := actualErr.Error(); actual != expected {
-					t.Errorf("got error %q; want %q", actual, expected)
-				}
-			}
-		}
-
-		// Assert final phase has correct suffix, see "Note 1" above.
-		{
-			expected := test.FinalPhase
-			actual := rs.Phase()
-			if !strings.HasSuffix(actual, expected) {
-				t.Errorf("final phase == %q; want suffix %q", actual, expected)
-			}
-		}
-
-		{
-			expected := test.Resolutions
-			actual := lateStatus.Log
-			if len(actual) != len(expected) {
-				t.Errorf("final log of resolutions has wrong number of entries %d vs %d", len(expected), len(actual))
-			}
-		}
-
-		{
-			if len(earlyStatus.Log) > 0 {
-				earlyStatus.Log[0].Desc = "changed"
-				// ugh, this is kind of suspect...
-				if lateStatus.Log[0].Desc != test.Resolutions[0].Desc {
-					t.Errorf("early  and late statuses share a log!")
-				}
-			}
-		}
-	}
 }

--- a/lib/resolvestatus_test.go
+++ b/lib/resolvestatus_test.go
@@ -5,61 +5,6 @@ import (
 	"testing"
 )
 
-var resolveStatusTests = []struct {
-	// Phases are named "test %d; phase %d" which are 1-indexed test number, and
-	// the 1-indexed phase number. See "Note 1" below.
-	Phases      []interface{}
-	Resolutions []DiffResolution
-
-	Error, FinalPhase string
-}{
-	{
-		// Test 1: no phases.
-		FinalPhase: "finished",
-	},
-	{
-		// Test 2: two phases.
-		Phases: []interface{}{
-			func() error {
-				return nil
-			},
-			func() {},
-		},
-		FinalPhase: "finished",
-	},
-	{
-		// Test 3: two phases, first fails.
-		Phases: []interface{}{
-			func() error {
-				return fmt.Errorf("an error")
-			},
-			func() {},
-		},
-		Error:      "an error",
-		FinalPhase: "phase 1",
-	},
-	{
-		// Test 4: six phases, fourth one fails.
-		Phases: []interface{}{
-			func() {},
-			func() {},
-			func() {},
-			func() error {
-				return fmt.Errorf("first error")
-			},
-			func() error {
-				return fmt.Errorf("an error")
-			},
-			func() {
-				panic("this will not be run due to the error above")
-			},
-		},
-		Resolutions: []DiffResolution{DiffResolution{Desc: "1"}},
-		Error:       "first error",
-		FinalPhase:  "phase 4",
-	},
-}
-
 type rrResult struct {
 	err         error
 	early, late ResolveStatus

--- a/lib/resolvestatus_test.go
+++ b/lib/resolvestatus_test.go
@@ -61,7 +61,142 @@ var resolveStatusTests = []struct {
 	},
 }
 
+type rrResult struct {
+	err         error
+	early, late ResolveStatus
+	finalPhase  string
+}
+
+func exerciseResolveRecorder(t *testing.T, f func(*ResolveRecorder)) rrResult {
+	rez := rrResult{}
+	block := make(chan struct{})
+
+	// Run all the phases in the test in order.
+	rs := NewResolveRecorder(NewDeployments(), func(rs *ResolveRecorder) {
+		f(rs)
+		close(rs.Log)
+		<-block // Wait for signal from the test that this func may finish.
+	})
+
+	if rs.Done() {
+		t.Fatalf("Done() == true before func finished")
+	}
+
+	rez.early = rs.CurrentStatus()
+
+	close(block) // Unblock the function.
+
+	rez.err = rs.Wait()
+
+	if !rs.Done() {
+		t.Fatalf("Done() == false after Wait() call")
+	}
+
+	rez.late = rs.CurrentStatus()
+	rez.finalPhase = rs.Phase()
+
+	if len(rez.early.Log) > 0 && len(rez.late.Log) > 0 {
+		if &(rez.early.Log[0]) == &(rez.late.Log[0]) {
+			t.Fatalf("Early and late resolution status share a log!")
+		}
+	}
+
+	return rez
+}
+
+func (r rrResult) assertNoError(t *testing.T) {
+	t.Helper()
+	if r.err != nil {
+		t.Errorf("expected no error; got error %q", r.err)
+	}
+}
+
+func (r rrResult) assertError(t *testing.T, expected string) {
+	t.Helper()
+	if r.err == nil {
+		t.Errorf("expected %q; got no error", expected)
+		return
+	}
+
+	if expected != r.err.Error() {
+		t.Errorf("expected %q; got %q", expected, r.err)
+	}
+}
+
+func (r rrResult) assertFinalPhase(t *testing.T, expected string) {
+	t.Helper()
+
+	if expected != r.finalPhase {
+		t.Errorf("expected final phase to be %q; was %q", expected, r.finalPhase)
+	}
+}
+
+func (r rrResult) assertResolutionsLen(t *testing.T, expected int) {
+	t.Helper()
+
+	actual := len(r.late.Log)
+	if actual != expected {
+		t.Errorf("expected log of resolutions to have %d entries; has %d", expected, actual)
+	}
+}
+
 func TestResolveRecorder(t *testing.T) {
+	t.Run("No phases", func(t *testing.T) {
+		rez := exerciseResolveRecorder(t, func(r *ResolveRecorder) {})
+
+		rez.assertFinalPhase(t, "finished")
+		rez.assertNoError(t)
+		rez.assertResolutionsLen(t, 0)
+	})
+
+	t.Run("Two phases", func(t *testing.T) {
+		rez := exerciseResolveRecorder(t, func(r *ResolveRecorder) {
+			r.performPhase("one", func() error { return nil })
+			r.performPhase("two", func() error { return nil })
+		})
+
+		rez.assertFinalPhase(t, "finished")
+		rez.assertNoError(t)
+		rez.assertResolutionsLen(t, 0)
+	})
+
+	t.Run("Second phase fails", func(t *testing.T) {
+		rez := exerciseResolveRecorder(t, func(r *ResolveRecorder) {
+			r.performPhase("one", func() error { return fmt.Errorf("an error") })
+			r.performPhase("two", func() error { return nil })
+		})
+
+		rez.assertFinalPhase(t, "one")
+		rez.assertError(t, "an error")
+		rez.assertResolutionsLen(t, 0)
+	})
+
+	t.Run("Six phases, fourth fails", func(t *testing.T) {
+		rez := exerciseResolveRecorder(t, func(r *ResolveRecorder) {
+			r.performPhase("one", func() error { return nil })
+			r.performPhase("two", func() error { return nil })
+			r.performPhase("three", func() error {
+				r.Log <- DiffResolution{Desc: "pristine"}
+				return nil
+			})
+			r.performPhase("four -fails", func() error { return fmt.Errorf("first error") })
+			r.performPhase("five -fails", func() error { return fmt.Errorf("second error") })
+			r.performPhase("six -never see", func() error {
+				t.Fatalf("We should never get to the sixth phase of this test.")
+				return nil
+			})
+		})
+
+		rez.assertError(t, "first error")
+		rez.assertFinalPhase(t, "four -fails")
+		rez.assertResolutionsLen(t, 1)
+		if len(rez.early.Log) > 0 && len(rez.late.Log) > 0 {
+			rez.early.Log[0].Desc = "mangled"
+			if rez.late.Log[0].Desc != "pristine" {
+				t.Errorf("Expected late statue log to be unchanged by updates to early status log: %q", rez.late.Log)
+			}
+		}
+	})
 
 	for testNum, test := range resolveStatusTests {
 
@@ -72,11 +207,17 @@ func TestResolveRecorder(t *testing.T) {
 
 		// Run all the phases in the test in order.
 		rs := NewResolveRecorder(NewDeployments(), func(rs *ResolveRecorder) {
+			performGuaranteedPhase := func(name string, f func()) {
+				rs.performPhase(name, func() error {
+					f()
+					return nil
+				})
+			}
 			for phaseNum, phase := range test.Phases {
 				// Note 1: 1-indexed phase naming.
 				phaseName := fmt.Sprintf("test %d; phase %d", testNum+1, phaseNum+1)
 				if p, ok := phase.(func()); ok {
-					rs.performGuaranteedPhase(phaseName, p)
+					performGuaranteedPhase(phaseName, p)
 				} else if p, ok := phase.(func() error); ok {
 					rs.performPhase(phaseName, p)
 				} else {


### PR DESCRIPTION
Slight simplification to ResolveRecorder interface (yagni'd performGauranteedPhase)
Transformed table tests to t.Run with helpers.

Sam and I agreed that there's no outside-facing change to this, and it shouldn't have a CL entry.