### PR TITLE
`sous server -autoresolver=false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ with respect to its command line interface and HTTP interface.
   the default 'sous deploy' after some real-world validation.
 * Flaws describing problems with resource fields now get more context.
 * Recording metrics for DB access (rows, time, errors)
+* Server now accepts -autoresolver=false to disable to autoresolver.
 
 ## [0.5.72](//github.com/opentable/sous/compare/0.5.71...0.5.72)
 

--- a/cli/actions/server.go
+++ b/cli/actions/server.go
@@ -38,7 +38,11 @@ func (ss *Server) Do() error {
 
 	reportServerMessage("Starting scheduled GDM resolution.  Filtering the GDM to resolve on this server", ss.DeployFilterFlags, ss.ListenAddr, ss.Log)
 
-	ss.AutoResolver.Kickoff()
+	if ss.AutoResolver != nil {
+		ss.AutoResolver.Kickoff()
+	} else {
+		reportServerMessage("Auto-resolver DISABLED", ss.DeployFilterFlags, ss.ListenAddr, ss.Log)
+	}
 
 	reportServerMessage("Sous Server Running", ss.DeployFilterFlags, ss.ListenAddr, ss.Log)
 
@@ -104,7 +108,7 @@ func reportServerMessage(msg string, filterFlags config.DeployFilterFlags, liste
 }
 
 func (msg serverMessage) WriteToConsole(console io.Writer) {
-	fmt.Fprintf(console, "%s\n", msg.composeMsg())
+	console.Write([]byte(msg.msg))
 }
 
 func (msg serverMessage) DefaultLevel() logging.Level {
@@ -112,15 +116,18 @@ func (msg serverMessage) DefaultLevel() logging.Level {
 }
 
 func (msg serverMessage) Message() string {
-	return msg.composeMsg()
-}
-
-func (msg serverMessage) composeMsg() string {
-	return fmt.Sprintf("%s, server at %s for %s: DeployFilter Flags %v", msg.msg, msg.listenAddress, msg.deployFilterFlags.Cluster, msg.deployFilterFlags)
+	return msg.msg
 }
 
 func (msg serverMessage) EachField(f logging.FieldReportFn) {
 	f("@loglov3-otl", "sous-generic-v1")
 	f("sous-listen-address", msg.listenAddress)
+	f("filter-cluster", msg.deployFilterFlags.Cluster)
+	f("filter-flavor", msg.deployFilterFlags.Flavor)
+	f("filter-offset", msg.deployFilterFlags.Offset)
+	f("filter-repo", msg.deployFilterFlags.Repo)
+	f("filter-revision", msg.deployFilterFlags.Revision)
+	f("filter-tag", msg.deployFilterFlags.Tag)
+
 	msg.CallerInfo.EachField(f)
 }

--- a/cli/sous_server.go
+++ b/cli/sous_server.go
@@ -15,7 +15,8 @@ type SousServer struct {
 	dryrun,
 	laddr,
 	gdmRepo string
-	profiling bool
+	profiling          bool
+	enableAutoResolver bool
 }
 
 func init() { TopLevelCommands["server"] = &SousServer{} }
@@ -39,11 +40,12 @@ func (ss *SousServer) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&ss.laddr, `listen`, `:80`, "The address to listen on, like '127.0.0.1:https'")
 	fs.StringVar(&ss.gdmRepo, "gdm-repo", "", "Git repo containing the GDM (cloned into config.SourceLocation)")
 	fs.BoolVar(&ss.profiling, "profiling", false, "Enable profiling in the server.")
+	fs.BoolVar(&ss.enableAutoResolver, "autoresolver", true, "Enable the autoresolver")
 }
 
 // Execute is part of the cmdr.Command interface(s).
 func (ss *SousServer) Execute(args []string) cmdr.Result {
-	server, err := ss.SousGraph.GetServer(ss.DeployFilterFlags, ss.dryrun, ss.laddr, ss.gdmRepo, ss.profiling)
+	server, err := ss.SousGraph.GetServer(ss.DeployFilterFlags, ss.dryrun, ss.laddr, ss.gdmRepo, ss.profiling, ss.enableAutoResolver)
 	if err != nil {
 		return cmdr.EnsureErrorResult(err)
 	}

--- a/graph/actions.go
+++ b/graph/actions.go
@@ -84,7 +84,14 @@ func (di *SousGraph) GetPollStatus(dryrun string, dff config.DeployFilterFlags) 
 }
 
 // GetServer returns the server action.
-func (di *SousGraph) GetServer(dff config.DeployFilterFlags, dryrun string, laddr string, gdmRepo string, profiling bool) (actions.Action, error) {
+func (di *SousGraph) GetServer(
+	dff config.DeployFilterFlags,
+	dryrun string,
+	laddr string,
+	gdmRepo string,
+	profiling bool,
+	enableAutoResolver bool,
+) (actions.Action, error) {
 	dff.Offset = "*"
 	dff.Flavor = "*"
 	profiling = profiling || os.Getenv("SOUS_PROFILING") == "enable"
@@ -105,6 +112,11 @@ func (di *SousGraph) GetServer(dff config.DeployFilterFlags, dryrun string, ladd
 		return nil, err
 	}
 
+	ar := scoop.AutoResolver
+	if !enableAutoResolver {
+		ar = nil
+	}
+
 	return &actions.Server{
 		DeployFilterFlags: dff,
 		GDMRepo:           gdmRepo,
@@ -113,6 +125,6 @@ func (di *SousGraph) GetServer(dff config.DeployFilterFlags, dryrun string, ladd
 		Log:               scoop.LogSink.LogSink,
 		Config:            scoop.Config,
 		ServerHandler:     scoop.ServerHandler.Handler,
-		AutoResolver:      scoop.AutoResolver,
+		AutoResolver:      ar,
 	}, nil
 }

--- a/lib/resolver.go
+++ b/lib/resolver.go
@@ -43,25 +43,24 @@ func (r *Resolver) queueDiffs(dcs *DeployableChans, results chan DiffResolution)
 	var wg sync.WaitGroup
 	for p := range dcs.Pairs {
 		sr := NewRectification(*p)
-		messages.ReportLogFieldsMessageWithIDs("Adding to queset", logging.ExtraDebug1Level, r.ls, p, sr)
+		messages.ReportLogFieldsMessageWithIDs("Adding to queue-set", logging.ExtraDebug1Level, r.ls, p, sr)
 		queued, ok := r.QueueSet.PushIfEmpty(sr)
 		if !ok {
-			messages.ReportLogFieldsMessageWithIDs("failed to que", logging.ExtraDebug1Level, r.ls, p, sr)
+			messages.ReportLogFieldsMessageWithIDs("Failed to queue", logging.ExtraDebug1Level, r.ls, p, sr)
 			reportR11nAnomaly(r.ls, sr, r11nDroppedQueueNotEmpty)
 			continue
 		}
 		wg.Add(1)
-		did := p.ID() // Capture did from the range var p outside the goroutine.
-		go func() {
+		go func(p *DeployablePair) {
 			defer wg.Done()
 			messages.ReportLogFieldsMessageWithIDs("Inserting to QueueSet.Wait", logging.ExtraDebug1Level, r.ls, queued.ID, p, sr)
-			result, ok := r.QueueSet.Wait(did, queued.ID)
+			result, ok := r.QueueSet.Wait(p.ID(), queued.ID)
 			if !ok {
-				messages.ReportLogFieldsMessageWithIDs("failed to QueueSet.Wait", logging.ExtraDebug1Level, r.ls, queued.ID, p, sr)
+				messages.ReportLogFieldsMessageWithIDs("Failed to QueueSet.Wait", logging.ExtraDebug1Level, r.ls, queued.ID, p, sr)
 				reportR11nAnomaly(r.ls, sr, r11nWentMissing)
 			}
 			results <- result
-		}()
+		}(p)
 	}
 	wg.Wait()
 }


### PR DESCRIPTION
Adds a flag to sous server to disable the autoresolver.
This is only intended to be used for local debugging efforts,
so it has not been made a configuration option.

There's also a couple of logging cleanups and linter satisfaction changes.