### PR TITLE
server: /single-deployment deployspec validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ with respect to its command line interface and HTTP interface.
 
 ### Fixed
 * Server: /deploy-queue-item now returns correct queue position and Resolution field.
+* Server: /single-deployment validation now correctly validates only after taking
+  into consideration default values.
 
 ## [0.5.76](//github.com/opentable/sous/compare/0.5.72...0.5.76)
 

--- a/server/data.go
+++ b/server/data.go
@@ -57,7 +57,7 @@ type (
 	// of HTTP methods of a SingleDeploymentResource.
 	SingleDeploymentBody struct {
 		Meta       ResponseMeta
-		Deployment sous.DeploySpec
+		Deployment *sous.DeploySpec
 	}
 )
 
@@ -153,7 +153,7 @@ func (b SingleDeploymentBody) VariancesFrom(other restful.Comparable) restful.Va
 	default:
 		return restful.Variances{"Not a SingleDeploymentBody"}
 	case *SingleDeploymentBody:
-		_, diffs := (&b.Deployment).Diff(ob.Deployment)
+		_, diffs := (b.Deployment).Diff(*ob.Deployment)
 		return restful.Variances(diffs)
 	}
 }

--- a/server/handle_single_deployment.go
+++ b/server/handle_single_deployment.go
@@ -103,7 +103,7 @@ func (h *GETSingleDeploymentHandler) Exchange() (interface{}, int) {
 		return h.err(404, "Manifest %q has no deployment for cluster %q.", m.ID(), did.Cluster)
 	}
 
-	h.Body.Deployment = dep
+	h.Body.Deployment = &dep
 
 	return h.ok(200, nil)
 }
@@ -137,12 +137,11 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 		return psd.err(400, "Error parsing body: %s.", err)
 	}
 
-	messages.ReportLogFieldsMessageToConsole("Exchange PutSingleDeplymentHandler", logging.ExtraDebug1Level, psd.log, did, psd.Body)
-
-	flaws := psd.Body.Deployment.Validate()
-	if len(flaws) > 0 {
-		return psd.err(400, "Invalid deployment: %q", flaws)
+	if psd.Body.Deployment == nil {
+		return psd.err(400, "Body.Deployment is nil.")
 	}
+
+	messages.ReportLogFieldsMessageToConsole("Exchange PutSingleDeplymentHandler", logging.ExtraDebug1Level, psd.log, did, psd.Body)
 
 	m, ok := psd.GDM.Manifests.Get(did.ManifestID)
 	if !ok {
@@ -159,7 +158,7 @@ func (psd *PUTSingleDeploymentHandler) Exchange() (interface{}, int) {
 		return psd.ok(200, nil)
 	}
 
-	m.Deployments[did.Cluster] = psd.Body.Deployment
+	m.Deployments[did.Cluster] = *psd.Body.Deployment
 
 	user := sous.User(psd.GetUser(psd.req))
 


### PR DESCRIPTION
- No longer validates the partial deploy spec from the request
  since we expect that to be incomplete information.
- Validation is still done after round-tripping the new DeploySpec
  to the GDM so that default values are added.