### PR TITLE
#trivial storage/test: make repo paths abs; add t.Helper()

### DIFF
--- a/ext/storage/preparetestgitrepo.go
+++ b/ext/storage/preparetestgitrepo.go
@@ -14,6 +14,7 @@ var testUser = sous.User{Name: "Test User", Email: "test@user.com"}
 
 // PrepareTestGitRepo prepares a git repo for test purposes.
 func PrepareTestGitRepo(t *testing.T, s *sous.State, remotepath, outpath string) {
+	t.Helper()
 
 	clobberDir(t, remotepath)
 	clobberDir(t, outpath)
@@ -39,6 +40,7 @@ func PrepareTestGitRepo(t *testing.T, s *sous.State, remotepath, outpath string)
 }
 
 func clobberDir(t *testing.T, path string) {
+	t.Helper()
 	if err := os.RemoveAll(path); err != nil {
 		t.Fatal(err)
 	}

--- a/test/server_integration_test.go
+++ b/test/server_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/opentable/sous/config"
@@ -38,10 +39,14 @@ type (
 )
 
 func (suite *integrationServerTests) prepare() (logging.LogSink, http.Handler) {
+	td, err := filepath.Abs("../ext/storage/testdata")
+	if err != nil {
+		suite.FailNow("setup failed: %s", err)
+	}
 	sourcepath, remotepath, outpath :=
-		"../ext/storage/testdata/in",
-		"../ext/storage/testdata/remote",
-		"../ext/storage/testdata/out"
+		filepath.Join(td, "in"),
+		filepath.Join(td, "remote"),
+		filepath.Join(td, "out")
 
 	dsm := storage.NewDiskStateManager(sourcepath)
 	s, err := dsm.ReadState()

--- a/test/server_integration_test.go
+++ b/test/server_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/opentable/sous/server"
 	"github.com/opentable/sous/util/logging"
 	"github.com/opentable/sous/util/restful"
+	"github.com/pborman/uuid"
 	"github.com/samsalisbury/psyringe"
 	"github.com/samsalisbury/semv"
 	"github.com/stretchr/testify/suite"
@@ -30,23 +31,29 @@ type (
 
 	liveServerSuite struct {
 		integrationServerTests
-		server *httptest.Server
+		server  *httptest.Server
+		cleanup func()
 	}
 
 	inmemServerSuite struct {
 		integrationServerTests
+		cleanup func()
 	}
 )
 
-func (suite *integrationServerTests) prepare() (logging.LogSink, http.Handler) {
+// prepare returns a logging.LogSink and http.Handler for use in tests.
+// It also returns a cleanup function which should be called to remove
+// temp files created after each test run.
+func (suite *integrationServerTests) prepare() (logging.LogSink, http.Handler, func()) {
 	td, err := filepath.Abs("../ext/storage/testdata")
 	if err != nil {
 		suite.FailNow("setup failed: %s", err)
 	}
+	temp := filepath.Join(os.TempDir(), "soustests", uuid.New())
 	sourcepath, remotepath, outpath :=
 		filepath.Join(td, "in"),
-		filepath.Join(td, "remote"),
-		filepath.Join(td, "out")
+		filepath.Join(temp, "remote"),
+		filepath.Join(temp, "out")
 
 	dsm := storage.NewDiskStateManager(sourcepath)
 	s, err := dsm.ReadState()
@@ -84,11 +91,20 @@ func (suite *integrationServerTests) prepare() (logging.LogSink, http.Handler) {
 	if serverScoop.Handler.Handler == nil {
 		suite.FailNow("Didn't inject http.Handler!")
 	}
-	return log, serverScoop.Handler.Handler
+	return log, serverScoop.Handler.Handler, func() {
+		if err := os.RemoveAll(outpath); err != nil {
+			suite.T().Errorf("cleanup failed: %s", err)
+		}
+		if err := os.RemoveAll(remotepath); err != nil {
+			suite.T().Errorf("cleanup failed: %s", err)
+		}
+	}
+
 }
 
 func (suite *liveServerSuite) SetupTest() {
-	lt, h := suite.prepare()
+	lt, h, cleanup := suite.prepare()
+	suite.cleanup = cleanup
 
 	suite.server = httptest.NewServer(h)
 	suite.user = sous.User{}
@@ -101,7 +117,8 @@ func (suite *liveServerSuite) SetupTest() {
 }
 
 func (suite *inmemServerSuite) SetupTest() {
-	lt, h := suite.prepare()
+	lt, h, cleanup := suite.prepare()
+	suite.cleanup = cleanup
 
 	suite.user = sous.User{}
 	var err error
@@ -113,6 +130,15 @@ func (suite *inmemServerSuite) SetupTest() {
 
 func (suite liveServerSuite) TearDownTest() {
 	suite.server.Close()
+	if suite.cleanup != nil {
+		suite.cleanup()
+	}
+}
+
+func (suite inmemServerSuite) TearDownTest() {
+	if suite.cleanup != nil {
+		suite.cleanup()
+	}
 }
 
 func (suite integrationServerTests) TestOverallRouter() {


### PR DESCRIPTION
- I get intermittent failures where test setup fails to
  remove testdata directories.
- I put these changes in to try & debug the problem, ~and
  it appears to have stopped happening, not sure if this
  fixed it or if after 5+ test runs the issue cleared by
  itself.~
- Worth keeping these changes in case it happens again.

**Update:** these test failures continued to happen frequently, I've added a further commit that puts generated test data in a separate temp dir per test so they don't interfere with each other. Also added cleanup to save filling up disks. This looks to have solved the issue on my machine, but I can see other places we could apply this pattern. Has anyone else seen intermittent failures like those below?

```
--- FAIL: TestOverallRouter (0.05s)
        preparetestgitrepo.go:57: "git init --template=/dev/null" errored: exit status 128
                 fatal: unable to get current working directory: No such file or directory
--- FAIL: TestUpdateServers (0.01s)
        server_integration_test.go:55: remove /Users/ssalisbury/src/github.com/opentable/sous/ext/storage/testdata/remote: directory not empty
--- FAIL: TestUpdateStateDeployments_Precondition (0.02s)
        preparetestgitrepo.go:57: "git init --template=/dev/null --bare" errored: exit status 128
                 warning: templates not found /dev/null
                error: could not lock config file /Users/ssalisbury/src/github.com/opentable/sous/ext/storage/testdata/remote/config: File exists
                fatal: could not set 'core.ignorecase' to 'true'
--- FAIL: TestUpdateStateDeployments_Update (0.01s)
        server_integration_test.go:55: remove /Users/ssalisbury/src/github.com/opentable/sous/ext/storage/testdata/out/.git: directory not empty
--- FAIL: TestLiveServerSuite (0.10s)
--- FAIL: TestOverallRouter (0.02s)
        preparetestgitrepo.go:57: "git init --template=/dev/null --bare" errored: exit status 128
                 fatal: unable to get current working directory: No such file or directory
--- FAIL: TestInMemoryServerSuite (1.14s)
```
