### PR TITLE
Hit specific server + return all query params in Location from PUT /single-deployment #trivial

### DIFF
--- a/cli/sous_newdeploy.go
+++ b/cli/sous_newdeploy.go
@@ -18,7 +18,7 @@ import (
 type SousNewDeploy struct {
 	DeployFilterFlags config.DeployFilterFlags `inject:"optional"`
 	StateReader       graph.StateReader
-	HTTPClient        graph.HTTPClient
+	HTTPClient        graph.ClusterSpecificHTTPClient
 	TargetManifestID  graph.TargetManifestID
 	LogSink           graph.LogSink
 	dryrunOption      string
@@ -61,14 +61,16 @@ func (sd *SousNewDeploy) RegisterOn(psy Addable) {
 // Execute creates the new deployment.
 func (sd *SousNewDeploy) Execute(args []string) cmdr.Result {
 
+	cluster := sd.DeployFilterFlags.Cluster
+
 	newVersion, err := semv.Parse(sd.DeployFilterFlags.Tag)
 	if err != nil {
-		return cmdr.UsageErrorf("not semver: %s", sd.DeployFilterFlags.Tag)
+		return cmdr.UsageErrorf("not semver: -tag %s", sd.DeployFilterFlags.Tag)
 	}
 
 	d := server.SingleDeploymentBody{}
 	q := sd.TargetManifestID.QueryMap()
-	q["cluster"] = sd.DeployFilterFlags.Cluster
+	q["cluster"] = cluster
 	updater, err := sd.HTTPClient.Retrieve("./single-deployment", q, &d, nil)
 	if err != nil {
 		return cmdr.EnsureErrorResult(err)

--- a/lib/rectification.go
+++ b/lib/rectification.go
@@ -31,13 +31,12 @@ func (r *Rectification) Begin(d Deployer) {
 		// that somehow this channel is being closed before reaching the line
 		// below. I doubt it's a bug in sync.Once (though that should be
 		// eliminated). We should figure out the cause and remove this select.
-	CLOSE_CH:
 		select {
 		default:
 			close(r.done)
 		case _, open := <-r.done:
 			if open {
-				goto CLOSE_CH
+				close(r.done)
 			}
 			// Already closed.
 		}

--- a/lib/rectification.go
+++ b/lib/rectification.go
@@ -27,7 +27,20 @@ func NewRectification(dp DeployablePair) *Rectification {
 func (r *Rectification) Begin(d Deployer) {
 	r.once.Do(func() {
 		r.Resolution = d.Rectify(&r.Pair)
-		close(r.done)
+		// TODO SS: This select statement is a bandage around the problem
+		// that somehow this channel is being closed before reaching the line
+		// below. I doubt it's a bug in sync.Once (though that should be
+		// eliminated). We should figure out the cause and remove this select.
+	CLOSE_CH:
+		select {
+		default:
+			close(r.done)
+		case _, open := <-r.done:
+			if open {
+				goto CLOSE_CH
+			}
+			// Already closed.
+		}
 	})
 }
 

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -160,7 +160,12 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 	}
 
 	actionKV := restful.KV{"action", string(qr.ID)}
-	queueURI, err := psd.routeMap.URIFor("deploy-queue-item", nil, actionKV)
+	clusterKV := restful.KV{"cluster", did.Cluster}
+	repoKV := restful.KV{"repo", did.ManifestID.Source.Repo}
+	offsetKV := restful.KV{"offset", did.ManifestID.Source.Dir}
+	flavorKV := restful.KV{"flavor", did.ManifestID.Flavor}
+	queueURI, err := psd.routeMap.URIFor("deploy-queue-item", nil,
+		actionKV, clusterKV, repoKV, offsetKV, flavorKV)
 	if err != nil {
 		return psd.err(500, "Determining queue item URL: %s", err)
 	}

--- a/server/handle_single_deployment_test.go
+++ b/server/handle_single_deployment_test.go
@@ -119,7 +119,7 @@ func (scn psdhExScenario) assertHeader(t *testing.T, wantKey, wantValue string) 
 
 	gotValue := h.Get(wantKey)
 	if gotValue != wantValue {
-		t.Errorf("got %q=%q; want %q=%q", wantKey, gotValue, wantKey, wantValue)
+		t.Errorf("got:\n%q=%q\nwant:\n%q=%q", wantKey, gotValue, wantKey, wantValue)
 	}
 }
 
@@ -267,7 +267,8 @@ func TestPUTSingleDeploymentHandler_Exchange(t *testing.T) {
 		scenario.assertStatus(t, 201)
 		scenario.assertDeploymentWritten(t)
 		scenario.assertR11nQueued(t)
-		scenario.assertHeader(t, "Location", "/deploy-queue-item?action=actionid1")
+		scenario.assertHeader(t, "Location",
+			"/deploy-queue-item?action=actionid1&cluster=cluster1&flavor=&offset=&repo=github.com%2Fuser1%2Frepo1")
 	})
 
 	t.Run("WriteDeployment error", func(t *testing.T) {


### PR DESCRIPTION
'sous newdeploy' now selects the appropriate server to issue PUT /single-deployment to. Previously it always tried to put the the server in user's config which is not always appropriate.

Also fixed: PUT /single-deployment returns a Location header pointing to a rectification which can be watched for completion. However, the URL in Location header was missing DeploymentID query params, so the R11n could never be found. This PR adds the remaining query params so this relative URL is complete.