### PR TITLE
#trivial singularity: remove reference to deprecated type

### DIFF
--- a/ext/singularity/deployment_builder.go
+++ b/ext/singularity/deployment_builder.go
@@ -75,13 +75,11 @@ func isMalformed(log logging.LogSink, err error) bool {
 	log.Vomitf("is malformedResponse? err: %+v %T %t", err, err, isMal)
 	_, isUMT := err.(*json.UnmarshalTypeError)
 	log.Vomitf("is json unmarshal type error? err: %+v %T %t", err, err, isUMT)
-	_, isUMF := err.(*json.UnmarshalFieldError)
-	log.Vomitf("is json unmarshal value error? err: %+v %T %t", err, err, isUMF)
 	_, isUST := err.(*json.UnsupportedTypeError)
 	log.Vomitf("is json unsupported type error? err: %+v %T %t", err, err, isUST)
 	_, isUSV := err.(*json.UnsupportedValueError)
 	log.Vomitf("is json unsupported value error? err: %+v %T %t", err, err, isUSV)
-	return isMal || isUMT || isUMF || isUST || isUSV
+	return isMal || isUMT || isUST || isUSV
 }
 
 func (cr *canRetryRequest) Error() string {


### PR DESCRIPTION
- UnmarshalFieldError has been unused since early 2013:
  https://github.com/golang/go/commit/6e3f3af4e0f4293f868aa71c4271cab6344d5797#diff-3be5c7b44b3117ade8424ec490983cb6R109
- In go 1.10 it is marked deprecated using GoDoc comment:
  https://github.com/golang/go/commit/a3e013b0824ba53168b5d91abdb6ce191510a89d#diff-e79d4db81e8544657cb631be813f89b4R249
- This caused make staticcheck to fail with go 1.10