### PR TITLE
add teamcity formatting for unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,9 @@ test-gofmt:
 test-unit: postgres-test-prepare
 	go test $(EXTRA_GO_FLAGS) $(TEST_VERBOSE) -timeout 3m -race $(SOUS_PACKAGES_WITH_TESTS)
 
+test-unit-tc: postgres-test-prepare
+	go test -race -v $(SOUS_PACKAGES_WITH_TESTS) | docker run -i xjewer/go-test-teamcity
+
 test-integration: setup-containers
 	@echo
 	@echo


### PR DESCRIPTION
https://github.com/2tvenom/go-test-teamcity

Will use this to create A TC project that runs these and reports in standard TC reporters

Example:

`##teamcity[testFinished timestamp='2018-03-05T18:37:24.335' name='TestCanMakeAnAgent']
##teamcity[testStarted timestamp='2018-03-05T18:37:24.335' name='TestUntilReady']
##teamcity[testFinished timestamp='2018-03-05T18:37:24.335' name='TestUntilReady']
PASS
ok      github.com/opentable/sous/util/test_with_docker 3.342s
##teamcity[testStarted timestamp='2018-03-05T18:37:24.335' name='TestValidate_NestedStructs']
##teamcity[testFinished timestamp='2018-03-05T18:37:24.335' name='TestValidate_NestedStructs']
##teamcity[testStarted timestamp='2018-03-05T18:37:24.335' name='TestValidate_Interface_InvalidKey']
##teamcity[testFinished timestamp='2018-03-05T18:37:24.335' name='TestValidate_Interface_InvalidKey']
##teamcity[testStarted timestamp='2018-03-05T18:37:24.335' name='TestValidate_Interface_InvalidValue']
##teamcity[testFinished timestamp='2018-03-05T18:37:24.335' name='TestValidate_Interface_InvalidValue']
##teamcity[testStarted timestamp='2018-03-05T18:37:24.335' name='TestValidate_Interface_InvalidField']
##teamcity[testFinished timestamp='2018-03-05T18:37:24.335' name='TestValidate_Interface_InvalidField']
##teamcity[testStarted timestamp='2018-03-05T18:37:24.335' name='TestValidate_Invalid']
##teamcity[testFinished timestamp='2018-03-05T18:37:24.335' name='TestValidate_Invalid']
##teamcity[testStarted timestamp='2018-03-05T18:37:24.335' name='TestValidate_Valid']
##teamcity[testFinished timestamp='2018-03-05T18:37:24.335' name='TestValidate_Valid']
PASS
ok      github.com/opentable/sous/util/validator        1.012s
##teamcity[testStarted timestamp='2018-03-05T18:37:24.335' name='TestCleanWS']
##teamcity[testFinished timestamp='2018-03-05T18:37:24.335' name='TestCleanWS']
PASS
ok      github.com/opentable/sous/util/whitespace       1.011s
##teamcity[testStarted timestamp='2018-03-05T18:37:24.335' name='TestInjectTemplatePipelineMap']
##teamcity[testFinished timestamp='2018-03-05T18:37:24.335' name='TestInjectTemplatePipelineMap']
##teamcity[testStarted timestamp='2018-03-05T18:37:24.335' name='TestInjectTemplatePipelineStruct']
##teamcity[testFinished timestamp='2018-03-05T18:37:24.335' name='TestInjectTemplatePipelineStruct']
##teamcity[testStarted timestamp='2018-03-05T18:37:24.335' name='TestInjectTemplatePipelineComplex']
##teamcity[testFinished timestamp='2018-03-05T18:37:24.335' name='TestInjectTemplatePipelineComplex']
##teamcity[testStarted timestamp='2018-03-05T18:37:24.335' name='TestInjectTemplatePipelineIntoSelfComplex']
##teamcity[testFinished timestamp='2018-03-05T18:37:24.335' name='TestInjectTemplatePipelineIntoSelfComplex']
##teamcity[testStarted timestamp='2018-03-05T18:37:24.335' name='TestUnmarshalAnonymousFields']
##teamcity[testFinished timestamp='2018-03-05T18:37:24.335' name='TestUnmarshalAnonymousFields']
        yaml_test.go:22: Got: {StringField:hello StructField:{IntField: 5}}
PASS
ok      github.com/opentable/sous/util/yaml     1.013s
`