### PR TITLE
Build artifact needed

### DIFF
--- a/cli/sous_newdeploy.go
+++ b/cli/sous_newdeploy.go
@@ -85,7 +85,10 @@ func (sd *SousNewDeploy) Execute(args []string) cmdr.Result {
 		return cmdr.EnsureErrorResult(err)
 	}
 
-	location := updateResponse.Location()
+	if location := updateResponse.Location(); location != "" {
+		return cmdr.Successf("Deployment queued at: %s", location)
+	}
+	return cmdr.Successf("Desired version for %q in cluster %q already %q",
+		sd.TargetManifestID, cluster, sd.DeployFilterFlags.Tag)
 
-	return cmdr.Successf("Deployment queued at: %s", location)
 }

--- a/cli/sous_newdeploy.go
+++ b/cli/sous_newdeploy.go
@@ -78,7 +78,7 @@ func (sd *SousNewDeploy) Execute(args []string) cmdr.Result {
 	messages.ReportLogFieldsMessage("SousNewDeploy.Execute Retrieved Deployment",
 		logging.ExtraDebug1Level, sd.LogSink, d)
 
-	d.Deployment.SourceID.Version = newVersion
+	d.Deployment.Version = newVersion
 
 	updateResponse, err := updater.Update(d, nil)
 	if err != nil {

--- a/graph/server.go
+++ b/graph/server.go
@@ -27,8 +27,8 @@ func newServerComponentLocator(ls LogSink, cfg LocalSousConfig, ins sous.Inserte
 
 // NewR11nQueueSet returns a new queue set configured to start processing r11ns
 // immediately.
-func NewR11nQueueSet(d sous.Deployer) *sous.R11nQueueSet {
-	return sous.NewR11nQueueSet(sous.R11nQueueStartWithHandler(
+func NewR11nQueueSet(d sous.Deployer, r sous.Registry) *sous.R11nQueueSet {
+	return sous.NewR11nQueueSet(r, sous.R11nQueueStartWithHandler(
 		func(qr *sous.QueuedR11n) sous.DiffResolution {
 			qr.Rectification.Begin(d)
 			return qr.Rectification.Wait()

--- a/graph/server.go
+++ b/graph/server.go
@@ -28,9 +28,9 @@ func newServerComponentLocator(ls LogSink, cfg LocalSousConfig, ins sous.Inserte
 // NewR11nQueueSet returns a new queue set configured to start processing r11ns
 // immediately.
 func NewR11nQueueSet(d sous.Deployer, r sous.Registry) *sous.R11nQueueSet {
-	return sous.NewR11nQueueSet(r, sous.R11nQueueStartWithHandler(
+	return sous.NewR11nQueueSet(sous.R11nQueueStartWithHandler(
 		func(qr *sous.QueuedR11n) sous.DiffResolution {
-			qr.Rectification.Begin(d)
+			qr.Rectification.Begin(d, r)
 			return qr.Rectification.Wait()
 		}))
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -406,7 +406,7 @@ func (suite *integrationSuite) TestMissingImage() {
 	}
 
 	// ****
-	qs := graph.NewR11nQueueSet(suite.deployer)
+	qs := graph.NewR11nQueueSet(suite.deployer, suite.nameCache)
 	r := sous.NewResolver(suite.deployer, suite.nameCache, &sous.ResolveFilter{}, logging.SilentLogSet(), qs)
 
 	deploymentsOne, err := stateOne.Deployments()
@@ -463,7 +463,7 @@ func (suite *integrationSuite) TestResolve() {
 	logsink, logController := logging.NewLogSinkSpy()
 
 	// ****
-	qs := graph.NewR11nQueueSet(suite.deployer)
+	qs := graph.NewR11nQueueSet(suite.deployer, suite.nameCache)
 	r := sous.NewResolver(suite.deployer, suite.nameCache, &sous.ResolveFilter{}, logsink, qs)
 
 	suite.T().Log("Begining OneTwo")
@@ -529,7 +529,7 @@ func (suite *integrationSuite) TestResolve() {
 		client := singularity.NewRectiAgent(suite.nameCache)
 		deployer := singularity.NewDeployer(client, logging.SilentLogSet())
 
-		qs := graph.NewR11nQueueSet(suite.deployer)
+		qs := graph.NewR11nQueueSet(suite.deployer, suite.nameCache)
 		r := sous.NewResolver(deployer, suite.nameCache, &sous.ResolveFilter{}, logging.SilentLogSet(), qs)
 
 		err = r.Begin(deploymentsTwoThree, clusterDefs.Clusters).Wait()

--- a/lib/auto_resolver_test.go
+++ b/lib/auto_resolver_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func dummyResolver() *Resolver {
-	return NewResolver(NewDummyDeployer(), NewDummyRegistry(), &ResolveFilter{}, logging.SilentLogSet(), NewR11nQueueSet())
+	return NewResolver(NewDummyDeployer(), NewDummyRegistry(), &ResolveFilter{},
+		logging.SilentLogSet(), NewR11nQueueSet())
 }
 
 func setupAR() *AutoResolver {

--- a/lib/deployment_manager.go
+++ b/lib/deployment_manager.go
@@ -78,7 +78,6 @@ func (dm *deploymentManagerDecorator) WriteDeployment(dep *Deployment, user User
 	if err != nil {
 		return err
 	}
-
 	deps.Set(dep.ID(), dep)
-	return nil
+	return dm.WriteState(state, user)
 }

--- a/lib/nameresolver.go
+++ b/lib/nameresolver.go
@@ -19,6 +19,11 @@ func (d *DeployableChans) ResolveNames(ctx context.Context, r Registry) *Deploya
 	return d.Pipeline(ctx, names)
 }
 
+func HandlePairsByRegistry(r Registry, dp *DeployablePair) (*DeployablePair, *DiffResolution) {
+	names := &nameResolver{registry: r}
+	return names.HandlePairs(dp)
+}
+
 func (names *nameResolver) HandlePairs(dp *DeployablePair) (*DeployablePair, *DiffResolution) {
 	intended := dp.Post
 	action := dp.Kind().ResolveVerb()

--- a/lib/r11n_queue.go
+++ b/lib/r11n_queue.go
@@ -121,21 +121,19 @@ func NewR11nID() R11nID {
 }
 
 // Start starts applying handler to each item on the queue in order.
-func (rq *R11nQueue) Start(handler func(*QueuedR11n) DiffResolution) <-chan DiffResolution {
+func (rq *R11nQueue) Start(handler func(*QueuedR11n) DiffResolution) {
 	rq.Lock()
 	defer rq.Unlock()
-	results := make(chan DiffResolution, 100)
 	go func() {
 		for {
 			qr := rq.next()
-			results <- handler(qr)
+			handler(qr)
 			rq.Lock()
 			close(qr.done)
 			delete(rq.refs, qr.ID)
 			rq.Unlock()
 		}
 	}()
-	return results
 }
 
 // Wait waits for a particular rectification to be processed then returns its

--- a/lib/r11n_queue_set.go
+++ b/lib/r11n_queue_set.go
@@ -30,11 +30,10 @@ type (
 )
 
 // NewR11nQueueSet returns a ready to use R11nQueueSet.
-func NewR11nQueueSet(r Registry, opts ...R11nQueueOpt) *R11nQueueSet {
+func NewR11nQueueSet(opts ...R11nQueueOpt) *R11nQueueSet {
 	return &R11nQueueSet{
 		set:  map[DeploymentID]*R11nQueue{},
 		opts: opts,
-		reg:  r,
 	}
 }
 
@@ -57,11 +56,6 @@ func (rqs *R11nQueueSet) PushIfEmpty(r *Rectification) (*QueuedR11n, bool) {
 func (rqs *R11nQueueSet) Push(r *Rectification) (*QueuedR11n, bool) {
 	rqs.Lock()
 	defer rqs.Unlock()
-
-	if r.Pair.Post.BuildArtifact == nil {
-		pair, _ := HandlePairsByRegistry(rqs.reg, &r.Pair)
-		r.Pair = *pair
-	}
 	id := r.Pair.ID()
 	queue, ok := rqs.set[id]
 	if !ok {

--- a/lib/r11n_queue_set.go
+++ b/lib/r11n_queue_set.go
@@ -19,6 +19,7 @@ type (
 	R11nQueueSet struct {
 		set  map[DeploymentID]*R11nQueue
 		opts []R11nQueueOpt
+		reg  Registry
 		sync.RWMutex
 	}
 
@@ -29,10 +30,11 @@ type (
 )
 
 // NewR11nQueueSet returns a ready to use R11nQueueSet.
-func NewR11nQueueSet(opts ...R11nQueueOpt) *R11nQueueSet {
+func NewR11nQueueSet(r Registry, opts ...R11nQueueOpt) *R11nQueueSet {
 	return &R11nQueueSet{
 		set:  map[DeploymentID]*R11nQueue{},
 		opts: opts,
+		reg:  r,
 	}
 }
 
@@ -55,6 +57,11 @@ func (rqs *R11nQueueSet) PushIfEmpty(r *Rectification) (*QueuedR11n, bool) {
 func (rqs *R11nQueueSet) Push(r *Rectification) (*QueuedR11n, bool) {
 	rqs.Lock()
 	defer rqs.Unlock()
+
+	if r.Pair.Post.BuildArtifact == nil {
+		pair, _ := HandlePairsByRegistry(rqs.reg, &r.Pair)
+		r.Pair = *pair
+	}
 	id := r.Pair.ID()
 	queue, ok := rqs.set[id]
 	if !ok {

--- a/lib/rectification_test.go
+++ b/lib/rectification_test.go
@@ -10,12 +10,16 @@ func TestSingleRectification_Resolve_completes(t *testing.T) {
 	// This test just checks that SingleRectification.Resolve actually
 	// completes.
 
-	sr := NewRectification(DeployablePair{})
+	sr := NewRectification(DeployablePair{
+		Post: &Deployable{
+			Deployment: &Deployment{},
+		},
+	})
 
 	done := make(chan struct{})
 
 	go func() {
-		sr.Begin(&DummyDeployer{})
+		sr.Begin(&DummyDeployer{}, &DummyRegistry{})
 		sr.Wait()
 		close(done)
 	}()

--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -2,6 +2,7 @@ package sous
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/opentable/sous/util/logging"
@@ -42,6 +43,12 @@ func NewResolver(d Deployer, r Registry, rf *ResolveFilter, ls logging.LogSink, 
 func (r *Resolver) queueDiffs(dcs *DeployableChans, results chan DiffResolution) {
 	var wg sync.WaitGroup
 	for p := range dcs.Pairs {
+		p := p
+		if p.Post == nil {
+			err := fmt.Errorf("queueDiffs called with nil Pair.Post in the chan")
+			logging.ReportError(r.ls, err)
+			continue
+		}
 		sr := NewRectification(*p)
 		messages.ReportLogFieldsMessageWithIDs("Adding to queset", logging.ExtraDebug1Level, r.ls, p, sr)
 		queued, ok := r.QueueSet.PushIfEmpty(sr)

--- a/lib/state_fixture.go
+++ b/lib/state_fixture.go
@@ -60,7 +60,7 @@ func StateFixture(o StateFixtureOpts) *State {
 				ConnectDelay:              30,
 				Timeout:                   30,
 				ConnectInterval:           10,
-				CheckReadyProtocol:        "http",
+				CheckReadyProtocol:        "HTTP",
 				CheckReadyURIPath:         "/health",
 				CheckReadyFailureStatuses: []int{500},
 				CheckReadyURITimeout:      2,
@@ -81,7 +81,12 @@ func StateFixture(o StateFixtureOpts) *State {
 			manifest.Deployments[clusterName] = DeploySpec{
 				DeployConfig: DeployConfig{
 					Resources: map[string]string{
-						"cpus": "0.1",
+						"cpus":   "0.1",
+						"memory": "32",
+						"ports":  "1",
+					},
+					Startup: Startup{
+						CheckReadyProtocol: "HTTP",
 					},
 					Metadata: map[string]string{
 						"": "",

--- a/lib/state_manager.go
+++ b/lib/state_manager.go
@@ -20,6 +20,8 @@ type (
 	DummyStateManager struct {
 		*State
 		ReadCount, WriteCount int
+		WriteErr              error
+		ReadErr               error
 	}
 )
 
@@ -31,12 +33,12 @@ func NewDummyStateManager() *DummyStateManager {
 // ReadState implements StateManager
 func (sm *DummyStateManager) ReadState() (*State, error) {
 	sm.ReadCount++
-	return sm.State, nil
+	return sm.State, sm.ReadErr
 }
 
 // WriteState implements StateManager
 func (sm *DummyStateManager) WriteState(s *State, u User) error {
 	sm.WriteCount++
 	*sm.State = *s
-	return nil
+	return sm.WriteErr
 }

--- a/server/data.go
+++ b/server/data.go
@@ -56,8 +56,9 @@ type (
 	// SingleDeploymentBody is the response struct returned from handlers
 	// of HTTP methods of a SingleDeploymentResource.
 	SingleDeploymentBody struct {
-		Meta       ResponseMeta
-		Deployment sous.Deployment
+		Meta           ResponseMeta
+		ManifestHeader sous.Manifest
+		Deployment     sous.DeploySpec
 	}
 )
 
@@ -153,7 +154,7 @@ func (b SingleDeploymentBody) VariancesFrom(other restful.Comparable) restful.Va
 	default:
 		return restful.Variances{"Not a SingleDeploymentBody"}
 	case *SingleDeploymentBody:
-		_, diffs := (&b.Deployment).Diff(&ob.Deployment)
+		_, diffs := (&b.Deployment).Diff(ob.Deployment)
 		return restful.Variances(diffs)
 	}
 }

--- a/server/data.go
+++ b/server/data.go
@@ -56,9 +56,8 @@ type (
 	// SingleDeploymentBody is the response struct returned from handlers
 	// of HTTP methods of a SingleDeploymentResource.
 	SingleDeploymentBody struct {
-		Meta           ResponseMeta
-		ManifestHeader sous.Manifest
-		Deployment     sous.DeploySpec
+		Meta       ResponseMeta
+		Deployment sous.DeploySpec
 	}
 )
 

--- a/server/handle_gdm.go
+++ b/server/handle_gdm.go
@@ -145,11 +145,13 @@ func reportHandleGDMMessage(msg string, f []sous.Flaw, err error, log logging.Lo
 	}
 
 	msgLog := handleGDMMessage{
-		msg:          msg,
-		CallerInfo:   logging.GetCallerInfo(logging.NotHere()),
-		err:          err,
-		flawsMessage: sous.FlawMessage{f},
-		debug:        isDebug,
+		msg:        msg,
+		CallerInfo: logging.GetCallerInfo(logging.NotHere()),
+		err:        err,
+		flawsMessage: sous.FlawMessage{
+			Flaws: f,
+		},
+		debug: isDebug,
 	}
 	logging.Deliver(msgLog, log)
 }

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -160,6 +160,16 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 
 	cluster := did.Cluster
 	newSpec := psd.Body.Deployment.DeploySpec()
+	d, ok := m.Deployments[cluster]
+	if !ok {
+		return psd.err(404, "No %q deployment defined for %q.", cluster, did)
+	}
+
+	differentSpec, _ := newSpec.Diff(d)
+	if !differentSpec {
+		return psd.ok(200, nil)
+	}
+
 	m.Deployments[cluster] = newSpec
 
 	if err := psd.StateWriter.WriteState(psd.GDM, user); err != nil {

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -145,9 +145,16 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 		return psd.err(500, "Failed to write deployment: %s.", err)
 	}
 
+	/*
+	r := sous.NewRectification(sous.DeployablePair{Prior: &sous.Deployable{Deployment: original}, Post: &sous.Deployable{
+		Deployment: &psd.Body.Deployment,
+	}})
+*/
 	r := sous.NewRectification(sous.DeployablePair{Post: &sous.Deployable{
 		Deployment: &psd.Body.Deployment,
 	}})
+
+	
 	r.Pair.SetID(did)
 
 	log := logging.Log

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -164,11 +164,11 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 	// Round-trip the updated GDM back to deployments to check validity.
 	deployments, err := psd.GDM.Deployments()
 	if err != nil {
-		psd.err(500, "Failed to round-trip new deployment spec to GDM: %s", err)
+		return psd.err(500, "Failed to round-trip new deployment spec to GDM: %s", err)
 	}
 	newDeployment, ok := deployments.Get(did)
 	if !ok {
-		psd.err(500, "Failed to round-trip new deployment spec to GDM.")
+		return psd.err(500, "Failed to round-trip new deployment spec to GDM.")
 	}
 
 	if flaws := newDeployment.Validate(); len(flaws) != 0 {
@@ -178,7 +178,6 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 	r := sous.NewRectification(sous.DeployablePair{Post: &sous.Deployable{
 		Deployment: newDeployment,
 	}})
-
 	r.Pair.SetID(did)
 
 	log := logging.Log

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -143,15 +143,9 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 		return psd.err(500, "Failed to write deployment: %s.", err)
 	}
 
-	r := &sous.Rectification{
-		Pair: sous.DeployablePair{
-			Post: &sous.Deployable{
-				Status:     0,
-				Deployment: dep,
-			},
-			ExecutorData: nil,
-		},
-	}
+	r := sous.NewRectification(sous.DeployablePair{Post: &sous.Deployable{
+		Deployment: dep,
+	}})
 	r.Pair.SetID(did)
 
 	qr, ok := psd.QueueSet.Push(r)

--- a/test/server_integration_test.go
+++ b/test/server_integration_test.go
@@ -208,7 +208,7 @@ func (suite integrationServerTests) TestPUTSingleDeployment() {
 		"tag":     "1.0.1",
 	}
 	rez, err := suite.client.Retrieve("/single-deployment", params, nil, nil)
-	suite.errorMatches(err, `404 Not Found.*No deployment with ID`) // empty ID gets 404
+	suite.errorMatches(err, `404 Not Found.*No manifest with ID`) // empty ID gets 404
 	suite.Nil(rez)
 
 	params = map[string]string{

--- a/util/logging/messages/generalmsg_test.go
+++ b/util/logging/messages/generalmsg_test.go
@@ -118,7 +118,6 @@ func TestReportLogFieldsMessage_Submessage(t *testing.T) {
 		map[string]interface{}{
 			"@loglov3-otl":        "sous-generic-v1",
 			"call-stack-function": "github.com/opentable/sous/util/logging/messages.TestReportLogFieldsMessage_Submessage",
-			"json-value":          "{\"message\":{\"array\":[]}}",
 			"sous-fields":         "",
 			"sous-id-values":      "",
 			"sous-ids":            "",

--- a/util/restful/client.go
+++ b/util/restful/client.go
@@ -210,7 +210,9 @@ func (client *LiveHTTPClient) update(urlPath string, qParms map[string]string, f
 		rz, err := client.sendRequest(rq, err)
 		state, err = client.getBody(rz, nil, err)
 		client.enrichState(state, urlPath, qParms)
-		state.headers = rz.Header
+		if state != nil {
+			state.headers = rz.Header
+		}
 		return err
 	}(), "Update %s params: %v", urlPath, qParms)
 	return state, err


### PR DESCRIPTION
Finishes off #636 and reverts SingleDeploymentBody to use DeploySpec not full Deployment (since full Deployment is a denormalised blob and very unwieldy for API consumers; also contains many fields that cannot be modified).