### PR TITLE
Fixes sous-without-workspace issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,16 @@ with respect to its command line interface and HTTP interface.
 * Flaws describing problems with resource fields now get more context.
 * Recording metrics for DB access (rows, time, errors)
 
+### Fixed
+* Client: running `sous` from outside of git workspaces no longer results in
+  a confusing Git error.
+
 ## [0.5.72](//github.com/opentable/sous/compare/0.5.71...0.5.72)
 
 ### Fixed
 * PostgreSQL storage correctly retrieves arrays of healthcheck failure statuses
 * Caught a race condition in the logging subsystem.
+
 ### Changed
 * Log messages with `"@loglov3-otl": "sous-generic-v1"` field names changed:
   `fields` -> `sous-fields`, `types` -> `sous-types`, `ids` -> `sous-ids`,

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -21,18 +21,18 @@ import (
 	"github.com/samsalisbury/semv"
 )
 
-// Func aliases, for convenience returning from commands.
-var (
-	GeneralErrorf = func(format string, a ...interface{}) cmdr.ErrorResult {
-		return EnsureErrorResult(fmt.Errorf(format, a...))
-	}
-	EnsureErrorResult = func(err error) cmdr.ErrorResult {
-		var ls logging.LogSink
-		ls = logging.Log
-		messages.ReportLogFieldsMessageToConsole("Error:", logging.DebugLevel, ls, err)
-		return cmdr.EnsureErrorResult(err)
-	}
-)
+// GeneralErrorf is an convenience method for returning from commands.
+func GeneralErrorf(format string, a ...interface{}) cmdr.ErrorResult {
+	return EnsureErrorResult(fmt.Errorf(format, a...))
+}
+
+// EnsureErrorResult is a convenience for returning from a command.
+func EnsureErrorResult(err error) cmdr.ErrorResult {
+	var ls logging.LogSink
+	ls = logging.Log
+	messages.ReportLogFieldsMessage("Error:", logging.DebugLevel, ls, err)
+	return cmdr.EnsureErrorResult(err)
+}
 
 // ProduceResult converts errors into Results
 func ProduceResult(err error) cmdr.Result {

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -256,8 +256,6 @@ func AddInternals(graph adder) {
 		newBuildContext,
 		newSourceContext,
 		newSourceContextDiscovery,
-		newLocalGitClient,
-		newLocalGitRepo,
 		newSourceHostChooser,
 		NewCurrentState,
 		NewCurrentGDM,
@@ -338,7 +336,27 @@ func newMetricsHandler(set *logging.LogSet) MetricsHandler {
 	return MetricsHandler{set.ExpHandler()}
 }
 
-func newSourceContextDiscovery(g LocalGitRepo, ls LogSink) *SourceContextDiscovery {
+func newSourceContextDiscovery(sh LocalWorkDirShell, ls LogSink) *SourceContextDiscovery {
+	var err error
+
+	gitc := LocalGitClient{}
+	gitc.Client, err = git.NewClient(sh.Sh)
+	if err != nil {
+		return &SourceContextDiscovery{
+			Error:         err,
+			SourceContext: nil,
+		}
+	}
+
+	g := LocalGitRepo{}
+	g.Repo, err = gitc.OpenRepo(".")
+	if err != nil {
+		return &SourceContextDiscovery{
+			Error:         err,
+			SourceContext: nil,
+		}
+	}
+
 	c, err := g.SourceContext()
 	if err != nil {
 		return &SourceContextDiscovery{
@@ -451,16 +469,6 @@ func newLocalWorkDirShell(verbosity *config.Verbosity, l LocalWorkDir) (v LocalW
 	return v, initErr(err, "getting current working directory")
 }
 
-func newLocalGitClient(sh LocalWorkDirShell) (v LocalGitClient, err error) {
-	v.Client, err = git.NewClient(sh.Sh)
-	return v, initErr(err, "initialising git client")
-}
-
-func newLocalGitRepo(c LocalGitClient) (v LocalGitRepo, err error) {
-	v.Repo, err = c.OpenRepo(".")
-	return v, initErr(err, "opening local git repository")
-}
-
 func newSelector(regClient LocalDockerClient, log LogSink) sous.Selector {
 	return docker.NewBuildStrategySelector(log.Child("docker-build-strategy"), regClient)
 }
@@ -537,7 +545,7 @@ func newHTTPClient(c LocalSousConfig, user sous.User, srvr ServerHandler, log Lo
 		cl, err := restful.NewInMemoryClient(srvr.Handler, log.Child("local-http"))
 		return HTTPClient{HTTPClient: cl}, err
 	}
-	messages.ReportLogFieldsMessageToConsole("Using server", logging.ExtraDebug1Level, log, c.Server)
+	messages.ReportLogFieldsMessageToConsole(fmt.Sprintf("Using server %s", c.Server), logging.ExtraDebug1Level, log)
 	cl, err := restful.NewClient(c.Server, log.Child("http-client"))
 	return HTTPClient{HTTPClient: cl}, err
 }

--- a/util/logging/messages/generalmsg.go
+++ b/util/logging/messages/generalmsg.go
@@ -329,7 +329,7 @@ func (l logFieldsMessage) EachField(fn logging.FieldReportFn) {
 	}
 
 	if l.jsonObj != nil {
-		if n, err := l.jsonObj.ArrayCount("message", "array"); n > 0 && err != nil {
+		if n, err := l.jsonObj.ArrayCount("message", "array"); n > 0 && err == nil {
 			fn("json-value", l.jsonObj.String())
 		}
 

--- a/util/logging/messages/generalmsg.go
+++ b/util/logging/messages/generalmsg.go
@@ -192,12 +192,6 @@ type logFieldsMessage struct {
 func (l logFieldsMessage) WriteToConsole(console io.Writer) {
 	if l.console {
 		fmt.Fprintf(console, "%s\n", l.composeMsg())
-		if l.jsonObj != nil {
-			fmt.Fprintf(console, "%s\n", l.jsonObj.StringIndent("", " "))
-		}
-
-		fmt.Fprintf(console, "Fields: %s\n", strings.Join(l.Fields, ","))
-		fmt.Fprintf(console, "Types: %s\n", strings.Join(l.Types, ","))
 	}
 }
 
@@ -335,7 +329,9 @@ func (l logFieldsMessage) EachField(fn logging.FieldReportFn) {
 	}
 
 	if l.jsonObj != nil {
-		fn("json-value", l.jsonObj.String())
+		if n, err := l.jsonObj.ArrayCount("message", "array"); n > 0 && err != nil {
+			fn("json-value", l.jsonObj.String())
+		}
 
 	}
 	l.CallerInfo.EachField(fn)

--- a/util/logging/messages/generalmsg_test.go
+++ b/util/logging/messages/generalmsg_test.go
@@ -37,7 +37,6 @@ func TestReportLogFieldsMessage_NoInterface(t *testing.T) {
 		map[string]interface{}{
 			"sous-fields":    "",
 			"sous-types":     "",
-			"json-value":     "{\"message\":{\"array\":[]}}",
 			"@loglov3-otl":   "sous-generic-v1",
 			"sous-ids":       "",
 			"sous-id-values": "",


### PR DESCRIPTION
It's been a longstanding bug that when e.g. `sous query gdm` or
`sous manifest get -repo ...` was run outside of a git repo, it would crash
with a git error. This PR fixes that, since those use cases are pretty useful.

Also cleans up some logging & console interactions.