### PR TITLE
#trivial server/lib/graph: inject R11nQueueSet

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -270,6 +270,7 @@ func AddInternals(graph adder) {
 		newStatusPoller,
 		newServerComponentLocator,
 		newHTTPClient,
+		NewR11nQueueSet,
 	)
 }
 
@@ -277,8 +278,8 @@ func newResolveFilter(sf *config.DeployFilterFlags, shc sous.SourceHostChooser) 
 	return sf.BuildFilter(shc.ParseSourceLocation)
 }
 
-func newResolver(filter *sous.ResolveFilter, d sous.Deployer, r sous.Registry, ls LogSink) *sous.Resolver {
-	return sous.NewResolver(d, r, filter, ls.Child("resolver"))
+func newResolver(filter *sous.ResolveFilter, d sous.Deployer, r sous.Registry, ls LogSink, qs *sous.R11nQueueSet) *sous.Resolver {
+	return sous.NewResolver(d, r, filter, ls.Child("resolver"), qs)
 }
 
 func newAutoResolver(rez *sous.Resolver, sr *ServerStateManager, ls LogSink) *sous.AutoResolver {

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -149,6 +149,7 @@ func injectedStateManager(t *testing.T, cfg *config.Config) *StateManager {
 	g.Add(newAutoResolver)
 	g.Add(newServerHandler)
 	g.Add(newHTTPClient)
+	g.Add(NewR11nQueueSet)
 	g.Add(g)
 
 	smRcvr := struct {

--- a/graph/server.go
+++ b/graph/server.go
@@ -6,7 +6,7 @@ import (
 	"github.com/samsalisbury/semv"
 )
 
-func newServerComponentLocator(ls LogSink, cfg LocalSousConfig, ins sous.Inserter, sm *ServerStateManager, rf *sous.ResolveFilter, ar *sous.AutoResolver, v semv.Version) server.ComponentLocator {
+func newServerComponentLocator(ls LogSink, cfg LocalSousConfig, ins sous.Inserter, sm *ServerStateManager, rf *sous.ResolveFilter, ar *sous.AutoResolver, v semv.Version, qs *sous.R11nQueueSet) server.ComponentLocator {
 	return server.ComponentLocator{
 		LogSink:       ls.LogSink,
 		Config:        cfg.Config,
@@ -15,6 +15,17 @@ func newServerComponentLocator(ls LogSink, cfg LocalSousConfig, ins sous.Inserte
 		ResolveFilter: rf,
 		AutoResolver:  ar,
 		Version:       v,
+		QueueSet:      qs,
 	}
 
+}
+
+// NewR11nQueueSet returns a new queue set configured to start processing r11ns
+// immediately.
+func NewR11nQueueSet(d sous.Deployer) *sous.R11nQueueSet {
+	return sous.NewR11nQueueSet(sous.R11nQueueStartWithHandler(
+		func(qr *sous.QueuedR11n) sous.DiffResolution {
+			qr.Rectification.Begin(d)
+			return qr.Rectification.Wait()
+		}))
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/opentable/sous/ext/docker"
 	"github.com/opentable/sous/ext/singularity"
+	"github.com/opentable/sous/graph"
 	"github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/docker_registry"
 	"github.com/opentable/sous/util/logging"
@@ -400,7 +401,8 @@ func (suite *integrationSuite) TestMissingImage() {
 	}
 
 	// ****
-	r := sous.NewResolver(suite.deployer, suite.nameCache, &sous.ResolveFilter{}, logging.SilentLogSet())
+	qs := graph.NewR11nQueueSet(suite.deployer)
+	r := sous.NewResolver(suite.deployer, suite.nameCache, &sous.ResolveFilter{}, logging.SilentLogSet(), qs)
 
 	deploymentsOne, err := stateOne.Deployments()
 	suite.Require().NoError(err)
@@ -456,7 +458,8 @@ func (suite *integrationSuite) TestResolve() {
 	logsink, logController := logging.NewLogSinkSpy()
 
 	// ****
-	r := sous.NewResolver(suite.deployer, suite.nameCache, &sous.ResolveFilter{}, logsink)
+	qs := graph.NewR11nQueueSet(suite.deployer)
+	r := sous.NewResolver(suite.deployer, suite.nameCache, &sous.ResolveFilter{}, logsink, qs)
 
 	suite.T().Log("Begining OneTwo")
 	err = r.Begin(deploymentsOneTwo, clusterDefs.Clusters).Wait()
@@ -521,7 +524,8 @@ func (suite *integrationSuite) TestResolve() {
 		client := singularity.NewRectiAgent(suite.nameCache)
 		deployer := singularity.NewDeployer(client, logging.SilentLogSet())
 
-		r := sous.NewResolver(deployer, suite.nameCache, &sous.ResolveFilter{}, logging.SilentLogSet())
+		qs := graph.NewR11nQueueSet(suite.deployer)
+		r := sous.NewResolver(deployer, suite.nameCache, &sous.ResolveFilter{}, logging.SilentLogSet(), qs)
 
 		err = r.Begin(deploymentsTwoThree, clusterDefs.Clusters).Wait()
 		if err != nil {

--- a/lib/auto_resolver_test.go
+++ b/lib/auto_resolver_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func dummyResolver() *Resolver {
-	return NewResolver(NewDummyDeployer(), NewDummyRegistry(), &ResolveFilter{}, logging.SilentLogSet())
+	return NewResolver(NewDummyDeployer(), NewDummyRegistry(), &ResolveFilter{}, logging.SilentLogSet(), NewR11nQueueSet())
 }
 
 func setupAR() *AutoResolver {

--- a/server/handle_alldeployqueues.go
+++ b/server/handle_alldeployqueues.go
@@ -26,7 +26,9 @@ func newAllDeployQueuesResource(ctx ComponentLocator) *AllDeployQueuesResource {
 
 // Get returns a configured GETAllDeployQueuesHandler.
 func (r *AllDeployQueuesResource) Get(_ http.ResponseWriter, _ *http.Request, _ httprouter.Params) restful.Exchanger {
-	return &GETAllDeployQueuesHandler{}
+	return &GETAllDeployQueuesHandler{
+		QueueSet: r.context.QueueSet,
+	}
 }
 
 // Exchange returns deploymentsResponse representing all queues managed by this

--- a/server/handle_alldeployqueues_test.go
+++ b/server/handle_alldeployqueues_test.go
@@ -1,12 +1,29 @@
 package server
 
 import (
+	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
 	sous "github.com/opentable/sous/lib"
 	"github.com/pborman/uuid"
 )
+
+// TestNewAllDeployQueuesResource checks that the same queue set passed to the
+// constructor makes its way to the get handler.
+func TestNewAllDeployQueuesResource(t *testing.T) {
+	qs := &sous.R11nQueueSet{}
+	c := ComponentLocator{
+		QueueSet: qs,
+	}
+	adq := newAllDeployQueuesResource(c)
+
+	got := adq.Get(nil, &http.Request{URL: &url.URL{}}, nil).(*GETAllDeployQueuesHandler)
+	if got.QueueSet != qs {
+		t.Errorf("got different queueset")
+	}
+}
 
 func TestGETAllDeployQueuesHandler_Exchange(t *testing.T) {
 

--- a/server/handle_deployqueue.go
+++ b/server/handle_deployqueue.go
@@ -44,6 +44,7 @@ func deploymentIDFromRoute(r *http.Request) (sous.DeploymentID, error) {
 func (r *DeployQueueResource) Get(_ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
 	did, didErr := deploymentIDFromRoute(req)
 	return &GETDeployQueueHandler{
+		QueueSet:        r.context.QueueSet,
 		DeploymentID:    did,
 		DeploymentIDErr: didErr,
 	}

--- a/server/handle_deployqueue_test.go
+++ b/server/handle_deployqueue_test.go
@@ -18,6 +18,21 @@ func makeRequestWithQuery(t *testing.T, query string) *http.Request {
 	return &http.Request{URL: u}
 }
 
+// TestNewDeployQueueResource checks that the same queue set passed to the
+// constructor makes its way to the get handler.
+func TestNewDeployQueueResource(t *testing.T) {
+	qs := &sous.R11nQueueSet{}
+	c := ComponentLocator{
+		QueueSet: qs,
+	}
+	dq := newDeployQueueResource(c)
+
+	got := dq.Get(nil, &http.Request{URL: &url.URL{}}, nil).(*GETDeployQueueHandler)
+	if got.QueueSet != qs {
+		t.Errorf("got different queueset")
+	}
+}
+
 func TestDeployQueueResource_Get_no_errors(t *testing.T) {
 
 	testCases := []struct {

--- a/server/handle_r11n.go
+++ b/server/handle_r11n.go
@@ -45,6 +45,7 @@ func (r *R11nResource) Get(_ http.ResponseWriter, req *http.Request, _ httproute
 	rid, ridErr := r11nIDFromRoute(req)
 	wait := req.URL.Query().Get("wait") == "true"
 	return &GETR11nHandler{
+		QueueSet:          r.context.QueueSet,
 		WaitForResolution: wait,
 		DeploymentID:      did,
 		DeploymentIDErr:   didErr,

--- a/server/handle_r11n_test.go
+++ b/server/handle_r11n_test.go
@@ -2,11 +2,28 @@ package server
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
 	sous "github.com/opentable/sous/lib"
 )
+
+// TestNewR11nResource checks that the same queue set passed to the
+// constructor makes its way to the get handler.
+func TestNewR11nResource(t *testing.T) {
+	qs := &sous.R11nQueueSet{}
+	c := ComponentLocator{
+		QueueSet: qs,
+	}
+	dq := newR11nResource(c)
+
+	got := dq.Get(nil, &http.Request{URL: &url.URL{}}, nil).(*GETR11nHandler)
+	if got.QueueSet != qs {
+		t.Errorf("got different queueset")
+	}
+}
 
 func TestR11nResource_Get_no_errors(t *testing.T) {
 

--- a/server/server.go
+++ b/server/server.go
@@ -28,7 +28,8 @@ type (
 		sous.StateManager
 		ResolveFilter *sous.ResolveFilter
 		*sous.AutoResolver
-		Version semv.Version
+		Version  semv.Version
+		QueueSet *sous.R11nQueueSet
 	}
 )
 


### PR DESCRIPTION
- Also removes the global queue set that was always a smell.

**EDIT** marked this as trivial since it simply makes the current changelog entry about this true.