### PR TITLE
#trivial Deploy queue endpoints use separate query values.

### DIFF
--- a/server/handle_deployqueue.go
+++ b/server/handle_deployqueue.go
@@ -42,7 +42,8 @@ func deploymentIDFromRoute(r *http.Request) (sous.DeploymentID, error) {
 
 // Get returns a configured GETDeployQueueHandler.
 func (r *DeployQueueResource) Get(_ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
-	did, didErr := deploymentIDFromRoute(req)
+	qv := restful.QueryValues{Values: req.URL.Query()}
+	did, didErr := deploymentIDFromValues(qv)
 	return &GETDeployQueueHandler{
 		QueueSet:        r.context.QueueSet,
 		DeploymentID:    did,

--- a/server/handle_deployqueue.go
+++ b/server/handle_deployqueue.go
@@ -1,9 +1,7 @@
 package server
 
 import (
-	"fmt"
 	"net/http"
-	"net/url"
 
 	"github.com/julienschmidt/httprouter"
 	sous "github.com/opentable/sous/lib"
@@ -26,18 +24,6 @@ type (
 
 func newDeployQueueResource(ctx ComponentLocator) *DeployQueueResource {
 	return &DeployQueueResource{context: ctx}
-}
-
-func deploymentIDFromRoute(r *http.Request) (sous.DeploymentID, error) {
-	didStr, err := url.QueryUnescape(r.URL.Query().Get("DeploymentID"))
-	if err != nil {
-		return sous.DeploymentID{}, fmt.Errorf("unescaping query: %s", err)
-	}
-	did, err := sous.ParseDeploymentID(didStr)
-	if err != nil {
-		return sous.DeploymentID{}, fmt.Errorf("parsing DeploymentID from query: %s", err)
-	}
-	return did, nil
 }
 
 // Get returns a configured GETDeployQueueHandler.

--- a/server/handle_deployqueue_test.go
+++ b/server/handle_deployqueue_test.go
@@ -120,11 +120,11 @@ func TestDeployQueueResource_Get_DeploymentID_errors(t *testing.T) {
 	}{
 		{
 			query:      "repo=github.com%2Fuser1%2Frepo1",
-			wantDIDErr: `missing query parameter "cluster"`,
+			wantDIDErr: `No cluster given`,
 		},
 		{
 			query:      "cluster=cluster1",
-			wantDIDErr: `missing query parameter "repo"`,
+			wantDIDErr: `No repo given`,
 		},
 	}
 

--- a/server/handle_deployqueue_test.go
+++ b/server/handle_deployqueue_test.go
@@ -41,8 +41,8 @@ func TestDeployQueueResource_Get_no_errors(t *testing.T) {
 		wantDID sous.DeploymentID
 	}{
 		{
-			desc:  "valid deploymentID",
-			query: "DeploymentID=cluster1%3Agithub.com%2Fuser1%2Frepo1%2Cdir1~flavor1",
+			desc:  "cluster,flavor,offset,repo",
+			query: "cluster=cluster1&flavor=flavor1&offset=dir1&repo=github.com%2Fuser1%2Frepo1",
 			wantDID: sous.DeploymentID{
 				ManifestID: sous.ManifestID{
 					Source: sous.SourceLocation{
@@ -50,6 +50,44 @@ func TestDeployQueueResource_Get_no_errors(t *testing.T) {
 						Dir:  "dir1",
 					},
 					Flavor: "flavor1",
+				},
+				Cluster: "cluster1",
+			},
+		},
+		{
+			desc:  "cluster,offset,repo",
+			query: "cluster=cluster1&offset=dir1&repo=github.com%2Fuser1%2Frepo1",
+			wantDID: sous.DeploymentID{
+				ManifestID: sous.ManifestID{
+					Source: sous.SourceLocation{
+						Repo: "github.com/user1/repo1",
+						Dir:  "dir1",
+					},
+				},
+				Cluster: "cluster1",
+			},
+		},
+		{
+			desc:  "cluster,flavor,repo",
+			query: "cluster=cluster1&flavor=flavor1&repo=github.com%2Fuser1%2Frepo1",
+			wantDID: sous.DeploymentID{
+				ManifestID: sous.ManifestID{
+					Source: sous.SourceLocation{
+						Repo: "github.com/user1/repo1",
+					},
+					Flavor: "flavor1",
+				},
+				Cluster: "cluster1",
+			},
+		},
+		{
+			desc:  "cluster,repo",
+			query: "cluster=cluster1&repo=github.com%2Fuser1%2Frepo1",
+			wantDID: sous.DeploymentID{
+				ManifestID: sous.ManifestID{
+					Source: sous.SourceLocation{
+						Repo: "github.com/user1/repo1",
+					},
 				},
 				Cluster: "cluster1",
 			},
@@ -81,8 +119,12 @@ func TestDeployQueueResource_Get_DeploymentID_errors(t *testing.T) {
 		wantDIDErr string
 	}{
 		{
-			query:      "DeploymentID=cluster1Agithub.com%2Fuser1%2Frepo1%2Cdir1~flavor1",
-			wantDIDErr: `parsing DeploymentID from query: does not contain a colon`,
+			query:      "repo=github.com%2Fuser1%2Frepo1",
+			wantDIDErr: `missing query parameter "cluster"`,
+		},
+		{
+			query:      "cluster=cluster1",
+			wantDIDErr: `missing query parameter "repo"`,
 		},
 	}
 

--- a/server/handle_manifest.go
+++ b/server/handle_manifest.go
@@ -7,7 +7,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/julienschmidt/httprouter"
 	"github.com/opentable/sous/lib"
-	"github.com/opentable/sous/util/firsterr"
 	"github.com/opentable/sous/util/logging"
 	"github.com/opentable/sous/util/restful"
 	"github.com/pkg/errors"
@@ -127,38 +126,4 @@ func (pmh *PUTManifestHandler) Exchange() (interface{}, int) {
 		return errors.Wrapf(err, "state recording collision - retry"), http.StatusConflict
 	}
 	return m, http.StatusOK
-}
-
-/*
-To recap:
-
-To look up a manifest, we need a manifestID:
-ManifestID{
-	SourceLocation{
-		Repo
-		Offset
-	}
-	Flavor
-}
-*/
-
-func manifestIDFromValues(qv restful.QueryValues) (sous.ManifestID, error) {
-	var r, o, f string
-	var err error
-	err = firsterr.Returned(
-		func() error { r, err = qv.Single("repo"); return err },
-		func() error { o, err = qv.Single("offset", ""); return err },
-		func() error { f, err = qv.Single("flavor", ""); return err },
-	)
-	if err != nil {
-		return sous.ManifestID{}, err
-	}
-
-	return sous.ManifestID{
-		Source: sous.SourceLocation{
-			Repo: r,
-			Dir:  o,
-		},
-		Flavor: f,
-	}, nil
 }

--- a/server/handle_r11n.go
+++ b/server/handle_r11n.go
@@ -41,7 +41,7 @@ func r11nIDFromRoute(r *http.Request) (sous.R11nID, error) {
 
 // Get returns a configured GETR11nHandler.
 func (r *R11nResource) Get(_ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
-	did, didErr := deploymentIDFromRoute(req)
+	did, didErr := deploymentIDFromValues(restful.QueryValues{Values: req.URL.Query()})
 	rid, ridErr := r11nIDFromRoute(req)
 	wait := req.URL.Query().Get("wait") == "true"
 	return &GETR11nHandler{

--- a/server/handle_r11n.go
+++ b/server/handle_r11n.go
@@ -32,7 +32,7 @@ func newR11nResource(ctx ComponentLocator) *R11nResource {
 }
 
 func r11nIDFromRoute(r *http.Request) (sous.R11nID, error) {
-	ridStr, err := url.QueryUnescape(r.URL.Query().Get("R11nID"))
+	ridStr, err := url.QueryUnescape(r.URL.Query().Get("action"))
 	if err != nil {
 		return "", fmt.Errorf("unescaping query: %s", err)
 	}

--- a/server/handle_r11n_test.go
+++ b/server/handle_r11n_test.go
@@ -36,7 +36,7 @@ func TestR11nResource_Get_no_errors(t *testing.T) {
 	}{
 		{
 			desc:  "valid deploymentID and r11nID",
-			query: "cluster=cluster1&repo=github.com%2Fuser1%2Frepo1&offset=dir1&flavor=flavor1&R11nID=cabba9e",
+			query: "cluster=cluster1&repo=github.com%2Fuser1%2Frepo1&offset=dir1&flavor=flavor1&action=cabba9e",
 			wantDID: sous.DeploymentID{
 				ManifestID: sous.ManifestID{
 					Source: sous.SourceLocation{
@@ -51,7 +51,7 @@ func TestR11nResource_Get_no_errors(t *testing.T) {
 		},
 		{
 			desc:  "valid short DeploymentID and r11nID",
-			query: "cluster=cluster1&repo=github.com%2Fuser1%2Frepo1&R11nID=cabba9e",
+			query: "cluster=cluster1&repo=github.com%2Fuser1%2Frepo1&action=cabba9e",
 			wantDID: sous.DeploymentID{
 				ManifestID: sous.ManifestID{
 					Source: sous.SourceLocation{
@@ -64,7 +64,7 @@ func TestR11nResource_Get_no_errors(t *testing.T) {
 		},
 		{
 			desc:  "wait query",
-			query: "cluster=cluster1&repo=github.com%2Fuser1%2Frepo1&R11nID=cabba9e&wait=true",
+			query: "cluster=cluster1&repo=github.com%2Fuser1%2Frepo1&action=cabba9e&wait=true",
 			wantDID: sous.DeploymentID{
 				ManifestID: sous.ManifestID{
 					Source: sous.SourceLocation{

--- a/server/handle_r11n_test.go
+++ b/server/handle_r11n_test.go
@@ -36,7 +36,7 @@ func TestR11nResource_Get_no_errors(t *testing.T) {
 	}{
 		{
 			desc:  "valid deploymentID and r11nID",
-			query: "DeploymentID=cluster1%3Agithub.com%2Fuser1%2Frepo1%2Cdir1~flavor1&R11nID=cabba9e",
+			query: "cluster=cluster1&repo=github.com%2Fuser1%2Frepo1&offset=dir1&flavor=flavor1&R11nID=cabba9e",
 			wantDID: sous.DeploymentID{
 				ManifestID: sous.ManifestID{
 					Source: sous.SourceLocation{
@@ -51,7 +51,7 @@ func TestR11nResource_Get_no_errors(t *testing.T) {
 		},
 		{
 			desc:  "valid short DeploymentID and r11nID",
-			query: "DeploymentID=cluster1%3Agithub.com%2Fuser1%2Frepo1&R11nID=cabba9e",
+			query: "cluster=cluster1&repo=github.com%2Fuser1%2Frepo1&R11nID=cabba9e",
 			wantDID: sous.DeploymentID{
 				ManifestID: sous.ManifestID{
 					Source: sous.SourceLocation{
@@ -64,7 +64,7 @@ func TestR11nResource_Get_no_errors(t *testing.T) {
 		},
 		{
 			desc:  "wait query",
-			query: "DeploymentID=cluster1%3Agithub.com%2Fuser1%2Frepo1&R11nID=cabba9e&wait=true",
+			query: "cluster=cluster1&repo=github.com%2Fuser1%2Frepo1&R11nID=cabba9e&wait=true",
 			wantDID: sous.DeploymentID{
 				ManifestID: sous.ManifestID{
 					Source: sous.SourceLocation{

--- a/server/queries.go
+++ b/server/queries.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/firsterr"
+	"github.com/opentable/sous/util/restful"
+)
+
+func manifestIDFromValues(qv restful.QueryValues) (sous.ManifestID, error) {
+	var r, o, f string
+	var err error
+	err = firsterr.Returned(
+		func() error { r, err = qv.Single("repo"); return err },
+		func() error { o, err = qv.Single("offset", ""); return err },
+		func() error { f, err = qv.Single("flavor", ""); return err },
+	)
+	if err != nil {
+		return sous.ManifestID{}, err
+	}
+
+	return sous.ManifestID{
+		Source: sous.SourceLocation{
+			Repo: r,
+			Dir:  o,
+		},
+		Flavor: f,
+	}, nil
+}
+
+func deploymentIDFromValues(qv restful.QueryValues) (sous.DeploymentID, error) {
+	cluster, err := qv.Single("cluster")
+	if err != nil {
+		return sous.DeploymentID{}, err
+	}
+	mid, err := manifestIDFromValues(qv)
+	if err != nil {
+		return sous.DeploymentID{}, err
+	}
+	return sous.DeploymentID{
+		ManifestID: mid,
+		Cluster:    cluster,
+	}, nil
+}


### PR DESCRIPTION
We decided it would be easier for external API consumers to be able to specify the parts of a DeploymentID separately as query values rather than as a single concatenated string, this change effects that idea.

EDIT: Marked #trivial because the unreleased changelog already lists the addition of these endpoints.