### PR TITLE
Fixes deployment leak in DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ with respect to its command line interface and HTTP interface.
 ### Fixed
 * Client: running `sous` from outside of git workspaces no longer results in
   a confusing Git error.
+* Server: DB reading was omitting deployments without owners.
 
 ## [0.5.72](//github.com/opentable/sous/compare/0.5.71...0.5.72)
 

--- a/cli/actions/server.go
+++ b/cli/actions/server.go
@@ -109,6 +109,7 @@ func reportServerMessage(msg string, filterFlags config.DeployFilterFlags, liste
 
 func (msg serverMessage) WriteToConsole(console io.Writer) {
 	console.Write([]byte(msg.msg))
+	console.Write([]byte("\n"))
 }
 
 func (msg serverMessage) DefaultLevel() logging.Level {

--- a/ext/storage/disk_state_manager.go
+++ b/ext/storage/disk_state_manager.go
@@ -132,7 +132,7 @@ func reportDiskStateManagerMessage(msg string, f []sous.Flaw, err error, log log
 		msg:          msg,
 		CallerInfo:   logging.GetCallerInfo(logging.NotHere()),
 		err:          err,
-		flawsMessage: sous.FlawMessage{f},
+		flawsMessage: sous.FlawMessage{Flaws: f},
 		debug:        isDebug,
 	}
 	logging.Deliver(msgLog, log)

--- a/ext/storage/disk_state_manager_test.go
+++ b/ext/storage/disk_state_manager_test.go
@@ -171,8 +171,9 @@ func exampleState() *sous.State {
 			},
 			&sous.Manifest{
 				Source: sl2,
-				Owners: []string{"Sous Team"},
-				Kind:   "http-service",
+				Owners: []string{},
+				//Owners: []string{"Sous Team"},
+				Kind: "http-service",
 				Deployments: map[string]sous.DeploySpec{
 					"cluster-1": {
 						DeployConfig: sous.DeployConfig{

--- a/ext/storage/messages.go
+++ b/ext/storage/messages.go
@@ -1,8 +1,6 @@
 package storage
 
 import (
-	"fmt"
-	"io"
 	"strings"
 	"time"
 

--- a/ext/storage/messages.go
+++ b/ext/storage/messages.go
@@ -66,10 +66,6 @@ func (msg *sqlMessage) EachField(fn logging.FieldReportFn) {
 	}
 }
 
-func (msg *sqlMessage) WriteToConsole(c io.Writer) {
-	fmt.Fprintf(c, "SQL: %s %s %d rows err:%s \n", msg.mainTable, msg.dir, msg.rowcount, msg.err)
-}
-
 // MetricsTo implements MetricsMessage on sqlMessage
 func (msg *sqlMessage) MetricsTo(sink logging.MetricsSink) {
 	msg.MessageInterval.TimeMetric(strings.Join([]string{msg.mainTable, msg.dir.String(), "time"}, "."), sink)

--- a/ext/storage/messages.go
+++ b/ext/storage/messages.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -62,6 +64,10 @@ func (msg *sqlMessage) EachField(fn logging.FieldReportFn) {
 	if msg.err != nil {
 		fn("sous-sql-errreturned", msg.err.Error())
 	}
+}
+
+func (msg *sqlMessage) WriteToConsole(c io.Writer) {
+	fmt.Fprintf(c, "SQL: %s %s %d rows err:%s \n", msg.mainTable, msg.dir, msg.rowcount, msg.err)
 }
 
 // MetricsTo implements MetricsMessage on sqlMessage

--- a/ext/storage/postgresstatemanager_read.go
+++ b/ext/storage/postgresstatemanager_read.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lib/pq"
 	sous "github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/logging"
@@ -231,7 +230,6 @@ func loadManifests(context context.Context, log logging.LogSink, tx *sql.Tx, sta
 			); err != nil {
 				return errors.Wrapf(err, "loadManifests")
 			}
-			spew.Dump(m.ID().String())
 			if newM, has := state.Manifests.Get(m.ID()); has {
 				m = newM
 			} else {

--- a/ext/storage/postgresstatemanager_read.go
+++ b/ext/storage/postgresstatemanager_read.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/lib/pq"
 	sous "github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/logging"
@@ -159,26 +160,26 @@ func loadClusters(context context.Context, log logging.LogSink, tx *sql.Tx, stat
 }
 
 func loadManifests(context context.Context, log logging.LogSink, tx *sql.Tx, state *sous.State) error {
-	return loadTable(context, log, tx, "components",
+	return loadTable(context, log, tx, "manifests",
 		// This query is somewhat naive and returns many more rows than we need
 		// specifically, every possible combination of env/resource/volume/metadata
 		// results in its own row. Maybe that could be reduced?
 		`select
 			"repo", "dir", "flavor", components.kind,
-			"email",
 			"versionstring", "num_instances", "schedule_string",
 			"cr_skip", "cr_connect_delay", "cr_timeout", "cr_connect_interval",
 			"cr_proto", "cr_path", "cr_port_index", "cr_failure_statuses",
 			"cr_uri_timeout", "cr_interval", "cr_retries",
 			clusters.name,
+			"host", "container", "mode",
 			envs.key, envs.value,
 			"resource_name", "resource_value",
 			metadatas.name, metadatas.value,
-			"host", "container", "mode"
+			"email"
 		from
 			components
-			join component_owners using (component_id)
-			join owners using (owner_id)
+			left join component_owners using (component_id)
+			left join owners using (owner_id)
 			join deployments using (component_id)
 			join clusters using (cluster_id)
 			left join envs using (deployment_id)
@@ -203,7 +204,7 @@ func loadManifests(context context.Context, log logging.LogSink, tx *sql.Tx, sta
 					Volumes:   sous.Volumes{},
 				},
 			}
-			var ownerEmail, versionString,
+			var versionString,
 				clusterName string
 
 			var envKey, envValue,
@@ -211,30 +212,39 @@ func loadManifests(context context.Context, log logging.LogSink, tx *sql.Tx, sta
 				mdName, mdValue,
 				volHost, volContainer, volMode sql.NullString
 
+			var ownerEmail sql.NullString
+
 			failStates := make(pq.Int64Array, 0)
 
 			if err := rows.Scan(
 				&m.Source.Repo, &m.Source.Dir, &m.Flavor, &m.Kind,
-				&ownerEmail,
 				&versionString, &ds.NumInstances, &ds.Schedule,
 				&ds.Startup.SkipCheck, &ds.Startup.ConnectDelay, &ds.Startup.Timeout, &ds.Startup.ConnectInterval,
 				&ds.Startup.CheckReadyProtocol, &ds.Startup.CheckReadyURIPath, &ds.Startup.CheckReadyPortIndex, &failStates,
 				&ds.Startup.CheckReadyURITimeout, &ds.Startup.CheckReadyInterval, &ds.Startup.CheckReadyRetries,
 				&clusterName,
+				&volHost, &volContainer, &volMode,
 				&envKey, &envValue,
 				&resName, &resValue,
 				&mdName, &mdValue,
-				&volHost, &volContainer, &volMode,
+				&ownerEmail,
 			); err != nil {
 				return errors.Wrapf(err, "loadManifests")
 			}
+			spew.Dump(m.ID().String())
 			if newM, has := state.Manifests.Get(m.ID()); has {
 				m = newM
 			} else {
 				state.Manifests.Add(m)
 			}
 			set := sous.NewOwnerSet(m.Owners...)
-			set.Add(ownerEmail)
+			if ownerEmail.Valid {
+				email, err := ownerEmail.Value()
+				if err != nil {
+					panic(err)
+				}
+				set.Add(email.(string))
+			}
 			m.Owners = set.Slice()
 			if newDS, has := m.Deployments[clusterName]; has {
 				ds = newDS
@@ -288,6 +298,7 @@ func loadTable(ctx context.Context, log logging.LogSink, tx *sql.Tx, mainTable s
 	}
 	defer rows.Close()
 	for rows.Next() {
+		rowcount++
 		if err := pack(rows); err != nil {
 			reportSQLMessage(log, start, mainTable, read, sql, rowcount, err)
 			return errors.Wrapf(err, "sql %q", sql)

--- a/ext/storage/postgresstatemanager_write.go
+++ b/ext/storage/postgresstatemanager_write.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/lib/pq"
 	sous "github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/logging"
@@ -71,25 +70,13 @@ func storeManifests(ctx context.Context, log logging.LogSink, state *sous.State,
 			alldeps.Add(diff.Prior.Deployment)
 		}
 	}
-	spew.Dump(
-		currentDeps.Len(),
-		newDeps.Len(),
-		updates.Len(),
-		deletes.Len(),
-		alldeps.Len(),
-	)
 
-	for _, k := range newDeps.Keys() {
-		if _, there := currentDeps.Get(k); !there {
-			spew.Dump(k.String())
-			break
-		}
-	}
-
-	/*
-		for _, k := range currentDeps.Keys() {
-			spew.Dump(k)
-		}
+	/* XXX consider logging this
+	currentDeps.Len(),
+	newDeps.Len(),
+	updates.Len(),
+	deletes.Len(),
+	alldeps.Len(),
 	*/
 
 	if err := execInsertDeployments(ctx, log, tx, alldeps, "components", "on conflict do nothing", func(fields sqlgen.FieldSet, dep *sous.Deployment) {

--- a/ext/storage/postgresstatemanager_write.go
+++ b/ext/storage/postgresstatemanager_write.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/lib/pq"
 	sous "github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/logging"
@@ -70,6 +71,26 @@ func storeManifests(ctx context.Context, log logging.LogSink, state *sous.State,
 			alldeps.Add(diff.Prior.Deployment)
 		}
 	}
+	spew.Dump(
+		currentDeps.Len(),
+		newDeps.Len(),
+		updates.Len(),
+		deletes.Len(),
+		alldeps.Len(),
+	)
+
+	for _, k := range newDeps.Keys() {
+		if _, there := currentDeps.Get(k); !there {
+			spew.Dump(k.String())
+			break
+		}
+	}
+
+	/*
+		for _, k := range currentDeps.Keys() {
+			spew.Dump(k)
+		}
+	*/
 
 	if err := execInsertDeployments(ctx, log, tx, alldeps, "components", "on conflict do nothing", func(fields sqlgen.FieldSet, dep *sous.Deployment) {
 		fields.Row(func(r sqlgen.RowDef) {

--- a/ext/storage/testdata/in/manifests/github.com/user/project.yaml
+++ b/ext/storage/testdata/in/manifests/github.com/user/project.yaml
@@ -1,6 +1,5 @@
 Source: github.com/user/project
-Owners:
-- Sous Team
+Owners: []
 Kind: http-service
 Deployments:
   cluster-1:


### PR DESCRIPTION
Cause was that deployments with 0-length owners lists weren't being selected.