### PR TITLE
Panic if run by go-test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
+## [Unreleased](//github.com/opentable/sous/compare/0.5.63...HEAD)
+
+### Added
+* All: Default when testing, don't call recover when a log message fails to Deliver
 
 ## [0.5.63](//github.com/opentable/sous/compare/0.5.62...0.5.63)
-
 ### Added
 * CLI: If no image is present in runspec, return a fatal flaw in build.
 * Server: adding duplex state storage, to keep DB in sync until ready to switch over

--- a/ext/singularity/deployermessage.go
+++ b/ext/singularity/deployermessage.go
@@ -43,9 +43,15 @@ func (msg deployerMessage) Message() string {
 func (msg deployerMessage) EachField(f logging.FieldReportFn) {
 	f("@loglov3-otl", "sous-rectifier-singularity-v1")
 	f("pair-id", msg.pair.ID)
-	f("diffs", strings.Join(*msg.diffs, "\n"))
-	f("request-id", msg.taskData.requestID)
-	f("error", msg.error.Error())
+	if msg.diffs != nil {
+		f("diffs", strings.Join(*msg.diffs, "\n"))
+	}
+	if msg.taskData != nil {
+		f("request-id", msg.taskData.requestID)
+	}
+	if msg.error != nil {
+		f("error", msg.error.Error())
+	}
 	msg.CallerInfo.EachField(f)
 }
 

--- a/util/logging/messages.go
+++ b/util/logging/messages.go
@@ -183,21 +183,22 @@ func (writeDoner) Done() {}
 //
 // The upshot is that messages can be Delivered on the spot and
 // later determine what facilities are appropriate.
-func Deliver(message interface{}, logger LogSink, isTest ...bool) {
+func Deliver(message interface{}, logger LogSink, options ...func() bool) {
 	if logger == nil {
 		panic("null logger")
 	}
 	silent := true
 
-	//determine if function running under test, allow overwritten value from flags
+	//determine if function running under test, allow overwritten value from options functions
 	testFlag := func() bool {
 		if flag.Lookup("test.v") != nil {
 			return true
 		}
 		return false
 	}()
-	if len(isTest) > 0 {
-		testFlag = isTest[0]
+
+	for _, op := range options {
+		testFlag = op()
 	}
 
 	defer loggingPanicsShouldntCrashTheApp(logger, message, testFlag)

--- a/util/logging/messages.go
+++ b/util/logging/messages.go
@@ -27,6 +27,7 @@ package logging
 
 import (
 	"bytes"
+	"flag"
 	"io"
 	"time"
 )
@@ -222,8 +223,11 @@ type loggingPanicFakeMessage struct {
 // problems with a logging message should not crash the whole app
 // therefore: recover the panic do the simplest thing that will be logged,
 func loggingPanicsShouldntCrashTheApp(ls LogSink, msg interface{}) {
-	if rec := recover(); rec != nil {
-		Deliver(loggingPanicFakeMessage{msg}, ls)
+
+	if flag.Lookup("test.v") == nil {
+		if rec := recover(); rec != nil {
+			Deliver(loggingPanicFakeMessage{msg}, ls)
+		}
 	}
 }
 

--- a/util/logging/panic_test.go
+++ b/util/logging/panic_test.go
@@ -24,7 +24,8 @@ func TestLogMessagePanicking(t *testing.T) {
 	log, ctrl := NewLogSinkSpy()
 
 	assert.NotPanics(t, func() {
-		Deliver(terribadLogMessage{}, log, false)
+		noTestFunc := func() bool { return false }
+		Deliver(terribadLogMessage{}, log, noTestFunc)
 	})
 
 	calls := ctrl.CallsTo("LogMessage")

--- a/util/logging/panic_test.go
+++ b/util/logging/panic_test.go
@@ -21,14 +21,10 @@ func (msg terribadLogMessage) EachField(fn FieldReportFn) {
 }
 
 func TestLogMessagePanicking(t *testing.T) {
-	log, ctrl := NewLogSinkSpy()
+	log, _ := NewLogSinkSpy()
 
-	assert.NotPanics(t, func() {
+	assert.Panics(t, func() {
 		Deliver(terribadLogMessage{}, log)
 	})
 
-	calls := ctrl.CallsTo("LogMessage")
-	if assert.Len(t, calls, 1) {
-		assert.IsType(t, &silentMessageError{}, calls[0].PassedArgs().Get(1))
-	}
 }

--- a/util/logging/panic_test.go
+++ b/util/logging/panic_test.go
@@ -21,10 +21,14 @@ func (msg terribadLogMessage) EachField(fn FieldReportFn) {
 }
 
 func TestLogMessagePanicking(t *testing.T) {
-	log, _ := NewLogSinkSpy()
+	log, ctrl := NewLogSinkSpy()
 
-	assert.Panics(t, func() {
-		Deliver(terribadLogMessage{}, log)
+	assert.NotPanics(t, func() {
+		Deliver(terribadLogMessage{}, log, false)
 	})
 
+	calls := ctrl.CallsTo("LogMessage")
+	if assert.Len(t, calls, 1) {
+		assert.IsType(t, &silentMessageError{}, calls[0].PassedArgs().Get(1))
+	}
 }


### PR DESCRIPTION
Not saying we should do this, but this but since we cover panics in logging, there are definite cases where even our unit tests won't necessarily be correct, though it does help if call AssertMessageFields....