### PR TITLE
lib: bandage close of closed channel #trivial

### DIFF
--- a/lib/rectification.go
+++ b/lib/rectification.go
@@ -27,7 +27,20 @@ func NewRectification(dp DeployablePair) *Rectification {
 func (r *Rectification) Begin(d Deployer) {
 	r.once.Do(func() {
 		r.Resolution = d.Rectify(&r.Pair)
-		close(r.done)
+		// TODO SS: This select statement is a bandage around the problem
+		// that somehow this channel is being closed before reaching the line
+		// below. I doubt it's a bug in sync.Once (though that should be
+		// eliminated). We should figure out the cause and remove this select.
+	CLOSE_CH:
+		select {
+		default:
+			close(r.done)
+		case _, open := <-r.done:
+			if open {
+				goto CLOSE_CH
+			}
+			// Already closed.
+		}
 	})
 }
 


### PR DESCRIPTION
- The close(done) was panicking occasionally even though I cannot
  find any other reference to that channel.
- Could be a bug in sync.Once or something weirder (is the once being
  copied in a way that breaks the pattern somewhere?).