### PR TITLE
Fix (?) for ResolveRecorder race #trivial

### DIFF
--- a/lib/cluster_manager.go
+++ b/lib/cluster_manager.go
@@ -1,0 +1,31 @@
+package sous
+
+import "github.com/nyarly/spies"
+
+type (
+	// ClusterManager reads and writes deployments as scoped by cluster
+	ClusterManager interface {
+		ReadCluster(clusterName string) (Deployments, error)
+		WriteCluster(clusterName string, deps Deployments) error
+	}
+
+	clusterManagerSpy struct {
+		*spies.Spy
+	}
+)
+
+// NewClusterManagerSpy produces a spy/controller pair for ClusterManager
+func NewClusterManagerSpy() (ClusterManager, *spies.Spy) {
+	spy := &spies.Spy{}
+
+	return clusterManagerSpy{spy}, spy
+}
+
+func (cm clusterManagerSpy) ReadCluster(clusterName string) (Deployments, error) {
+	res := cm.Called(clusterName)
+	return res.Get(0).(Deployments), res.Error(1)
+}
+
+func (cm clusterManagerSpy) WriteCluster(clusterName string, deps Deployments) error {
+	return cm.Called(clusterName, deps).Error(0)
+}

--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -125,7 +125,6 @@ func (r *Resolver) Begin(intended Deployments, clusters Clusters) *ResolveRecord
 
 		recorder.performPhase("rectification", func() error {
 			r.queueDiffs(logger, recorder.Log)
-			close(recorder.Log)
 			return nil
 		})
 

--- a/lib/resolvestatus.go
+++ b/lib/resolvestatus.go
@@ -106,6 +106,7 @@ func NewResolveRecorder(intended Deployments, f func(*ResolveRecorder)) *Resolve
 	// Execute the main function (f) over this resolve recorder.
 	go func() {
 		f(rr)
+		close(rr.Log)
 		rr.write(func() {
 			rr.status.Finished = time.Now()
 			if rr.err == nil {

--- a/lib/resolvestatus_test.go
+++ b/lib/resolvestatus_test.go
@@ -18,7 +18,6 @@ func exerciseResolveRecorder(t *testing.T, f func(*ResolveRecorder)) rrResult {
 	// Run all the phases in the test in order.
 	rs := NewResolveRecorder(NewDeployments(), func(rs *ResolveRecorder) {
 		f(rs)
-		close(rs.Log)
 		<-block // Wait for signal from the test that this func may finish.
 	})
 

--- a/server/handle_state_deployments.go
+++ b/server/handle_state_deployments.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/restful"
+)
+
+type (
+	// A StateDeploymentResource provides for the /state/deployments resource family
+	StateDeploymentResource struct {
+		loc ComponentLocator
+	}
+
+	// A GETStateDeployments is the exchanger for GET /state/deployments
+	GETStateDeployments struct {
+		cluster     sous.ClusterManager
+		clusterName string
+	}
+
+	// A PUTStateDeployments is the exchanger for PUT /state/deployments
+	PUTStateDeployments struct {
+		cluster     sous.ClusterManager
+		clusterName string
+		req         *http.Request
+	}
+)
+
+// Get implements restful.Getable on StateDeployments
+func (res *StateDeploymentResource) Get(http.ResponseWriter, *http.Request, httprouter.Params) restful.Exchanger {
+	return &GETStateDeployments{
+		cluster:     res.loc.ClusterManager,
+		clusterName: res.loc.Cluster.ValueOr("no-cluster"),
+	}
+}
+
+// Put implements restful.Putable on StateDeployments
+func (res *StateDeploymentResource) Put(_ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
+	return &PUTStateDeployments{
+		cluster:     res.loc.ClusterManager,
+		clusterName: res.loc.Cluster.ValueOr("no-cluster"),
+		req:         req,
+	}
+}
+
+// Exchange implements restful.Exchanger on GETStateDeployments
+func (gsd *GETStateDeployments) Exchange() (interface{}, int) {
+	data := GDMWrapper{Deployments: []*sous.Deployment{}}
+	deps, err := gsd.cluster.ReadCluster(gsd.clusterName)
+	if err != nil {
+		return err, http.StatusInternalServerError
+	}
+
+	for _, d := range deps.Snapshot() {
+		data.Deployments = append(data.Deployments, d)
+	}
+
+	return data, http.StatusOK
+}
+
+// Exchange implements Exchanger on PUTStateDeployments
+func (psd *PUTStateDeployments) Exchange() (interface{}, int) {
+	data := GDMWrapper{}
+	dec := json.NewDecoder(psd.req.Body)
+	err := dec.Decode(&data)
+	if err != nil {
+		return err, http.StatusBadRequest
+	}
+
+	deps := sous.NewDeployments(data.Deployments...)
+
+	err = psd.cluster.WriteCluster(psd.clusterName, deps)
+	if err != nil {
+		return err, http.StatusInternalServerError
+	}
+
+	return nil, http.StatusAccepted
+}

--- a/server/server.go
+++ b/server/server.go
@@ -26,7 +26,8 @@ type (
 		*config.Config
 		sous.Inserter
 		sous.StateManager
-		ResolveFilter *sous.ResolveFilter
+		sous.ClusterManager // xxx temporary?
+		ResolveFilter       *sous.ResolveFilter
 		*sous.AutoResolver
 		Version semv.Version
 	}


### PR DESCRIPTION
Upshot here is that we were requiring the clients of the ResolveRecorder
to close the RR's Log channel for it.
The tests blocked on a channel after closing the log,
which meant there was a race between that `close(Log)`
and the tests of whether the RR was `Done()`.

Ultimately, it's better practice _anyway_ to have a channel be
closed by whoever created it - this PR simply moves the handling
of that that channel up to the ResolveRecorder, and removes the
places where it was closed in production/test code.

I **think** this will result in more stable tests.