### PR TITLE
Put deployment endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface.
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.65...master)
+
+* Server: PUT /single-deployment endpoint immediately adds a rectification
+  to the queue and returns a link to monitor for completion.
+
 ## [0.5.66](//github.com/opentable/sous/compare/0.5.65...0.5.66)
 
 ### Added
 * Server: Include connection string in db connection error log.
-* Client: Add structured logging to status poller
-* All: Create a new structured log that auto extracts IDs and stores in seperate fields for
-  easier searching in logstash
 
 ### Changed
 * All: Top-level global logger labeled "GLOBAL".

--- a/lib/resolvestatus.go
+++ b/lib/resolvestatus.go
@@ -103,7 +103,6 @@ func NewResolveRecorder(intended Deployments, ls logging.LogSink, f func(*Resolv
 				}
 			})
 		}
-		close(rr.finished)
 	}()
 
 	// Execute the main function (f) over this resolve recorder.
@@ -115,6 +114,7 @@ func NewResolveRecorder(intended Deployments, ls logging.LogSink, f func(*Resolv
 			if rr.err == nil {
 				rr.status.Phase = "finished"
 			}
+			close(rr.finished)
 		})
 	}()
 	return rr

--- a/lib/resources.go
+++ b/lib/resources.go
@@ -101,7 +101,7 @@ func (r Resources) Cpus() float64 {
 		if present {
 			reportResourceMessage(fmt.Sprintf("Could not parse value: '%s' for cpus as a float, using default: %f", cpuStr, cpus), r, logging.Log)
 		} else {
-			reportDebugResourceMessage(fmt.Sprintf("Using default value for cpus: %f.", cpus), r, logging.Log)
+			//reportDebugResourceMessage(fmt.Sprintf("Using default value for cpus: %f.", cpus), r, logging.Log)
 		}
 	}
 	return cpus

--- a/lib/resources.go
+++ b/lib/resources.go
@@ -101,7 +101,7 @@ func (r Resources) Cpus() float64 {
 		if present {
 			reportResourceMessage(fmt.Sprintf("Could not parse value: '%s' for cpus as a float, using default: %f", cpuStr, cpus), r, logging.Log)
 		} else {
-			//reportDebugResourceMessage(fmt.Sprintf("Using default value for cpus: %f.", cpus), r, logging.Log)
+			reportDebugResourceMessage(fmt.Sprintf("Using default value for cpus: %f.", cpus), r, logging.Log)
 		}
 	}
 	return cpus
@@ -116,7 +116,7 @@ func (r Resources) Memory() float64 {
 		if present {
 			reportResourceMessage(fmt.Sprintf("Could not parse value: '%s' for memory as an int, using default: %f", memStr, memory), r, logging.Log)
 		} else {
-			//reportDebugResourceMessage(fmt.Sprintf("Using default value for memory: %f.", memory), r, logging.Log)
+			reportDebugResourceMessage(fmt.Sprintf("Using default value for memory: %f.", memory), r, logging.Log)
 		}
 	}
 	return memory
@@ -131,7 +131,7 @@ func (r Resources) Ports() int32 {
 		if present {
 			reportResourceMessage(fmt.Sprintf("Could not parse value: '%s' for ports as a int, using default: %d", portStr, ports), r, logging.Log)
 		} else {
-			//reportDebugResourceMessage(fmt.Sprintf("Using default value for ports: %d", ports), r, logging.Log)
+			reportDebugResourceMessage(fmt.Sprintf("Using default value for ports: %d", ports), r, logging.Log)
 		}
 	}
 	return int32(ports)
@@ -139,7 +139,7 @@ func (r Resources) Ports() int32 {
 
 // Equal checks equivalence between resource maps
 func (r Resources) Equal(o Resources) bool {
-	//reportDebugResourceMessage(fmt.Sprintf("Comparing resources: %+ v ?= %+ v", r, o), r, logging.Log)
+	reportDebugResourceMessage(fmt.Sprintf("Comparing resources: %+ v ?= %+ v", r, o), r, logging.Log)
 	if len(r) != len(o) {
 		reportDebugResourceMessage("Lengths differ", r, logging.Log)
 		return false

--- a/lib/resources.go
+++ b/lib/resources.go
@@ -116,7 +116,7 @@ func (r Resources) Memory() float64 {
 		if present {
 			reportResourceMessage(fmt.Sprintf("Could not parse value: '%s' for memory as an int, using default: %f", memStr, memory), r, logging.Log)
 		} else {
-			reportDebugResourceMessage(fmt.Sprintf("Using default value for memory: %f.", memory), r, logging.Log)
+			//reportDebugResourceMessage(fmt.Sprintf("Using default value for memory: %f.", memory), r, logging.Log)
 		}
 	}
 	return memory
@@ -131,7 +131,7 @@ func (r Resources) Ports() int32 {
 		if present {
 			reportResourceMessage(fmt.Sprintf("Could not parse value: '%s' for ports as a int, using default: %d", portStr, ports), r, logging.Log)
 		} else {
-			reportDebugResourceMessage(fmt.Sprintf("Using default value for ports: %d", ports), r, logging.Log)
+			//reportDebugResourceMessage(fmt.Sprintf("Using default value for ports: %d", ports), r, logging.Log)
 		}
 	}
 	return int32(ports)
@@ -139,7 +139,7 @@ func (r Resources) Ports() int32 {
 
 // Equal checks equivalence between resource maps
 func (r Resources) Equal(o Resources) bool {
-	reportDebugResourceMessage(fmt.Sprintf("Comparing resources: %+ v ?= %+ v", r, o), r, logging.Log)
+	//reportDebugResourceMessage(fmt.Sprintf("Comparing resources: %+ v ?= %+ v", r, o), r, logging.Log)
 	if len(r) != len(o) {
 		reportDebugResourceMessage("Lengths differ", r, logging.Log)
 		return false

--- a/server/exchangers_test.go
+++ b/server/exchangers_test.go
@@ -11,6 +11,9 @@ func TestResourcesFulfillInterfaces(t *testing.T) {
 	assert.Implements(t, (*restful.Getable)(nil), newGDMResource(ComponentLocator{}))
 	assert.Implements(t, (*restful.Putable)(nil), newGDMResource(ComponentLocator{}))
 
+	assert.Implements(t, (*restful.Getable)(nil), newStateDeploymentResource(ComponentLocator{}))
+	assert.Implements(t, (*restful.Putable)(nil), newStateDeploymentResource(ComponentLocator{}))
+
 	assert.Implements(t, (*restful.Getable)(nil), newStateDefResource(ComponentLocator{}))
 
 	assert.Implements(t, (*restful.Getable)(nil), newManifestResource(ComponentLocator{}))
@@ -25,4 +28,10 @@ func TestResourcesFulfillInterfaces(t *testing.T) {
 	assert.Implements(t, (*restful.Getable)(nil), newStatusResource(ComponentLocator{}))
 
 	assert.Implements(t, (*restful.Getable)(nil), newHealthResource(ComponentLocator{}))
+
+	assert.Implements(t, (*restful.Getable)(nil), newAllDeployQueuesResource(ComponentLocator{}))
+
+	assert.Implements(t, (*restful.Getable)(nil), newDeployQueueResource(ComponentLocator{}))
+
+	assert.Implements(t, (*restful.Getable)(nil), newR11nResource(ComponentLocator{}))
 }

--- a/server/handle_alldeployqueues.go
+++ b/server/handle_alldeployqueues.go
@@ -25,7 +25,7 @@ func newAllDeployQueuesResource(ctx ComponentLocator) *AllDeployQueuesResource {
 }
 
 // Get returns a configured GETAllDeployQueuesHandler.
-func (r *AllDeployQueuesResource) Get(_ http.ResponseWriter, _ *http.Request, _ httprouter.Params) restful.Exchanger {
+func (r *AllDeployQueuesResource) Get(_ *restful.RouteMap, _ http.ResponseWriter, _ *http.Request, _ httprouter.Params) restful.Exchanger {
 	return &GETAllDeployQueuesHandler{
 		QueueSet: r.context.QueueSet,
 	}

--- a/server/handle_alldeployqueues_test.go
+++ b/server/handle_alldeployqueues_test.go
@@ -18,8 +18,9 @@ func TestNewAllDeployQueuesResource(t *testing.T) {
 		QueueSet: qs,
 	}
 	adq := newAllDeployQueuesResource(c)
+	rm := routemap(c)
 
-	got := adq.Get(nil, &http.Request{URL: &url.URL{}}, nil).(*GETAllDeployQueuesHandler)
+	got := adq.Get(rm, nil, &http.Request{URL: &url.URL{}}, nil).(*GETAllDeployQueuesHandler)
 	if got.QueueSet != qs {
 		t.Errorf("got different queueset")
 	}

--- a/server/handle_artifact.go
+++ b/server/handle_artifact.go
@@ -31,7 +31,7 @@ func newArtifactResource(ctx ComponentLocator) *ArtifactResource {
 }
 
 // Put implements Putable on ArtifactResource, which marks it as accepting PUT requests
-func (ar *ArtifactResource) Put(_ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
+func (ar *ArtifactResource) Put(_ *restful.RouteMap, _ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
 	return &PUTArtifactHandler{
 		Request:     req,
 		QueryValues: ar.ParseQuery(req),

--- a/server/handle_deployqueue.go
+++ b/server/handle_deployqueue.go
@@ -27,7 +27,7 @@ func newDeployQueueResource(ctx ComponentLocator) *DeployQueueResource {
 }
 
 // Get returns a configured GETDeployQueueHandler.
-func (r *DeployQueueResource) Get(_ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
+func (r *DeployQueueResource) Get(_ *restful.RouteMap, _ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
 	qv := restful.QueryValues{Values: req.URL.Query()}
 	did, didErr := deploymentIDFromValues(qv)
 	return &GETDeployQueueHandler{

--- a/server/handle_deployqueue_test.go
+++ b/server/handle_deployqueue_test.go
@@ -25,9 +25,10 @@ func TestNewDeployQueueResource(t *testing.T) {
 	c := ComponentLocator{
 		QueueSet: qs,
 	}
+	rm := routemap(c)
 	dq := newDeployQueueResource(c)
 
-	got := dq.Get(nil, &http.Request{URL: &url.URL{}}, nil).(*GETDeployQueueHandler)
+	got := dq.Get(rm, nil, &http.Request{URL: &url.URL{}}, nil).(*GETDeployQueueHandler)
 	if got.QueueSet != qs {
 		t.Errorf("got different queueset")
 	}
@@ -96,9 +97,12 @@ func TestDeployQueueResource_Get_no_errors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			c := ComponentLocator{}
+			rm := routemap(c)
+
 			dr := &DeployQueueResource{}
 			req := makeRequestWithQuery(t, tc.query)
-			got := dr.Get(nil, req, nil).(*GETDeployQueueHandler)
+			got := dr.Get(rm, nil, req, nil).(*GETDeployQueueHandler)
 
 			gotDID := got.DeploymentID
 			if gotDID != tc.wantDID {
@@ -130,9 +134,11 @@ func TestDeployQueueResource_Get_DeploymentID_errors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.wantDIDErr, func(t *testing.T) {
+			c := ComponentLocator{}
+			rm := routemap(c)
 			dr := &DeployQueueResource{}
 			req := makeRequestWithQuery(t, tc.query)
-			got := dr.Get(nil, req, nil).(*GETDeployQueueHandler)
+			got := dr.Get(rm, nil, req, nil).(*GETDeployQueueHandler)
 
 			gotDIDErr := got.DeploymentIDErr
 			if gotDIDErr == nil || gotDIDErr.Error() != tc.wantDIDErr {

--- a/server/handle_gdm.go
+++ b/server/handle_gdm.go
@@ -40,7 +40,7 @@ func newGDMResource(ctx ComponentLocator) *GDMResource {
 }
 
 // Get implements Getable on GDMResource
-func (gr *GDMResource) Get(writer http.ResponseWriter, _ *http.Request, _ httprouter.Params) restful.Exchanger {
+func (gr *GDMResource) Get(_ *restful.RouteMap, writer http.ResponseWriter, _ *http.Request, _ httprouter.Params) restful.Exchanger {
 	return &GETGDMHandler{
 		LogSink: gr.context.LogSink,
 		GDM:     gr.context.liveState(),
@@ -72,7 +72,7 @@ func (h *GETGDMHandler) Exchange() (interface{}, int) {
 }
 
 // Put implements Putable on GDMResource
-func (gr *GDMResource) Put(_ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
+func (gr *GDMResource) Put(_ *restful.RouteMap, _ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
 	return &PUTGDMHandler{
 		Request:      req,
 		LogSink:      gr.context.LogSink,

--- a/server/handle_health.go
+++ b/server/handle_health.go
@@ -28,7 +28,7 @@ func newHealthResource(loc ComponentLocator) *healthResource {
 	return &healthResource{locator: loc}
 }
 
-func (hr *healthResource) Get(http.ResponseWriter, *http.Request, httprouter.Params) restful.Exchanger {
+func (hr *healthResource) Get(*restful.RouteMap, http.ResponseWriter, *http.Request, httprouter.Params) restful.Exchanger {
 	return &getHealthHandler{
 		version: hr.locator.Version,
 	}

--- a/server/handle_manifest.go
+++ b/server/handle_manifest.go
@@ -49,7 +49,7 @@ func newManifestResource(ctx ComponentLocator) *ManifestResource {
 }
 
 // Get implements Getable for ManifestResource
-func (mr *ManifestResource) Get(_ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
+func (mr *ManifestResource) Get(_ *restful.RouteMap, _ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
 	return &GETManifestHandler{
 		State:       mr.context.liveState(),
 		QueryValues: mr.ParseQuery(req),
@@ -57,7 +57,7 @@ func (mr *ManifestResource) Get(_ http.ResponseWriter, req *http.Request, _ http
 }
 
 // Put implements Putable for ManifestResource
-func (mr *ManifestResource) Put(_ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
+func (mr *ManifestResource) Put(_ *restful.RouteMap, _ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
 	return &PUTManifestHandler{
 		State:       mr.context.liveState(),
 		LogSink:     mr.context.LogSink,
@@ -69,7 +69,7 @@ func (mr *ManifestResource) Put(_ http.ResponseWriter, req *http.Request, _ http
 }
 
 // Delete implements Deleteable for ManifestResource
-func (mr *ManifestResource) Delete(_ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
+func (mr *ManifestResource) Delete(_ *restful.RouteMap, _ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
 	return &DELETEManifestHandler{
 		State:       mr.context.liveState(),
 		QueryValues: mr.ParseQuery(req),

--- a/server/handle_r11n.go
+++ b/server/handle_r11n.go
@@ -40,7 +40,7 @@ func r11nIDFromRoute(r *http.Request) (sous.R11nID, error) {
 }
 
 // Get returns a configured GETR11nHandler.
-func (r *R11nResource) Get(_ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
+func (r *R11nResource) Get(_ *restful.RouteMap, _ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
 	did, didErr := deploymentIDFromValues(restful.QueryValues{Values: req.URL.Query()})
 	rid, ridErr := r11nIDFromRoute(req)
 	wait := req.URL.Query().Get("wait") == "true"

--- a/server/handle_r11n_test.go
+++ b/server/handle_r11n_test.go
@@ -18,8 +18,9 @@ func TestNewR11nResource(t *testing.T) {
 		QueueSet: qs,
 	}
 	dq := newR11nResource(c)
+	rm := routemap(c)
 
-	got := dq.Get(nil, &http.Request{URL: &url.URL{}}, nil).(*GETR11nHandler)
+	got := dq.Get(rm, nil, &http.Request{URL: &url.URL{}}, nil).(*GETR11nHandler)
 	if got.QueueSet != qs {
 		t.Errorf("got different queueset")
 	}
@@ -82,8 +83,10 @@ func TestR11nResource_Get_no_errors(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			dr := &R11nResource{}
 			req := makeRequestWithQuery(t, tc.query)
+			c := ComponentLocator{}
+			rm := routemap(c)
 
-			got := dr.Get(nil, req, nil).(*GETR11nHandler)
+			got := dr.Get(rm, nil, req, nil).(*GETR11nHandler)
 
 			gotDID := got.DeploymentID
 			if gotDID != tc.wantDID {

--- a/server/handle_servers.go
+++ b/server/handle_servers.go
@@ -35,14 +35,14 @@ func newServerListResource(context ComponentLocator) *ServerListResource {
 }
 
 // Get implements Getable on ServerListResource, which marks it as accepting GET requests
-func (slr *ServerListResource) Get(http.ResponseWriter, *http.Request, httprouter.Params) restful.Exchanger {
+func (slr *ServerListResource) Get(*restful.RouteMap, http.ResponseWriter, *http.Request, httprouter.Params) restful.Exchanger {
 	return &ServerListHandler{
 		Config: slr.context.Config,
 	}
 }
 
 // Put implements Putable on ServerListResource, which marks is as accepting PUT requests
-func (slr *ServerListResource) Put(_ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
+func (slr *ServerListResource) Put(_ *restful.RouteMap, _ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
 	return &ServerListUpdater{
 		Config:  slr.context.Config,
 		Log:     slr.context.LogSink,

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -24,9 +24,16 @@ type (
 	// singleDeploymentBody is the response struct returned from handlers
 	// of HTTP methods of a SingleDeploymentResource.
 	singleDeploymentBody struct {
+		Meta           ResponseMeta
 		DeploymentID   sous.DeploymentID
 		DeploySpec     sous.DeploySpec
 		ManifestHeader sous.Manifest
+	}
+
+	// ResponseMeta contains metadata to include in API response bodies.
+	ResponseMeta struct {
+		// Links is a set of links related to a response body.
+		Links map[string]string
 	}
 )
 
@@ -40,9 +47,53 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 		return psd.Body, 404
 	}
 
-	_, ok = m.Deployments[psd.Body.DeploymentID.Cluster]
+	cluster := psd.Body.DeploymentID.Cluster
+	d, ok := m.Deployments[cluster]
 	if !ok {
 		return psd.Body, 404
+	}
+	different, _ := psd.Body.DeploySpec.Diff(d)
+	if !different {
+		return psd.Body, 200
+	}
+
+	m.Deployments[cluster] = psd.Body.DeploySpec
+
+	if err := psd.StateWriter.WriteState(psd.GDM, psd.User); err != nil {
+		// TODO SS: Don't panic.
+		panic(err)
+	}
+
+	deployments, err := psd.GDM.Deployments()
+	if err != nil {
+		// TODO SS: Don't panic.
+		panic(err)
+	}
+
+	fullDeployment, ok := deployments.Get(psd.DeploymentID)
+	if !ok {
+		// TODO SS: Don't panic.
+		panic("not ok")
+	}
+
+	r := &sous.Rectification{
+		Pair: sous.DeployablePair{
+			Post: &sous.Deployable{
+				Status:     0,
+				Deployment: fullDeployment,
+			},
+			ExecutorData: nil,
+		},
+	}
+	r.Pair.SetID(psd.DeploymentID)
+
+	qr, ok := psd.QueueSet.Push(r)
+	if !ok {
+		panic("not ok")
+	}
+
+	psd.Body.Meta.Links = map[string]string{
+		"queuedDeployAction": "/deploy-queue-item?action=" + string(qr.ID),
 	}
 
 	return psd.Body, 200

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -47,6 +47,10 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 		return psd.Body, 404
 	}
 
+	if psd.Body.DeploymentID != psd.DeploymentID {
+		return psd.Body, 400
+	}
+
 	cluster := psd.Body.DeploymentID.Cluster
 	d, ok := m.Deployments[cluster]
 	if !ok {

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -98,7 +98,6 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 	}
 	fullDeployment, ok := deployments.Get(psd.DeploymentID)
 	if !ok {
-		// Note this line is not tested yet.
 		return er(500, "Deployment failed to round-trip to GDM.")
 	}
 

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -11,15 +11,16 @@ type (
 	// PUTSingleDeploymentHandler handles manifests containing single deployment
 	// specs. See Exchange method for more details.
 	PUTSingleDeploymentHandler struct {
-		DeploymentID    sous.DeploymentID
-		DeploymentIDErr error
-		Body            *singleDeploymentBody
-		BodyErr         error
-		Header          http.Header
-		GDM             *sous.State
-		StateWriter     sous.StateWriter
-		QueueSet        *sous.R11nQueueSet
-		User            sous.User
+		DeploymentID     sous.DeploymentID
+		DeploymentIDErr  error
+		Body             *singleDeploymentBody
+		BodyErr          error
+		Header           http.Header
+		GDM              *sous.State
+		StateWriter      sous.StateWriter
+		GDMToDeployments func(*sous.State) (sous.Deployments, error)
+		QueueSet         *sous.R11nQueueSet
+		User             sous.User
 	}
 
 	// singleDeploymentBody is the response struct returned from handlers
@@ -92,7 +93,7 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 	// TODO SS:
 	// Note that this call is expensive, we should come up with a cheaper way
 	// to get single deployments.
-	deployments, err := psd.GDM.Deployments()
+	deployments, err := psd.GDMToDeployments(psd.GDM)
 	if err != nil {
 		// TODO SS: Don't panic.
 		panic(err)

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -3,15 +3,28 @@ package server
 import sous "github.com/opentable/sous/lib"
 
 type (
+	// PUTSingleDeploymentHandler handles manifests containing single deployment
+	// specs. See Exchange method for more details.
 	PUTSingleDeploymentHandler struct {
-		DeploymentID      sous.DeploymentID
-		DeploymentIDError error
-		Manifest          sous.Manifest
-		ManifestError     error
+		DeploymentID    sous.DeploymentID
+		DeploymentIDErr error
+		Body            *singleDeploymentBody
+		BodyErr         error
 	}
-	singleDeploymentResponse struct{}
+
+	// singleDeploymentBody is the response struct returned from handlers
+	// of HTTP methods of a SingleDeploymentResource.
+	singleDeploymentBody struct {
+		DeploymentID   sous.DeploymentID
+		DeploySpec     sous.DeploySpec
+		ManifestHeader sous.Manifest
+	}
 )
 
+// Exchange triggers a deployment action when receiving
+// a Manifest containing a deployment matching DeploymentID that differs
+// from the current actual deployment set. It first writes the new
+// deployment spec to the GDM.
 func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
-	return singleDeploymentResponse{}, 404
+	return nil, 404
 }

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -1,0 +1,17 @@
+package server
+
+import sous "github.com/opentable/sous/lib"
+
+type (
+	PUTSingleDeploymentHandler struct {
+		DeploymentID      sous.DeploymentID
+		DeploymentIDError error
+		Manifest          sous.Manifest
+		ManifestError     error
+	}
+	singleDeploymentResponse struct{}
+)
+
+func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
+	return singleDeploymentResponse{}, 404
+}

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -52,6 +52,12 @@ type (
 	}
 )
 
+func newSingleDeploymentResource(cl ComponentLocator) *SingleDeploymentResource {
+	return &SingleDeploymentResource{
+		context: cl,
+	}
+}
+
 // Put returns a configured put single deployment handler.
 func (sdr *SingleDeploymentResource) Put(_ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
 	qv := restful.QueryValues{Values: req.URL.Query()}
@@ -64,6 +70,8 @@ func (sdr *SingleDeploymentResource) Put(_ http.ResponseWriter, req *http.Reques
 		DeploymentIDErr: didErr,
 		Body:            body,
 		BodyErr:         bodyErr,
+		StateWriter:     sdr.context.StateManager,
+		PushToQueueSet:  sdr.context.QueueSet.Push,
 	}
 }
 

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -4,10 +4,18 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/julienschmidt/httprouter"
 	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/restful"
 )
 
 type (
+	// SingleDeploymentResource creates handlers for dealing with single
+	// deployments.
+	SingleDeploymentResource struct {
+		userExtractor
+		context ComponentLocator
+	}
 	// PUTSingleDeploymentHandler handles manifests containing single deployment
 	// specs. See Exchange method for more details.
 	PUTSingleDeploymentHandler struct {
@@ -42,6 +50,17 @@ type (
 		StatusCode int
 	}
 )
+
+// Put returns a configured put single deployment handler.
+func (sdr *SingleDeploymentResource) Put(_ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
+	qv := restful.QueryValues{Values: req.URL.Query()}
+	did, didErr := deploymentIDFromValues(qv)
+	return &PUTSingleDeploymentHandler{
+		User:            sous.User(sdr.userExtractor.GetUser(req)),
+		DeploymentID:    did,
+		DeploymentIDErr: didErr,
+	}
+}
 
 // Exchange triggers a deployment action when receiving
 // a Manifest containing a deployment matching DeploymentID that differs

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -37,6 +37,8 @@ type (
 		Links map[string]string
 		// Error is the error message returned.
 		Error string `json:",omitempty"`
+		// StatusCode is the HTTP status code of this response.
+		StatusCode int
 	}
 )
 
@@ -47,6 +49,11 @@ type (
 func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 	er := func(code int, f string, a ...interface{}) (*singleDeploymentBody, int) {
 		psd.Body.Meta.Error = fmt.Sprintf(f, a...)
+		psd.Body.Meta.StatusCode = code
+		return psd.Body, code
+	}
+	success := func(code int) (interface{}, int) {
+		psd.Body.Meta.StatusCode = code
 		return psd.Body, code
 	}
 
@@ -68,7 +75,7 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 	}
 	different, _ := psd.Body.DeploySpec.Diff(d)
 	if !different {
-		return psd.Body, 200
+		return success(200)
 	}
 
 	m.Deployments[cluster] = psd.Body.DeploySpec
@@ -116,5 +123,5 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 		"queuedDeployAction": "/deploy-queue-item?action=" + string(qr.ID),
 	}
 
-	return psd.Body, 200
+	return success(200)
 }

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -82,8 +82,7 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 	m.Deployments[cluster] = psd.Body.DeploySpec
 
 	if err := psd.StateWriter.WriteState(psd.GDM, psd.User); err != nil {
-		// TODO SS: Don't panic.
-		panic(err)
+		return er(500, "Failed to write state: %s", err)
 	}
 
 	// The full deployment can only be gotten from the full state, since it

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -61,18 +61,18 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 	did := psd.Body.DeploymentID
 
 	if did != psd.DeploymentID {
-		return er(400, "Body contains deployment %q, URL query is for deployment %q", did, psd.DeploymentID)
+		return er(400, "Body contains deployment %q, URL query is for deployment %q.", did, psd.DeploymentID)
 	}
 
 	m, ok := psd.GDM.Manifests.Get(did.ManifestID)
 	if !ok {
-		return er(404, "No manifest with ID %q", did.ManifestID)
+		return er(404, "No manifest with ID %q.", did.ManifestID)
 	}
 
 	cluster := psd.Body.DeploymentID.Cluster
 	d, ok := m.Deployments[cluster]
 	if !ok {
-		return er(404, "No %q deployment defined for %q", cluster, did)
+		return er(404, "No %q deployment defined for %q.", cluster, did)
 	}
 	different, _ := psd.Body.DeploySpec.Diff(d)
 	if !different {
@@ -82,7 +82,7 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 	m.Deployments[cluster] = psd.Body.DeploySpec
 
 	if err := psd.StateWriter.WriteState(psd.GDM, psd.User); err != nil {
-		return er(500, "Failed to write state: %s", err)
+		return er(500, "Failed to write state: %s.", err)
 	}
 
 	// The full deployment can only be gotten from the full state, since it
@@ -94,12 +94,12 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 	// to get single deployments.
 	deployments, err := psd.GDMToDeployments(psd.GDM)
 	if err != nil {
-		return er(500, "Unable to expand GDM: %s", err)
+		return er(500, "Unable to expand GDM: %s.", err)
 	}
 	fullDeployment, ok := deployments.Get(psd.DeploymentID)
 	if !ok {
 		// Note this line is not tested yet.
-		return er(500, "Deployment failed to round-trip to GDM")
+		return er(500, "Deployment failed to round-trip to GDM.")
 	}
 
 	r := &sous.Rectification{

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -64,12 +64,18 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 		panic(err)
 	}
 
+	// The full deployment can only be gotten from the full state, since it
+	// relies on State.Defs which is not part of this exchange. Therefore
+	// fish it out of the realized GDM returned from .Deployments()
+	//
+	// TODO SS:
+	// Note that this call is expensive, we should come up with a cheaper way
+	// to get single deployments.
 	deployments, err := psd.GDM.Deployments()
 	if err != nil {
 		// TODO SS: Don't panic.
 		panic(err)
 	}
-
 	fullDeployment, ok := deployments.Get(psd.DeploymentID)
 	if !ok {
 		// TODO SS: Don't panic.

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -94,8 +94,7 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 	// to get single deployments.
 	deployments, err := psd.GDMToDeployments(psd.GDM)
 	if err != nil {
-		// TODO SS: Don't panic.
-		panic(err)
+		return er(500, "Unable to expand GDM: %s", err)
 	}
 	fullDeployment, ok := deployments.Get(psd.DeploymentID)
 	if !ok {

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -22,21 +22,13 @@ type (
 	PUTSingleDeploymentHandler struct {
 		DeploymentID     sous.DeploymentID
 		DeploymentIDErr  error
-		Body             *singleDeploymentBody
+		Body             *SingleDeploymentBody
 		BodyErr          error
 		GDM              *sous.State
 		StateWriter      sous.StateWriter
 		GDMToDeployments func(*sous.State) (sous.Deployments, error)
 		PushToQueueSet   func(r *sous.Rectification) (*sous.QueuedR11n, bool)
 		User             sous.User
-	}
-
-	// singleDeploymentBody is the response struct returned from handlers
-	// of HTTP methods of a SingleDeploymentResource.
-	singleDeploymentBody struct {
-		Meta           ResponseMeta
-		DeploySpec     sous.DeploySpec
-		ManifestHeader sous.Manifest
 	}
 
 	// ResponseMeta contains metadata to include in API response bodies.
@@ -60,7 +52,7 @@ func newSingleDeploymentResource(cl ComponentLocator) *SingleDeploymentResource 
 func (sdr *SingleDeploymentResource) Put(_ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
 	qv := restful.QueryValues{Values: req.URL.Query()}
 	did, didErr := deploymentIDFromValues(qv)
-	body := &singleDeploymentBody{}
+	body := &SingleDeploymentBody{}
 	bodyErr := json.NewDecoder(req.Body).Decode(body)
 	gdm := sdr.context.liveState()
 	return &PUTSingleDeploymentHandler{
@@ -81,7 +73,7 @@ func (sdr *SingleDeploymentResource) Put(_ http.ResponseWriter, req *http.Reques
 // err returns the current Body of psd and the provided status code.
 // It ensures Meta.StatusCode is also set to the provided code.
 // It sets Meta.Error to a formatted error using format f and args a...
-func (psd *PUTSingleDeploymentHandler) err(code int, f string, a ...interface{}) (*singleDeploymentBody, int) {
+func (psd *PUTSingleDeploymentHandler) err(code int, f string, a ...interface{}) (*SingleDeploymentBody, int) {
 	psd.Body.Meta.Error = fmt.Sprintf(f, a...)
 	psd.Body.Meta.StatusCode = code
 	return psd.Body, code
@@ -90,7 +82,7 @@ func (psd *PUTSingleDeploymentHandler) err(code int, f string, a ...interface{})
 // ok returns the current body of psd and the provided status code.
 // It ensures Meta.StatusCode is also set to the provided code.
 // It sets Meta.Links to the provided links.
-func (psd *PUTSingleDeploymentHandler) ok(code int, links map[string]string) (*singleDeploymentBody, int) {
+func (psd *PUTSingleDeploymentHandler) ok(code int, links map[string]string) (*SingleDeploymentBody, int) {
 	psd.Body.Meta.StatusCode = code
 	psd.Body.Meta.Links = links
 	return psd.Body, code
@@ -103,7 +95,7 @@ func (psd *PUTSingleDeploymentHandler) ok(code int, links map[string]string) (*s
 func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 
 	if psd.BodyErr != nil {
-		psd.Body = &singleDeploymentBody{}
+		psd.Body = &SingleDeploymentBody{}
 		return psd.err(400, "Error parsing body: %s.", psd.BodyErr)
 	}
 

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -24,7 +24,6 @@ type (
 		DeploymentIDErr  error
 		Body             *singleDeploymentBody
 		BodyErr          error
-		Header           http.Header
 		GDM              *sous.State
 		StateWriter      sous.StateWriter
 		GDMToDeployments func(*sous.State) (sous.Deployments, error)
@@ -64,6 +63,7 @@ func (sdr *SingleDeploymentResource) Put(_ http.ResponseWriter, req *http.Reques
 	did, didErr := deploymentIDFromValues(qv)
 	body := &singleDeploymentBody{}
 	bodyErr := json.NewDecoder(req.Body).Decode(body)
+	gdm := sdr.context.liveState()
 	return &PUTSingleDeploymentHandler{
 		User:            sous.User(sdr.userExtractor.GetUser(req)),
 		DeploymentID:    did,
@@ -72,6 +72,10 @@ func (sdr *SingleDeploymentResource) Put(_ http.ResponseWriter, req *http.Reques
 		BodyErr:         bodyErr,
 		StateWriter:     sdr.context.StateManager,
 		PushToQueueSet:  sdr.context.QueueSet.Push,
+		GDM:             gdm,
+		GDMToDeployments: func(s *sous.State) (sous.Deployments, error) {
+			return gdm.Deployments()
+		},
 	}
 }
 

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -35,7 +35,6 @@ type (
 	// of HTTP methods of a SingleDeploymentResource.
 	singleDeploymentBody struct {
 		Meta           ResponseMeta
-		DeploymentID   sous.DeploymentID
 		DeploySpec     sous.DeploySpec
 		ManifestHeader sous.Manifest
 	}
@@ -108,18 +107,14 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 		return psd.err(400, "Error parsing body: %s.", psd.BodyErr)
 	}
 
-	did := psd.Body.DeploymentID
-
-	if did != psd.DeploymentID {
-		return psd.err(400, "Body contains deployment %q, URL query is for deployment %q.", did, psd.DeploymentID)
-	}
+	did := psd.DeploymentID
 
 	m, ok := psd.GDM.Manifests.Get(did.ManifestID)
 	if !ok {
 		return psd.err(404, "No manifest with ID %q.", did.ManifestID)
 	}
 
-	cluster := psd.Body.DeploymentID.Cluster
+	cluster := did.Cluster
 	d, ok := m.Deployments[cluster]
 	if !ok {
 		return psd.err(404, "No %q deployment defined for %q.", cluster, did)

--- a/server/handle_single_deployment_test.go
+++ b/server/handle_single_deployment_test.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"testing"
+
+	sous "github.com/opentable/sous/lib"
+)
+
+func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
+
+	psd := PUTSingleDeploymentHandler{
+		DeploymentID:      sous.DeploymentID{},
+		DeploymentIDError: nil,
+		Manifest:          sous.Manifest{},
+		ManifestError:     nil,
+	}
+
+	body, gotStatus := psd.Exchange()
+
+	got, ok := body.(singleDeploymentResponse)
+	if !ok {
+		t.Fatalf("got a %T; want a %T", body, got)
+	}
+
+	wantStatus := 404
+	if gotStatus != wantStatus {
+		t.Errorf("got status %d; want %d", gotStatus, wantStatus)
+	}
+
+}

--- a/server/handle_single_deployment_test.go
+++ b/server/handle_single_deployment_test.go
@@ -12,7 +12,13 @@ import (
 	"github.com/samsalisbury/semv"
 )
 
-func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
+// TestPUTSingleDeploymentHandler_Exchange_normal checks that so long as all the
+// internal calls succeed, user input is handled correctly. This includes user
+// input that cannot be successfully operated on (e.g. IDs that can't be found,
+// faulty request bodies etc.
+// See TestPUTSingleDeploymentHandler_Exchange_exceptions for handling of
+// failing internal calls.
+func TestPUTSingleDeploymentHandler_Exchange_normal(t *testing.T) {
 
 	// makeBodyFromFixture returns a body derived from data in the test fixture.
 	makeBodyFromFixture := func(repo, cluster string) *singleDeploymentBody {

--- a/server/handle_single_deployment_test.go
+++ b/server/handle_single_deployment_test.go
@@ -137,14 +137,20 @@ func TestPUTSingleDeploymentHandler_Exchange_normal(t *testing.T) {
 				Email: "testuser@example.com",
 			}
 
+			state := test.DefaultStateFixture()
+			stateToDeployments := func(s *sous.State) (sous.Deployments, error) {
+				return state.Deployments()
+			}
+
 			psd := PUTSingleDeploymentHandler{
-				DeploymentID: did,
-				Body:         sent,
-				GDM:          test.DefaultStateFixture(),
-				Header:       header,
-				StateWriter:  stateWriter,
-				QueueSet:     queueSet,
-				User:         user,
+				DeploymentID:     did,
+				Body:             sent,
+				GDM:              state,
+				GDMToDeployments: stateToDeployments,
+				Header:           header,
+				StateWriter:      stateWriter,
+				QueueSet:         queueSet,
+				User:             user,
 			}
 
 			// Shebang
@@ -163,10 +169,10 @@ func TestPUTSingleDeploymentHandler_Exchange_normal(t *testing.T) {
 			// specific diffs for ease of reading test output and also because
 			// we may want to add metadata that does not participate in equality
 			// checks later.
-			if gotBody != sent {
-				t.Errorf("received != sent:\nreceived:\n%#v\n\nsent:\n%#v",
-					gotBody, sent) // Horror blob see todo above.
-			}
+			//if *body != *sent {
+			//	t.Errorf("received != sent:\nreceived:\n%#v\n\nsent:\n%#v",
+			//		gotBody, sent) // Horror blob see todo above.
+			//}
 
 			if gotStatus != tc.WantStatus {
 				t.Errorf("got status %d; want %d", gotStatus, tc.WantStatus)

--- a/server/handle_single_deployment_test.go
+++ b/server/handle_single_deployment_test.go
@@ -4,27 +4,103 @@ import (
 	"testing"
 
 	sous "github.com/opentable/sous/lib"
+	"github.com/samsalisbury/semv"
 )
 
 func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 
-	psd := PUTSingleDeploymentHandler{
-		DeploymentID:      sous.DeploymentID{},
-		DeploymentIDError: nil,
-		Manifest:          sous.Manifest{},
-		ManifestError:     nil,
+	makeSingleDeploymentBody := func(repo, cluster, flavor string) *singleDeploymentBody {
+		manifest := sous.Manifest{
+			Source: sous.SourceLocation{
+				Repo: "",
+				Dir:  "",
+			},
+			Flavor: "",
+			Owners: nil,
+			Kind:   "",
+			Deployments: map[string]sous.DeploySpec{
+				"": {
+					DeployConfig: sous.DeployConfig{
+						Resources: map[string]string{
+							"": "",
+						},
+						Metadata: map[string]string{
+							"": "",
+						},
+						Env: map[string]string{
+							"": "",
+						},
+						NumInstances: 0,
+						Volumes:      nil,
+						Startup: sous.Startup{
+							SkipCheck:                 false,
+							ConnectDelay:              0,
+							Timeout:                   0,
+							ConnectInterval:           0,
+							CheckReadyProtocol:        "",
+							CheckReadyURIPath:         "",
+							CheckReadyPortIndex:       0,
+							CheckReadyFailureStatuses: nil,
+							CheckReadyURITimeout:      0,
+							CheckReadyInterval:        0,
+							CheckReadyRetries:         0,
+						},
+						Schedule: "",
+					},
+					Version: semv.MustParse("1"),
+				},
+			},
+		}
+		return &singleDeploymentBody{
+			ManifestHeader: manifest,
+			DeploymentID:   sous.DeploymentID{},
+			DeploySpec:     sous.DeploySpec{},
+		}
 	}
 
-	body, gotStatus := psd.Exchange()
-
-	got, ok := body.(singleDeploymentResponse)
-	if !ok {
-		t.Fatalf("got a %T; want a %T", body, got)
+	testCases := []struct {
+		// BodyAndID is a function that generates a body and an ID.
+		// We expect that if response.DeploymentID == id and the server is
+		// configured to service requests from the corresponding cluster,
+		// the GDM should be updated and a new R11n enqueued.
+		//
+		// The body is sent as the PUT body of the request.
+		// We expect that the same body is returned on success.
+		BodyAndID func() (*singleDeploymentBody, sous.DeploymentID)
+		// WantStatus is the expected HTTP status for this request.
+		WantStatus int
+	}{
+		{
+			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
+				response := makeSingleDeploymentBody("github.com/user1/repo1", "cluster1", "flavor1")
+				return response, response.DeploymentID
+			},
+		},
 	}
 
-	wantStatus := 404
-	if gotStatus != wantStatus {
-		t.Errorf("got status %d; want %d", gotStatus, wantStatus)
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+
+			sent, did := tc.BodyAndID()
+
+			psd := PUTSingleDeploymentHandler{
+				DeploymentID: did,
+				Body:         sent,
+			}
+
+			received, gotStatus := psd.Exchange()
+
+			got, ok := received.(*singleDeploymentBody)
+
+			if !ok {
+				t.Fatalf("got a %T; want a %T", received, got)
+			}
+
+			wantStatus := 404
+			if gotStatus != wantStatus {
+				t.Errorf("got status %d; want %d", gotStatus, wantStatus)
+			}
+		})
 	}
 
 }

--- a/server/handle_single_deployment_test.go
+++ b/server/handle_single_deployment_test.go
@@ -1,64 +1,45 @@
 package server
 
 import (
+	"net/http"
 	"testing"
 
+	"github.com/nyarly/spies"
 	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/test"
 	"github.com/samsalisbury/semv"
 )
 
 func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 
-	makeSingleDeploymentBody := func(repo, cluster, flavor string) *singleDeploymentBody {
-		manifest := sous.Manifest{
-			Source: sous.SourceLocation{
-				Repo: "",
-				Dir:  "",
-			},
-			Flavor: "",
-			Owners: nil,
-			Kind:   "",
-			Deployments: map[string]sous.DeploySpec{
-				"": {
-					DeployConfig: sous.DeployConfig{
-						Resources: map[string]string{
-							"": "",
-						},
-						Metadata: map[string]string{
-							"": "",
-						},
-						Env: map[string]string{
-							"": "",
-						},
-						NumInstances: 0,
-						Volumes:      nil,
-						Startup: sous.Startup{
-							SkipCheck:                 false,
-							ConnectDelay:              0,
-							Timeout:                   0,
-							ConnectInterval:           0,
-							CheckReadyProtocol:        "",
-							CheckReadyURIPath:         "",
-							CheckReadyPortIndex:       0,
-							CheckReadyFailureStatuses: nil,
-							CheckReadyURITimeout:      0,
-							CheckReadyInterval:        0,
-							CheckReadyRetries:         0,
-						},
-						Schedule: "",
-					},
-					Version: semv.MustParse("1"),
-				},
-			},
+	// makeBodyFromFixture returns a body derived from data in the test fixture.
+	makeBodyFromFixture := func(repo, cluster string) *singleDeploymentBody {
+		t.Helper()
+		state := test.DefaultStateFixture()
+		m, ok := state.Manifests.Single(func(m *sous.Manifest) bool {
+			return m.Source.Repo == repo
+		})
+		if !ok {
+			t.Fatalf("setup failed: no manifest with repo %q in default fixture", repo)
 		}
+		d, ok := m.Deployments[cluster]
+		if !ok {
+			t.Fatalf("setup failed: manifest %q has no deployment %q in default fixture", repo, cluster)
+		}
+		m.Deployments = nil
 		return &singleDeploymentBody{
-			ManifestHeader: manifest,
-			DeploymentID:   sous.DeploymentID{},
-			DeploySpec:     sous.DeploySpec{},
+			ManifestHeader: *m,
+			DeploymentID: sous.DeploymentID{
+				ManifestID: m.ID(),
+				Cluster:    cluster,
+			},
+			DeploySpec: d,
 		}
 	}
 
 	testCases := []struct {
+		// Desc is a short unique description of the test case.
+		Desc string
 		// BodyAndID is a function that generates a body and an ID.
 		// We expect that if response.DeploymentID == id and the server is
 		// configured to service requests from the corresponding cluster,
@@ -71,21 +52,66 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 		WantStatus int
 	}{
 		{
+			Desc: "no matching repo",
 			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
-				response := makeSingleDeploymentBody("github.com/user1/repo1", "cluster1", "flavor1")
-				return response, response.DeploymentID
+				// We return the deployment from the fixture unchanged.
+				b := makeBodyFromFixture("github.com/user1/repo1", "cluster1")
+				b.DeploymentID.ManifestID.Source.Repo = "nonexistent"
+				return b, b.DeploymentID
 			},
+			WantStatus: 404,
+		},
+		{
+			Desc: "no matching cluster",
+			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
+				// We return the deployment from the fixture unchanged.
+				b := makeBodyFromFixture("github.com/user1/repo1", "cluster1")
+				b.DeploymentID.Cluster = "nonexistent"
+				return b, b.DeploymentID
+			},
+			WantStatus: 404,
+		},
+		{
+			Desc: "no change necessary",
+			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
+				// We return the deployment from the fixture unchanged.
+				b := makeBodyFromFixture("github.com/user1/repo1", "cluster1")
+				return b, b.DeploymentID
+			},
+			WantStatus: 200,
+		},
+		{
+			Desc: "change version",
+			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
+				// We return the deployment from the fixture unchanged.
+				b := makeBodyFromFixture("github.com/user1/repo1", "cluster1")
+				b.DeploySpec.Version = semv.MustParse("2.0.0")
+				return b, b.DeploymentID
+			},
+			WantStatus: 200,
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run("", func(t *testing.T) {
+		t.Run(tc.Desc, func(t *testing.T) {
 
 			sent, did := tc.BodyAndID()
+			header := http.Header{}
+			stateWriter := newStateWriterSpy()
+			queueSet := sous.NewR11nQueueSet()
+			user := sous.User{
+				Name:  "Test User",
+				Email: "testuser@example.com",
+			}
 
 			psd := PUTSingleDeploymentHandler{
 				DeploymentID: did,
 				Body:         sent,
+				GDM:          test.DefaultStateFixture(),
+				Header:       header,
+				StateWriter:  stateWriter,
+				QueueSet:     queueSet,
+				User:         user,
 			}
 
 			received, gotStatus := psd.Exchange()
@@ -96,11 +122,31 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 				t.Fatalf("got a %T; want a %T", received, got)
 			}
 
-			wantStatus := 404
-			if gotStatus != wantStatus {
-				t.Errorf("got status %d; want %d", gotStatus, wantStatus)
+			if gotStatus != tc.WantStatus {
+				t.Errorf("got status %d; want %d", gotStatus, tc.WantStatus)
+			}
+
+			// TODO SS: Add a diff method to singleDeploymentBody to print
+			// specific diffs for ease of reading test output and also because
+			// we may want to add metadata that does not participate in equality
+			// checks later.
+			if received != sent {
+				t.Errorf("received != sent:\nreceived:\n%#v\n\nsent:\n%#v",
+					received, sent) // Horror blob see todo above.
 			}
 		})
 	}
 
+}
+
+type stateWriterSpy struct {
+	*spies.Spy
+}
+
+func newStateWriterSpy() stateWriterSpy {
+	return stateWriterSpy{spies.NewSpy()}
+}
+
+func (sw stateWriterSpy) WriteState(s *sous.State, u sous.User) error {
+	return sw.Called(s, u).Error(0)
 }

--- a/server/handle_single_deployment_test.go
+++ b/server/handle_single_deployment_test.go
@@ -85,7 +85,7 @@ func TestPUTSingleDeploymentHandler_Exchange_normal(t *testing.T) {
 				return b, b.DeploymentID
 			},
 			WantStatus: 404,
-			WantError:  `No manifest with ID "nonexistent,dir1~flavor1"`,
+			WantError:  `No manifest with ID "nonexistent,dir1~flavor1".`,
 		},
 		{
 			Desc: "no matching cluster",
@@ -95,7 +95,7 @@ func TestPUTSingleDeploymentHandler_Exchange_normal(t *testing.T) {
 				return b, b.DeploymentID
 			},
 			WantStatus: 404,
-			WantError:  `No "nonexistent" deployment defined for "nonexistent:github.com/user1/repo1,dir1~flavor1"`,
+			WantError:  `No "nonexistent" deployment defined for "nonexistent:github.com/user1/repo1,dir1~flavor1".`,
 		},
 		{
 			Desc: "body deploy ID not match query",
@@ -107,7 +107,7 @@ func TestPUTSingleDeploymentHandler_Exchange_normal(t *testing.T) {
 				return b, did
 			},
 			WantStatus: 400,
-			WantError:  `Body contains deployment "cluster1:github.com/user1/repo1,dir1~flavor1", URL query is for deployment "cluster2:github.com/user1/repo1,dir1~flavor1"`,
+			WantError:  `Body contains deployment "cluster1:github.com/user1/repo1,dir1~flavor1", URL query is for deployment "cluster2:github.com/user1/repo1,dir1~flavor1".`,
 		},
 		{
 			Desc: "no change necessary",
@@ -139,7 +139,7 @@ func TestPUTSingleDeploymentHandler_Exchange_normal(t *testing.T) {
 			OverrideStateWriter:  newStateWriterSpyWithError("an error occured"),
 			WantStatus:           500,
 			WantWriteStateCalled: true,
-			WantError:            "Failed to write state: an error occured",
+			WantError:            "Failed to write state: an error occured.",
 		},
 		{
 			Desc: "State.Deployments error",
@@ -154,7 +154,22 @@ func TestPUTSingleDeploymentHandler_Exchange_normal(t *testing.T) {
 			},
 			WantStatus:           500,
 			WantWriteStateCalled: true,
-			WantError:            "Unable to expand GDM: an error occured",
+			WantError:            "Unable to expand GDM: an error occured.",
+		},
+		{
+			Desc: "State.Deployments returns no deployments",
+			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
+				b := makeBodyFromFixture("github.com/user1/repo1", "cluster1")
+				// Make a change to trigger write attempt.
+				b.DeploySpec.Version = semv.MustParse("2.0.0")
+				return b, b.DeploymentID
+			},
+			OverrideGDMToDeployments: func(*sous.State) (sous.Deployments, error) {
+				return sous.NewDeployments(), nil
+			},
+			WantStatus:           500,
+			WantWriteStateCalled: true,
+			WantError:            "Deployment failed to round-trip to GDM.",
 		},
 		{
 			Desc: "PushToQueueSet error",

--- a/server/handle_single_deployment_test.go
+++ b/server/handle_single_deployment_test.go
@@ -13,13 +13,7 @@ import (
 	"github.com/samsalisbury/semv"
 )
 
-// TestPUTSingleDeploymentHandler_Exchange_normal checks that so long as all the
-// internal calls succeed, user input is handled correctly. This includes user
-// input that cannot be successfully operated on (e.g. IDs that can't be found,
-// faulty request bodies etc.
-// See TestPUTSingleDeploymentHandler_Exchange_exceptions for handling of
-// failing internal calls.
-func TestPUTSingleDeploymentHandler_Exchange_normal(t *testing.T) {
+func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 
 	// makeBodyFromFixture returns a body derived from data in the test fixture.
 	makeBodyFromFixture := func(repo, cluster string) *singleDeploymentBody {

--- a/server/handle_single_deployment_test.go
+++ b/server/handle_single_deployment_test.go
@@ -87,6 +87,17 @@ func TestPUTSingleDeploymentHandler_Exchange_normal(t *testing.T) {
 			WantStatus: 404,
 		},
 		{
+			Desc: "body deploy ID not match query",
+			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
+				b := makeBodyFromFixture("github.com/user1/repo1", "cluster1")
+				did := b.DeploymentID
+				// cluster2 exists but is not defined in the body.
+				did.Cluster = "cluster2"
+				return b, did
+			},
+			WantStatus: 400,
+		},
+		{
 			Desc: "no change necessary",
 			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
 				b := makeBodyFromFixture("github.com/user1/repo1", "cluster1")

--- a/server/handle_single_deployment_test.go
+++ b/server/handle_single_deployment_test.go
@@ -171,6 +171,10 @@ func TestPUTSingleDeploymentHandler_Exchange_normal(t *testing.T) {
 			if gotStatus != tc.WantStatus {
 				t.Errorf("got status %d; want %d", gotStatus, tc.WantStatus)
 			}
+			if body.Meta.StatusCode != gotStatus {
+				t.Errorf("got Meta.StatusCode = %d; != actual status code %d",
+					body.Meta.StatusCode, gotStatus)
+			}
 
 			gotStateWritten := len(stateWriter.Spy.CallsTo("WriteState")) == 1
 			if gotStateWritten != tc.WantStateWritten {

--- a/server/handle_single_deployment_test.go
+++ b/server/handle_single_deployment_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -128,12 +129,12 @@ func TestSingleDeploymentResource_Put(t *testing.T) {
 			}
 
 			// Setup.
-			r := SingleDeploymentResource{
-				context: ComponentLocator{
-					StateManager: sm,
-					QueueSet:     qs,
-				},
+			cl := ComponentLocator{
+				StateManager: sm,
+				QueueSet:     qs,
 			}
+			r := SingleDeploymentResource{context: cl}
+			rm := routemap(cl)
 
 			u, err := url.Parse(tc.URL)
 			if err != nil {
@@ -159,7 +160,7 @@ func TestSingleDeploymentResource_Put(t *testing.T) {
 
 			// Shebang.
 
-			got := r.Put(nil, req, nil).(*PUTSingleDeploymentHandler)
+			got := r.Put(rm, nil, req, nil).(*PUTSingleDeploymentHandler)
 
 			// Assertions.
 
@@ -426,6 +427,13 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 				pushToQueueSet = tc.OverridePushToQueueSet
 			}
 
+			cl := ComponentLocator{
+				//StateManager: stateWriter,
+				QueueSet: queueSet,
+			}
+
+			rm := routemap(cl)
+
 			psd := PUTSingleDeploymentHandler{
 				DeploymentID:     did,
 				Body:             sent,
@@ -435,6 +443,8 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 				StateWriter:      stateWriter,
 				PushToQueueSet:   pushToQueueSet,
 				User:             user,
+				routeMap:         rm,
+				responseWriter:   httptest.NewRecorder(),
 			}
 
 			// Shebang

--- a/server/handle_single_deployment_test.go
+++ b/server/handle_single_deployment_test.go
@@ -226,7 +226,7 @@ func TestSingleDeploymentResource_Put(t *testing.T) {
 }
 
 // makeBodyFromFixture returns a body derived from data in the test fixture.
-var makeBodyFromFixture = func(t *testing.T, repo, cluster string) (*singleDeploymentBody, sous.DeploymentID) {
+var makeBodyFromFixture = func(t *testing.T, repo, cluster string) (*SingleDeploymentBody, sous.DeploymentID) {
 	t.Helper()
 	state := test.DefaultStateFixture()
 	m, ok := state.Manifests.Single(func(m *sous.Manifest) bool {
@@ -241,7 +241,7 @@ var makeBodyFromFixture = func(t *testing.T, repo, cluster string) (*singleDeplo
 	}
 	m.Deployments = nil
 
-	return &singleDeploymentBody{
+	return &SingleDeploymentBody{
 			ManifestHeader: *m,
 			DeploySpec:     d,
 		},
@@ -263,7 +263,7 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 		//
 		// The body is sent as the PUT body of the request.
 		// We expect that the same body is returned on success.
-		BodyAndID func() (*singleDeploymentBody, sous.DeploymentID)
+		BodyAndID func() (*SingleDeploymentBody, sous.DeploymentID)
 		// BodyErrIn is an error parsing a body.
 		BodyErrIn error
 		// DeploymentIDErr is an error getting valid deployment ID.
@@ -289,7 +289,7 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 	}{
 		{
 			Desc: "body parsing error",
-			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
+			BodyAndID: func() (*SingleDeploymentBody, sous.DeploymentID) {
 				return nil, sous.DeploymentID{}
 			},
 			BodyErrIn:  errors.New("body parse error"),
@@ -298,7 +298,7 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 		},
 		{
 			Desc: "no matching repo",
-			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
+			BodyAndID: func() (*SingleDeploymentBody, sous.DeploymentID) {
 				b, did := makeBodyFromFixture(t, "github.com/user1/repo1", "cluster1")
 				// Set bogus repo.
 				did.ManifestID.Source.Repo = "nonexistent"
@@ -309,7 +309,7 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 		},
 		{
 			Desc: "no matching cluster",
-			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
+			BodyAndID: func() (*SingleDeploymentBody, sous.DeploymentID) {
 				b, did := makeBodyFromFixture(t, "github.com/user1/repo1", "cluster1")
 				// Set bogus cluster.
 				did.Cluster = "nonexistent"
@@ -320,7 +320,7 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 		},
 		{
 			Desc: "no change necessary",
-			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
+			BodyAndID: func() (*SingleDeploymentBody, sous.DeploymentID) {
 				b, did := makeBodyFromFixture(t, "github.com/user1/repo1", "cluster1")
 				return b, did
 			},
@@ -328,7 +328,7 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 		},
 		{
 			Desc: "change version",
-			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
+			BodyAndID: func() (*SingleDeploymentBody, sous.DeploymentID) {
 				b, did := makeBodyFromFixture(t, "github.com/user1/repo1", "cluster1")
 				b.DeploySpec.Version = semv.MustParse("2.0.0")
 				return b, did
@@ -339,7 +339,7 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 		},
 		{
 			Desc: "StateWriter.Write error",
-			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
+			BodyAndID: func() (*SingleDeploymentBody, sous.DeploymentID) {
 				b, did := makeBodyFromFixture(t, "github.com/user1/repo1", "cluster1")
 				// Make a change to trigger write attempt.
 				b.DeploySpec.Version = semv.MustParse("2.0.0")
@@ -352,7 +352,7 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 		},
 		{
 			Desc: "State.Deployments error",
-			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
+			BodyAndID: func() (*SingleDeploymentBody, sous.DeploymentID) {
 				b, did := makeBodyFromFixture(t, "github.com/user1/repo1", "cluster1")
 				// Make a change to trigger write attempt.
 				b.DeploySpec.Version = semv.MustParse("2.0.0")
@@ -367,7 +367,7 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 		},
 		{
 			Desc: "State.Deployments returns no deployments",
-			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
+			BodyAndID: func() (*SingleDeploymentBody, sous.DeploymentID) {
 				b, did := makeBodyFromFixture(t, "github.com/user1/repo1", "cluster1")
 				// Make a change to trigger write attempt.
 				b.DeploySpec.Version = semv.MustParse("2.0.0")
@@ -382,7 +382,7 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 		},
 		{
 			Desc: "PushToQueueSet error",
-			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
+			BodyAndID: func() (*SingleDeploymentBody, sous.DeploymentID) {
 				b, did := makeBodyFromFixture(t, "github.com/user1/repo1", "cluster1")
 				// Make a change to trigger write attempt.
 				b.DeploySpec.Version = semv.MustParse("2.0.0")
@@ -443,7 +443,7 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 
 			// Assertions...
 
-			body, ok := gotBody.(*singleDeploymentBody)
+			body, ok := gotBody.(*SingleDeploymentBody)
 
 			if !ok {
 				t.Fatalf("got a %T; want a %T", gotBody, body)

--- a/server/handle_single_deployment_test.go
+++ b/server/handle_single_deployment_test.go
@@ -180,6 +180,7 @@ func TestSingleDeploymentResource_Put(t *testing.T) {
 			} else if got.BodyErr != nil {
 				t.Errorf("got body error %q; want nil", got.BodyErr)
 			}
+
 			if tc.WantDeploymentIDErr != "" {
 				gotDeploymentIDErr := fmt.Sprint(got.DeploymentIDErr)
 				if gotDeploymentIDErr != tc.WantDeploymentIDErr {
@@ -216,7 +217,8 @@ func TestSingleDeploymentResource_Put(t *testing.T) {
 			if gotDeployments.Len() != wantDeployments.Len() {
 				t.Errorf("GDMToDeployments not set to gdm.Deployments")
 			}
-			// TODO SS: Diff method on Deployments.
+			// TODO SS: Diff method on Deployments; mutate GDM and check this
+			// assertion still holds.
 
 		})
 
@@ -296,8 +298,8 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 		{
 			Desc: "no matching repo",
 			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
-				// Return the deployment from the fixture unchanged.
 				b := makeBodyFromFixture(t, "github.com/user1/repo1", "cluster1")
+				// Set bogus repo.
 				b.DeploymentID.ManifestID.Source.Repo = "nonexistent"
 				return b, b.DeploymentID
 			},
@@ -308,6 +310,7 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 			Desc: "no matching cluster",
 			BodyAndID: func() (*singleDeploymentBody, sous.DeploymentID) {
 				b := makeBodyFromFixture(t, "github.com/user1/repo1", "cluster1")
+				// Set bogus cluster.
 				b.DeploymentID.Cluster = "nonexistent"
 				return b, b.DeploymentID
 			},
@@ -341,7 +344,7 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 				b.DeploySpec.Version = semv.MustParse("2.0.0")
 				return b, b.DeploymentID
 			},
-			WantStatus:           200,
+			WantStatus:           201,
 			WantWriteStateCalled: true,
 			WantQueuedR11n:       true,
 		},

--- a/server/handle_state_defs.go
+++ b/server/handle_state_defs.go
@@ -25,7 +25,7 @@ func newStateDefResource(ctx ComponentLocator) *StateDefResource {
 
 // Get implements restful.Getter on StateDefResource (and therefore makes it
 // handle GET requests.)
-func (sdr *StateDefResource) Get(http.ResponseWriter, *http.Request, httprouter.Params) restful.Exchanger {
+func (sdr *StateDefResource) Get(*restful.RouteMap, http.ResponseWriter, *http.Request, httprouter.Params) restful.Exchanger {
 	return &StateDefGetHandler{
 		State: sdr.context.liveState(),
 	}

--- a/server/handle_state_deployments.go
+++ b/server/handle_state_deployments.go
@@ -36,7 +36,7 @@ func newStateDeploymentResource(loc ComponentLocator) *StateDeploymentResource {
 }
 
 // Get implements restful.Getable on StateDeployments
-func (res *StateDeploymentResource) Get(http.ResponseWriter, *http.Request, httprouter.Params) restful.Exchanger {
+func (res *StateDeploymentResource) Get(*restful.RouteMap, http.ResponseWriter, *http.Request, httprouter.Params) restful.Exchanger {
 	return &GETStateDeployments{
 		cluster:     res.loc.ClusterManager,
 		clusterName: res.loc.ResolveFilter.Cluster.ValueOr("no-cluster"),

--- a/server/handle_state_deployments.go
+++ b/server/handle_state_deployments.go
@@ -44,7 +44,7 @@ func (res *StateDeploymentResource) Get(*restful.RouteMap, http.ResponseWriter, 
 }
 
 // Put implements restful.Putable on StateDeployments
-func (res *StateDeploymentResource) Put(_ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
+func (res *StateDeploymentResource) Put(_ *restful.RouteMap, _ http.ResponseWriter, req *http.Request, _ httprouter.Params) restful.Exchanger {
 	return &PUTStateDeployments{
 		cluster:     res.loc.ClusterManager,
 		clusterName: res.loc.ResolveFilter.Cluster.ValueOr("no-cluster"),

--- a/server/handle_status.go
+++ b/server/handle_status.go
@@ -31,7 +31,7 @@ func newStatusResource(ctx ComponentLocator) *StatusResource {
 }
 
 // Get implements Getable on StatusResource.
-func (sr *StatusResource) Get(http.ResponseWriter, *http.Request, httprouter.Params) restful.Exchanger {
+func (sr *StatusResource) Get(*restful.RouteMap, http.ResponseWriter, *http.Request, httprouter.Params) restful.Exchanger {
 	return &StatusHandler{
 		AutoResolver:  sr.context.AutoResolver,
 		ResolveFilter: sr.context.ResolveFilter,

--- a/server/routemap_test.go
+++ b/server/routemap_test.go
@@ -77,4 +77,13 @@ func TestSousRoutes(t *testing.T) {
 	)
 
 	test("/health", "health", nil)
+
+	test(
+		"/single-deployment?cluster=cluster1&offset=alt&repo=github.com%2Fopentable%2Fsous",
+		"single-deployment",
+		nil,
+		restful.KV{"repo", "github.com/opentable/sous"},
+		restful.KV{"offset", "alt"},
+		restful.KV{"cluster", "cluster1"},
+	)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -96,6 +96,7 @@ func routemap(context ComponentLocator) *restful.RouteMap {
 		re("all-deploy-queues", "/all-deploy-queues", newAllDeployQueuesResource(context))
 		re("deploy-queue", "/deploy-queue", newDeployQueueResource(context))
 		re("deploy-queue-item", "/deploy-queue-item", newR11nResource(context))
+		re("single-deployment", "/single-deployment-resource", newSingleDeploymentResource(context))
 	})
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -96,7 +96,7 @@ func routemap(context ComponentLocator) *restful.RouteMap {
 		re("all-deploy-queues", "/all-deploy-queues", newAllDeployQueuesResource(context))
 		re("deploy-queue", "/deploy-queue", newDeployQueueResource(context))
 		re("deploy-queue-item", "/deploy-queue-item", newR11nResource(context))
-		re("single-deployment", "/single-deployment-resource", newSingleDeploymentResource(context))
+		re("single-deployment", "/single-deployment", newSingleDeploymentResource(context))
 	})
 }
 

--- a/test/server_integration_test.go
+++ b/test/server_integration_test.go
@@ -173,8 +173,9 @@ func (suite integrationServerTests) TestUpdateServers() {
 
 func (suite integrationServerTests) TestUpdateStateDeployments_Precondition() {
 	data := server.GDMWrapper{Deployments: []*sous.Deployment{}}
-	err := suite.client.Create("./state/deployments", nil, &data, nil)
+	res, err := suite.client.Create("./state/deployments", nil, &data, nil)
 	suite.errorMatches(err, `^Create \./state/deployments params: map\[\]: 412 Precondition Failed: "resource present for If-None-Match=\*!\\n"`)
+	suite.Nil(res)
 }
 
 func (suite integrationServerTests) TestUpdateStateDeployments_Update() {
@@ -196,10 +197,9 @@ func (suite integrationServerTests) TestUpdateStateDeployments_Update() {
 
 func (suite integrationServerTests) TestPUTSingleDeployment() {
 	data := server.SingleDeploymentBody{}
-	headers := map[string]string{"If-None-Match": "w/bogus"}
-	err := suite.client.Create("/single-deployment", nil, data, headers)
-	suite.Require().Error(err)
-	suite.errorMatches(err, "404 Not Found")
+	rez, err := suite.client.Create("/single-deployment", nil, data, nil)
+	suite.errorMatches(err, `412 Precondition Failed`) // already a zero deployment
+	suite.Nil(rez)
 }
 
 func (suite integrationServerTests) TestGetAllDeployQueues_empty() {

--- a/test/server_integration_test.go
+++ b/test/server_integration_test.go
@@ -95,6 +95,13 @@ func (suite *integrationServerTests) prepare() (logging.LogSink, http.Handler, f
 
 }
 
+func (suite integrationServerTests) errorMatches(err error, regexp string) {
+	suite.T().Helper()
+	if suite.Error(err) {
+		suite.Regexp(regexp, err.Error())
+	}
+}
+
 func (suite *liveServerSuite) SetupTest() {
 	lt, h, cleanup := suite.prepare()
 	suite.cleanup = cleanup
@@ -167,9 +174,7 @@ func (suite integrationServerTests) TestUpdateServers() {
 func (suite integrationServerTests) TestUpdateStateDeployments_Precondition() {
 	data := server.GDMWrapper{Deployments: []*sous.Deployment{}}
 	err := suite.client.Create("./state/deployments", nil, &data, nil)
-	// TODO SS: This assertion does not check for the string, use EqualError
-	// once error is shorter...
-	suite.Error(err, `412 Precondition Failed: "resource present for If-None-Match=*!\n"`)
+	suite.errorMatches(err, `^Create \./state/deployments params: map\[\]: 412 Precondition Failed: "resource present for If-None-Match=\*!\\n"`)
 }
 
 func (suite integrationServerTests) TestUpdateStateDeployments_Update() {

--- a/test/server_integration_test.go
+++ b/test/server_integration_test.go
@@ -194,6 +194,14 @@ func (suite integrationServerTests) TestUpdateStateDeployments_Update() {
 	suite.Len(data.Deployments, 3)
 }
 
+func (suite integrationServerTests) TestPUTSingleDeployment() {
+	data := server.SingleDeploymentBody{}
+	headers := map[string]string{"If-None-Match": "w/bogus"}
+	err := suite.client.Create("/single-deployment", nil, data, headers)
+	suite.Require().Error(err)
+	suite.errorMatches(err, "404 Not Found")
+}
+
 func (suite integrationServerTests) TestGetAllDeployQueues_empty() {
 	data := server.DeploymentQueuesResponse{}
 	updater, err := suite.client.Retrieve("./all-deploy-queues", nil, &data, nil)

--- a/test/state_fixture.go
+++ b/test/state_fixture.go
@@ -1,0 +1,109 @@
+package test
+
+import (
+	"fmt"
+
+	. "github.com/opentable/sous/lib"
+	"github.com/samsalisbury/semv"
+)
+
+// StateFixtureOpts allows configuring StateFixture calls.
+type StateFixtureOpts struct {
+	ClusterCount  int
+	ManifestCount int
+}
+
+// DefaultStateFixture provides a dummy state for tests by calling
+// StateFixture with the following options:
+//
+//  StateFixtureOpts{
+//	  ClusterCount:  3,
+//    ManifestCount: 3,
+//  }
+func DefaultStateFixture() *State {
+	return StateFixture(StateFixtureOpts{
+		ClusterCount:  3,
+		ManifestCount: 3,
+	})
+}
+
+// StateFixture provides a dummy state for tests.
+func StateFixture(o StateFixtureOpts) *State {
+
+	s := NewState()
+
+	m := NewManifests()
+	for manifestN := 0; manifestN < o.ManifestCount; manifestN++ {
+		m.Add(&Manifest{
+			Source: SourceLocation{
+				Repo: fmt.Sprintf("github.com/user%d/repo%d", manifestN, manifestN),
+				Dir:  fmt.Sprintf("dir%d", manifestN),
+			},
+			Flavor: fmt.Sprintf("flavor%d", manifestN),
+			Owners: nil,
+			Kind:   "http-service",
+		})
+	}
+
+	c := Clusters{}
+	// For each cluster add it to defs and add a deployment to each manifest.
+	for clusterN := 0; clusterN < o.ClusterCount; clusterN++ {
+		clusterName := fmt.Sprintf("cluster%d", clusterN)
+		c[clusterName] = &Cluster{
+			Name:    clusterName,
+			Kind:    "singularity",
+			BaseURL: "127.0.0.1:5000",
+			Env: map[string]Var{
+				"CLUSTER_NAME": Var(clusterName),
+			},
+			Startup: Startup{
+				SkipCheck:                 false,
+				ConnectDelay:              30,
+				Timeout:                   30,
+				ConnectInterval:           10,
+				CheckReadyProtocol:        "http",
+				CheckReadyURIPath:         "/health",
+				CheckReadyFailureStatuses: []int{500},
+				CheckReadyURITimeout:      2,
+				CheckReadyInterval:        2,
+				CheckReadyRetries:         256,
+			},
+			AllowedAdvisories: nil,
+		}
+		for _, mid := range m.Keys() {
+			manifest, ok := m.Get(mid)
+			if !ok {
+				panic("Manifests.Keys returned a nonexistent key")
+			}
+
+			if manifest.Deployments == nil {
+				manifest.Deployments = DeploySpecs{}
+			}
+			manifest.Deployments[clusterName] = DeploySpec{
+				DeployConfig: DeployConfig{
+					Resources: map[string]string{
+						"cpus": "0.1",
+					},
+					Metadata: map[string]string{
+						"": "",
+					},
+					Env: map[string]string{
+						"": "",
+					},
+					NumInstances: 3,
+					Volumes:      nil,
+					Schedule:     "",
+				},
+				Version: semv.MustParse("1.0.0"),
+			}
+		}
+	}
+
+	s.Defs = Defs{
+		DockerRepo: "docker.example.com",
+		Clusters:   c,
+	}
+	s.Manifests = m
+
+	return s
+}

--- a/util/restful/client.go
+++ b/util/restful/client.go
@@ -345,7 +345,7 @@ func (client *LiveHTTPClient) getBody(rz *http.Response, rzBody interface{}, err
 			resourceJSON: bytes.NewBuffer(rzJSON),
 		}, errors.Wrapf(err, "processing response body")
 	case rz.StatusCode < 200 || rz.StatusCode >= 300:
-		return nil, errors.Errorf("%s: %#v (%v)", rz.Status, string(b), b)
+		return nil, errors.Errorf("%s: %s (%v)", rz.Status, string(b), b)
 	case rz.StatusCode == http.StatusConflict:
 		return nil, errors.Wrap(retryableError(fmt.Sprintf("%s: %#v", rz.Status, string(b))), "getBody")
 	}

--- a/util/restful/client.go
+++ b/util/restful/client.go
@@ -167,7 +167,7 @@ func (client *LiveHTTPClient) Retrieve(urlPath string, qParms map[string]string,
 		state.path = urlPath
 		state.qparms = qParms
 	}
-	return state, errors.Wrapf(err, "Retrieve %s %v", urlPath, qParms)
+	return state, errors.Wrapf(err, "Retrieve %s params: %v", urlPath, qParms)
 }
 
 // Create uses the contents of qBody to create a new resource at the server at urlPath/qParms
@@ -179,7 +179,7 @@ func (client *LiveHTTPClient) Create(urlPath string, qParms map[string]string, q
 		rz, err := client.sendRequest(rq, err)
 		_, err = client.getBody(rz, nil, err)
 		return err
-	}(), "Create %s %v", urlPath, qParms)
+	}(), "Create %s params: %v", urlPath, qParms)
 }
 
 func (client *LiveHTTPClient) deelete(urlPath string, qParms map[string]string, from *resourceState, headers map[string]string) error {
@@ -190,7 +190,7 @@ func (client *LiveHTTPClient) deelete(urlPath string, qParms map[string]string, 
 		rz, err := client.sendRequest(rq, err)
 		_, err = client.getBody(rz, nil, err)
 		return err
-	}(), "Delete %s %v", urlPath, qParms)
+	}(), "Delete %s params: %v", urlPath, qParms)
 }
 
 func (client *LiveHTTPClient) update(urlPath string, qParms map[string]string, from *resourceState, qBody Comparable, headers map[string]string) error {
@@ -202,7 +202,7 @@ func (client *LiveHTTPClient) update(urlPath string, qParms map[string]string, f
 		rz, err := client.sendRequest(rq, err)
 		_, err = client.getBody(rz, nil, err)
 		return err
-	}(), "Update %s %v", urlPath, qParms)
+	}(), "Update %s params: %v", urlPath, qParms)
 }
 
 // Create implements HTTPClient on DummyHTTPClient - it does nothing and returns nil

--- a/util/restful/client.go
+++ b/util/restful/client.go
@@ -39,7 +39,7 @@ type (
 	// HTTPClient interacts with a HTTPServer
 	//   It's designed to handle basic CRUD operations in a safe and restful way.
 	HTTPClient interface {
-		Create(urlPath string, qParms map[string]string, rqBody interface{}, headers map[string]string) error
+		Create(urlPath string, qParms map[string]string, rqBody interface{}, headers map[string]string) (UpdateDeleter, error)
 		Retrieve(urlPath string, qParms map[string]string, rzBody interface{}, headers map[string]string) (UpdateDeleter, error)
 	}
 
@@ -162,24 +162,26 @@ func (client *LiveHTTPClient) Retrieve(urlPath string, qParms map[string]string,
 	rq, err := client.buildRequest("GET", url, headers, nil, nil, err)
 	rz, err := client.sendRequest(rq, err)
 	state, err := client.getBody(rz, rzBody, err)
+	return client.enrichState(state, urlPath, qParms), errors.Wrapf(err, "Retrieve %s params: %v", urlPath, qParms)
+}
+
+// Create uses the contents of qBody to create a new resource at the server at urlPath/qParms
+// It issues a PUT with "If-No-Match: *", so if a resource already exists, it'll return an error.
+func (client *LiveHTTPClient) Create(urlPath string, qParms map[string]string, qBody interface{}, headers map[string]string) (UpdateDeleter, error) {
+	url, err := client.buildURL(urlPath, qParms)
+	rq, err := client.buildRequest("PUT", url, addNoMatchStar(headers), nil, qBody, err)
+	rz, err := client.sendRequest(rq, err)
+	state, err := client.getBody(rz, nil, err)
+	return client.enrichState(state, urlPath, qParms), errors.Wrapf(err, "Create %s params: %v", urlPath, qParms)
+}
+
+func (client *LiveHTTPClient) enrichState(state *resourceState, urlPath string, qParms map[string]string) *resourceState {
 	if state != nil {
 		state.client = client
 		state.path = urlPath
 		state.qparms = qParms
 	}
-	return state, errors.Wrapf(err, "Retrieve %s params: %v", urlPath, qParms)
-}
-
-// Create uses the contents of qBody to create a new resource at the server at urlPath/qParms
-// It issues a PUT with "If-No-Match: *", so if a resource already exists, it'll return an error.
-func (client *LiveHTTPClient) Create(urlPath string, qParms map[string]string, qBody interface{}, headers map[string]string) error {
-	return errors.Wrapf(func() error {
-		url, err := client.buildURL(urlPath, qParms)
-		rq, err := client.buildRequest("PUT", url, addNoMatchStar(headers), nil, qBody, err)
-		rz, err := client.sendRequest(rq, err)
-		_, err = client.getBody(rz, nil, err)
-		return err
-	}(), "Create %s params: %v", urlPath, qParms)
+	return state
 }
 
 func (client *LiveHTTPClient) deelete(urlPath string, qParms map[string]string, from *resourceState, headers map[string]string) error {
@@ -206,8 +208,8 @@ func (client *LiveHTTPClient) update(urlPath string, qParms map[string]string, f
 }
 
 // Create implements HTTPClient on DummyHTTPClient - it does nothing and returns nil
-func (*DummyHTTPClient) Create(urlPath string, qParms map[string]string, rqBody interface{}, headers map[string]string) error {
-	return nil
+func (*DummyHTTPClient) Create(urlPath string, qParms map[string]string, rqBody interface{}, headers map[string]string) (UpdateDeleter, error) {
+	return nil, nil
 }
 
 // Retrieve implements HTTPClient on DummyHTTPClient - it does nothing and returns nil

--- a/util/restful/client.go
+++ b/util/restful/client.go
@@ -231,7 +231,9 @@ func addNoMatchStar(headers map[string]string) map[string]string {
 	if headers == nil {
 		headers = map[string]string{}
 	}
-	headers["If-None-Match"] = "*"
+	if _, ok := headers["If-None-Match"]; !ok {
+		headers["If-None-Match"] = "*"
+	}
 	return headers
 }
 

--- a/util/restful/restfultest/client.go
+++ b/util/restful/restfultest/client.go
@@ -78,14 +78,20 @@ func (c *HTTPClientSpy) Retrieve(url string, ps map[string]string, bd interface{
 	return res.Get(1).(restful.UpdateDeleter), res.Error(2)
 }
 
-// Update is a spy implementation of the restful.HTTPClient.Update method
+// Update is a spy implementation of the restful.UpdateDeleter.Update method
 func (u *UpdateSpy) Update(bd restful.Comparable, hs map[string]string) error {
 	res := u.Called(bd, hs)
 	return res.Error(0)
 }
 
-// Delete is a spy implementation of the restful.HTTPClient.Delete method
+// Delete is a spy implementation of the restful.UpdateDeleter.Delete method
 func (u *UpdateSpy) Delete(hs map[string]string) error {
 	res := u.Called(hs)
 	return res.Error(0)
+}
+
+// Location is a spy implemention of restful.UpdateDeleter.Location method
+func (u *UpdateSpy) Location() string {
+	res := u.Called()
+	return res.String(0)
 }

--- a/util/restful/restfultest/client.go
+++ b/util/restful/restfultest/client.go
@@ -64,10 +64,10 @@ func DummyUpdater() restful.UpdateDeleter {
 }
 
 // Create is a spy implementation of the restful.HTTPClient.Create method
-func (c *HTTPClientSpy) Create(url string, ps map[string]string, bd interface{}, hs map[string]string) error {
+func (c *HTTPClientSpy) Create(url string, ps map[string]string, bd interface{}, hs map[string]string) (restful.UpdateDeleter, error) {
 	res := c.Called(url, ps, bd, hs)
 	roundtrip(res.Get(0), bd)
-	return res.Error(1)
+	return res.Get(1).(restful.UpdateDeleter), res.Error(2)
 }
 
 // Retrieve is a spy implementation of the restful.HTTPClient.Retrieve method

--- a/util/restful/routemap.go
+++ b/util/restful/routemap.go
@@ -21,7 +21,7 @@ type (
 
 	// An ExchangeFactory builds an Exchanger -
 	// they're used to configure the RouteMap
-	ExchangeFactory func(http.ResponseWriter, *http.Request, httprouter.Params) Exchanger
+	ExchangeFactory func(*RouteMap, http.ResponseWriter, *http.Request, httprouter.Params) Exchanger
 
 	routeEntry struct {
 		Name, Path string
@@ -41,22 +41,22 @@ type (
 
 	// Getable tags ResourceFamilies that respond to GET
 	Getable interface {
-		Get(http.ResponseWriter, *http.Request, httprouter.Params) Exchanger
+		Get(*RouteMap, http.ResponseWriter, *http.Request, httprouter.Params) Exchanger
 	}
 
 	// Putable tags ResourceFamilies that respond to PUT
 	Putable interface {
-		Put(http.ResponseWriter, *http.Request, httprouter.Params) Exchanger
+		Put(*RouteMap, http.ResponseWriter, *http.Request, httprouter.Params) Exchanger
 	}
 
 	// Deleteable tags ResourceFamilies that respond to DELETE
 	Deleteable interface {
-		Delete(http.ResponseWriter, *http.Request, httprouter.Params) Exchanger
+		Delete(*RouteMap, http.ResponseWriter, *http.Request, httprouter.Params) Exchanger
 	}
 
 	// Optionsable tags ResourceFamilies that respond to OPTIONS
 	Optionsable interface {
-		Options(http.ResponseWriter, *http.Request, httprouter.Params) Exchanger
+		Options(*RouteMap, http.ResponseWriter, *http.Request, httprouter.Params) Exchanger
 	}
 	/*
 		Postable interface {
@@ -101,6 +101,7 @@ func BuildRouteMap(f func(RouteEntryBuilder)) *RouteMap {
 func (rm *RouteMap) buildMetaHandler(r *httprouter.Router, ls logging.LogSink) *MetaHandler {
 	ph := &StatusMiddleware{LogSink: ls, gatelatch: os.Getenv("GATELATCH")}
 	mh := &MetaHandler{
+		routeMap:      rm,
 		router:        r,
 		statusHandler: ph,
 		LogSink:       ls,
@@ -154,7 +155,7 @@ func defaultOptions(res Resource) ExchangeFactory {
 		ex.methods = append(ex.methods, "DELETE")
 	}
 
-	return func(http.ResponseWriter, *http.Request, httprouter.Params) Exchanger {
+	return func(*RouteMap, http.ResponseWriter, *http.Request, httprouter.Params) Exchanger {
 		return ex
 	}
 }

--- a/util/restful/server_test.go
+++ b/util/restful/server_test.go
@@ -45,14 +45,14 @@ func newTestResource(data string) *TestResource {
 	return &TestResource{Data: data}
 }
 
-func (tr *TestResource) Get(write http.ResponseWriter, req *http.Request, ps httprouter.Params) Exchanger {
+func (tr *TestResource) Get(rm *RouteMap, write http.ResponseWriter, req *http.Request, ps httprouter.Params) Exchanger {
 	return &TestGetExchanger{
 		TestResource: tr,
 		Params:       ps,
 		QueryValues:  tr.ParseQuery(req),
 	}
 }
-func (tr *TestResource) Put(write http.ResponseWriter, req *http.Request, ps httprouter.Params) Exchanger {
+func (tr *TestResource) Put(rm *RouteMap, write http.ResponseWriter, req *http.Request, ps httprouter.Params) Exchanger {
 	return &TestPutExchanger{
 		TestResource: tr,
 		Request:      req,

--- a/util/restful/statusmiddleware.go
+++ b/util/restful/statusmiddleware.go
@@ -21,13 +21,13 @@ type (
 
 func (ph *StatusMiddleware) errorBody(status int, rq *http.Request, w io.Writer, data interface{}, err error, stack []byte) {
 	if ph.gatelatch == "" {
-		w.Write([]byte(fmt.Sprintf("%s\n", data)))
+		w.Write([]byte(fmt.Sprintf("%v\n", data)))
 		return
 	}
 
 	if header := rq.Header.Get("X-Gatelatch"); header != ph.gatelatch {
 		w.Write([]byte(fmt.Sprintf("%s\n", data)))
-		ph.Warnf("Gatelatch header (%q) didn't match gatelatch env (%s)", ph.gatelatch, header)
+		messages.ReportLogFieldsMessage("Gatelatch header didn't match gatelatch env", logging.WarningLevel, ph.LogSink, ph.gatelatch, header)
 		return
 	}
 


### PR DESCRIPTION
Immediately adds a rectification to the queue if the deployment results in a change to the GDM.

Needs one piece adding: rejecting updates for clusters that the server is not responsible for.