### PR TITLE
Rectifier polls singularity for deploy to complete.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ with respect to its command line interface and HTTP interface.
 
 ## [Unreleased](//github.com/opentable/sous/compare/0.5.76...HEAD)
 
+### Added
+* Server: Single deployment rectification now waits for a reports a DeployState.
+
 ### Fixed
 * Server: /deploy-queue-item now returns correct queue position and Resolution field.
 

--- a/ext/singularity/actual_deployment_set.go
+++ b/ext/singularity/actual_deployment_set.go
@@ -240,6 +240,7 @@ func (sc *deployer) depPipeline(
 	errCh chan error,
 ) {
 	defer catchAndSend("dependency building", errCh, sc.log)
+	// XXX This doesn't as yet actually restrict the number of assemblers.
 	poolLimit := make(chan struct{}, poolCount)
 	for req := range reqCh {
 		depAssWait.Add(1)

--- a/ext/singularity/actual_deployment_set_test.go
+++ b/ext/singularity/actual_deployment_set_test.go
@@ -18,7 +18,7 @@ func TestGetDepSetWorks(t *testing.T) {
 
 	reg := sous.NewDummyRegistry()
 	client := sous.NewDummyRectificationClient()
-	singFac := func(url string) *singularity.Client {
+	singFac := func(url string) singClient {
 		cl, co := singularity.NewDummyClient(url)
 
 		co.FeedDTO(&dtos.SingularityRequestParentList{

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -52,9 +52,6 @@ type (
 		log           logging.LogSink
 	}
 
-	// DeployerOption is an option for configuring singularity deployers.
-	DeployerOption func(*deployer)
-
 	// rectificationClient abstracts the raw interactions with Singularity.
 	rectificationClient interface {
 		// Deploy creates a new deploy on a particular requeust
@@ -86,12 +83,6 @@ func NewDeployer(c rectificationClient, ls logging.LogSink, options ...DeployerO
 		opt(d)
 	}
 	return d
-}
-
-// OptMaxHTTPReqsPerServer overrides the DefaultMaxHTTPConcurrencyPerServer
-// for this server.
-func OptMaxHTTPReqsPerServer(n int) DeployerOption {
-	return func(d *deployer) { d.ReqsPerServer = n }
 }
 
 // Rectify invokes actions to ensure that the real world matches pair.Post,
@@ -229,7 +220,6 @@ func (r *deployer) RectifySingleModification(pair *sous.DeployablePair) (err err
 	}
 	reqID := data.requestID
 
-	//changesApplied := false
 	reportDeployerMessage("Operating on request", pair, diffs, data, nil, logging.ExtraDebug1Level, r.log)
 	if changesReq(pair) {
 		reportDeployerMessage("Updating request", pair, diffs, data, nil, logging.DebugLevel, r.log)
@@ -237,7 +227,6 @@ func (r *deployer) RectifySingleModification(pair *sous.DeployablePair) (err err
 			reportDeployerMessage("Error posting request to Singularity", pair, diffs, data, err, logging.WarningLevel, r.log)
 			return err
 		}
-		//changesApplied = true
 	} else {
 		reportDeployerMessage("No change to Singularity request required", pair, diffs, data, nil, logging.DebugLevel, r.log)
 	}
@@ -248,7 +237,6 @@ func (r *deployer) RectifySingleModification(pair *sous.DeployablePair) (err err
 			reportDeployerMessage(err.Error(), pair, diffs, data, nil, logging.WarningLevel, r.log)
 			return err
 		}
-		//changesApplied = true
 	} else {
 		reportDeployerMessage("No change to Singularity deployment required", pair, diffs, data, nil, logging.DebugLevel, r.log)
 	}

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -47,7 +47,7 @@ dChans := intendedSet.Diff(existingSet)
 type (
 	deployer struct {
 		Client        rectificationClient
-		singFac       func(string) *singularity.Client
+		singFac       func(string) singClient
 		ReqsPerServer int
 		log           logging.LogSink
 	}
@@ -149,11 +149,11 @@ func (r *deployer) Rectify(pair *sous.DeployablePair) sous.DiffResolution {
 	}
 }
 
-func (r *deployer) SetSingularityFactory(fn func(string) *singularity.Client) {
+func (r *deployer) SetSingularityFactory(fn func(string) singClient) {
 	r.singFac = fn
 }
 
-func (r *deployer) buildSingClient(url string) *singularity.Client {
+func (r *deployer) buildSingClient(url string) singClient {
 	if r.singFac == nil {
 		return singularity.NewClient(url, r.log)
 	}

--- a/ext/singularity/deployer.go
+++ b/ext/singularity/deployer.go
@@ -1,7 +1,6 @@
 package singularity
 
 import (
-	"context"
 	"fmt"
 	"runtime/debug"
 	"strings"

--- a/ext/singularity/deployerconfig.go
+++ b/ext/singularity/deployerconfig.go
@@ -1,0 +1,10 @@
+package singularity
+
+// DeployerOption is an option for configuring singularity deployers.
+type DeployerOption func(*deployer)
+
+// OptMaxHTTPReqsPerServer overrides the DefaultMaxHTTPConcurrencyPerServer
+// for this server.
+func OptMaxHTTPReqsPerServer(n int) DeployerOption {
+	return func(d *deployer) { d.ReqsPerServer = n }
+}

--- a/ext/singularity/requeststate.go
+++ b/ext/singularity/requeststate.go
@@ -1,24 +1,28 @@
 package singularity
 
 import (
-	"context"
-
-	singularity "github.com/opentable/go-singularity"
 	sous "github.com/opentable/sous/lib"
-	"github.com/opentable/sous/util/logging"
 	"github.com/pkg/errors"
 )
 
-// RequestState uses reqID to retrieve the current DeployState in Singularity.
-func RequestState(
-	ctx context.Context,
-	reqID string,
-	url string,
-	client *singularity.Client,
-	reg sous.Registry,
-	clusters sous.Clusters,
-	log logging.LogSink,
-) (*sous.DeployState, error) {
+// Status implements sous.Deployer on deployer.
+func (r *deployer) Status(reg sous.Registry, clusters sous.Clusters, pair *sous.DeployablePair) (*sous.DeployState, error) {
+	var url string
+
+	reqID, err := r.getRequestID(pair.Post)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterName := pair.Post.Deployment.ClusterName
+	if cluster, has := clusters[clusterName]; has {
+		url = cluster.BaseURL
+	} else {
+		return nil, errors.Errorf("No cluster found for %q. Known are: %q.", clusterName, clusters.Names())
+	}
+
+	client := r.buildSingClient(url)
+
 	reqParent, err := client.GetRequest(reqID, false) //don't use the web cache
 	if err != nil {
 		return nil, err
@@ -30,7 +34,12 @@ func RequestState(
 		ReqParent: reqParent,
 	}
 
-	tgt, err := BuildDeployment(reg, clusters, singReq, log)
+	tgt, err := BuildDeployment(reg, clusters, singReq, r.log)
 
 	return &tgt, errors.Wrapf(err, "getting request state")
+}
+
+func (r *deployer) getRequestID(d *sous.Deployable) (string, error) {
+	// TODO: add a cache of known Deployables to their Requests (and current state...)
+	return computeRequestID(d)
 }

--- a/ext/singularity/requeststate.go
+++ b/ext/singularity/requeststate.go
@@ -1,0 +1,36 @@
+package singularity
+
+import (
+	"context"
+
+	singularity "github.com/opentable/go-singularity"
+	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/logging"
+	"github.com/pkg/errors"
+)
+
+// RequestState uses reqID to retrieve the current DeployState in Singularity.
+func RequestState(
+	ctx context.Context,
+	reqID string,
+	url string,
+	client *singularity.Client,
+	reg sous.Registry,
+	clusters sous.Clusters,
+	log logging.LogSink,
+) (*sous.DeployState, error) {
+	reqParent, err := client.GetRequest(reqID, false) //don't use the web cache
+	if err != nil {
+		return nil, err
+	}
+
+	singReq := SingReq{
+		SourceURL: url,
+		Sing:      client,
+		ReqParent: reqParent,
+	}
+
+	tgt, err := BuildDeployment(reg, clusters, singReq, log)
+
+	return &tgt, errors.Wrapf(err, "getting request state")
+}

--- a/ext/singularity/requeststate_test.go
+++ b/ext/singularity/requeststate_test.go
@@ -1,0 +1,87 @@
+package singularity
+
+import (
+	"testing"
+
+	"github.com/nyarly/spies"
+	"github.com/opentable/go-singularity/dtos"
+	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/logging"
+)
+
+func TestStatus(t *testing.T) {
+	ls, _ := logging.NewLogSinkSpy()
+	dep := &deployer{
+		log: ls,
+	}
+
+	sing := singClientFixture()
+	dep.SetSingularityFactory(func(string) singClient {
+		return sing
+	})
+
+	reg, rc := sous.NewRegistrySpy()
+	rc.MatchMethod("ImageLabels", spies.AnyArgs, map[string]string{
+		"com.opentable.sous.repo_url":    "github.com/example/test",
+		"com.opentable.sous.version":     "1.2.3",
+		"com.opentable.sous.revision":    "",
+		"com.opentable.sous.repo_offset": "",
+	}, nil)
+
+	clusters := sous.Clusters{
+		"cluster-1": &sous.Cluster{BaseURL: "http://sing,example.com"},
+	}
+	pair := &sous.DeployablePair{
+		Post: sous.DeployableFixture(""),
+	}
+
+	status, err := dep.Status(reg, clusters, pair)
+	if err != nil {
+		t.Fatalf("%+#v", err)
+	}
+
+	expectedStatus := sous.DeployStatusActive
+	if status.Status != expectedStatus {
+		t.Errorf("Expected status %q, got %q.", expectedStatus, status.Status)
+	}
+
+}
+
+func singClientFixture() singClient {
+	req := &dtos.SingularityRequestParent{
+		Request: &dtos.SingularityRequest{
+			RequestType: dtos.SingularityRequestRequestTypeSERVICE,
+		},
+		RequestDeployState: &dtos.SingularityRequestDeployState{
+			RequestId: "request-id",
+		},
+	}
+
+	dh := &dtos.SingularityDeployHistory{
+		DeployResult: &dtos.SingularityDeployResult{
+			DeployState: dtos.SingularityDeployResultDeployStateSUCCEEDED,
+		},
+
+		DeployMarker: &dtos.SingularityDeployMarker{},
+		Deploy: &dtos.SingularityDeploy{
+			Metadata: map[string]string{
+				sous.ClusterNameLabel: "cluster-1",
+			},
+			ContainerInfo: &dtos.SingularityContainerInfo{
+				Type: dtos.SingularityContainerInfoSingularityContainerTypeDOCKER,
+				Docker: &dtos.SingularityDockerInfo{
+					Image: "docker-image",
+				},
+			},
+			Resources: &dtos.Resources{},
+		},
+	}
+	dhl := dtos.SingularityDeployHistoryList{dh}
+
+	sing, c := newSingClientSpy()
+	c.MatchMethod("GetRequest", spies.AnyArgs, req, nil)
+	c.MatchMethod("GetDeploy", spies.AnyArgs, dh, nil)
+	c.MatchMethod("GetDeploys", spies.AnyArgs, dhl, nil)
+
+	return sing
+}

--- a/ext/singularity/singclient.go
+++ b/ext/singularity/singclient.go
@@ -1,0 +1,54 @@
+package singularity
+
+import (
+	"github.com/nyarly/spies"
+	"github.com/opentable/go-singularity/dtos"
+)
+
+type (
+	// singClient abstracts the queries we use to retrieve data from singularity.
+	singClient interface {
+		GetRequest(reqID string, useCache bool) (*dtos.SingularityRequestParent, error)
+		GetRequests(useCache bool) (dtos.SingularityRequestParentList, error)
+		GetDeploy(reqID, depID string) (*dtos.SingularityDeployHistory, error)
+		GetDeploys(reqID string, count int32, page int32) (dtos.SingularityDeployHistoryList, error)
+	}
+
+	singClientSpy struct {
+		spy *spies.Spy
+	}
+
+	singClientSpyController struct {
+		*spies.Spy
+	}
+)
+
+func newSingClientSpy() (singClientSpy, singClientSpyController) {
+	spy := spies.NewSpy()
+	return singClientSpy{spy: spy}, singClientSpyController{Spy: spy}
+}
+
+func (spy singClientSpy) GetRequest(reqID string, useCache bool) (*dtos.SingularityRequestParent, error) {
+	res := spy.spy.Called(reqID, useCache)
+	return res.Get(0).(*dtos.SingularityRequestParent), res.Error(1)
+}
+
+func (spy singClientSpy) GetRequests(useCache bool) (dtos.SingularityRequestParentList, error) {
+	res := spy.spy.Called(useCache)
+	return res.Get(0).(dtos.SingularityRequestParentList), res.Error(1)
+}
+
+func (spy singClientSpy) GetDeploy(reqID, depID string) (*dtos.SingularityDeployHistory, error) {
+	res := spy.spy.Called(reqID, depID)
+	return res.Get(0).(*dtos.SingularityDeployHistory), res.Error(1)
+}
+
+func (spy singClientSpy) GetDeploys(reqID string, count int32, page int32) (dtos.SingularityDeployHistoryList, error) {
+	res := spy.spy.Called(reqID, count, page)
+	return res.Get(0).(dtos.SingularityDeployHistoryList), res.Error(1)
+}
+
+func (ctrl singClientSpyController) cannedDeploy(cannedAnswer *dtos.SingularityDeployHistory) {
+	ctrl.MatchMethod("GetDeploy", spies.AnyArgs, cannedAnswer, nil)
+	ctrl.MatchMethod("GetDeploys", spies.AnyArgs, dtos.SingularityDeployHistoryList{cannedAnswer}, nil)
+}

--- a/graph/server.go
+++ b/graph/server.go
@@ -27,10 +27,16 @@ func newServerComponentLocator(ls LogSink, cfg LocalSousConfig, ins sous.Inserte
 
 // NewR11nQueueSet returns a new queue set configured to start processing r11ns
 // immediately.
-func NewR11nQueueSet(d sous.Deployer, r sous.Registry) *sous.R11nQueueSet {
+func NewR11nQueueSet(d sous.Deployer, r sous.Registry, rf *sous.ResolveFilter, sr StateReader) *sous.R11nQueueSet {
 	return sous.NewR11nQueueSet(sous.R11nQueueStartWithHandler(
 		func(qr *sous.QueuedR11n) sous.DiffResolution {
-			qr.Rectification.Begin(d, r)
+			qr.Rectification.Begin(d, r, rf, sr.StateReader)
 			return qr.Rectification.Wait()
 		}))
 }
+
+/*
+ar.currentRecorder = ar.Resolver.Begin(ar.GDM, state.Defs.Clusters)
+r:= &ResolveFilter{}
+clusters = r.FilteredClusters(clusters)
+*/

--- a/graph/server.go
+++ b/graph/server.go
@@ -27,16 +27,11 @@ func newServerComponentLocator(ls LogSink, cfg LocalSousConfig, ins sous.Inserte
 
 // NewR11nQueueSet returns a new queue set configured to start processing r11ns
 // immediately.
-func NewR11nQueueSet(d sous.Deployer, r sous.Registry, rf *sous.ResolveFilter, sr StateReader) *sous.R11nQueueSet {
+func NewR11nQueueSet(d sous.Deployer, r sous.Registry, rf *sous.ResolveFilter, sm *ServerStateManager) *sous.R11nQueueSet {
+	sr := sm.StateManager
 	return sous.NewR11nQueueSet(sous.R11nQueueStartWithHandler(
 		func(qr *sous.QueuedR11n) sous.DiffResolution {
-			qr.Rectification.Begin(d, r, rf, sr.StateReader)
+			qr.Rectification.Begin(d, r, rf, sr)
 			return qr.Rectification.Wait()
 		}))
 }
-
-/*
-ar.currentRecorder = ar.Resolver.Begin(ar.GDM, state.Defs.Clusters)
-r:= &ResolveFilter{}
-clusters = r.FilteredClusters(clusters)
-*/

--- a/integration/deployment_builder_test.go
+++ b/integration/deployment_builder_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestBuildDeployments(t *testing.T) {
-
 	// XXX unskip this
 	t.Skipf("Failing test on master preventing progress on other stories.")
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -409,7 +409,7 @@ func (suite *integrationSuite) TestMissingImage() {
 	rf := &sous.ResolveFilter{}
 	sr := sous.NewDummyStateManager()
 	sr.State = &stateOne
-	qs := graph.NewR11nQueueSet(suite.deployer, suite.nameCache, rf, graph.StateReader{sr})
+	qs := graph.NewR11nQueueSet(suite.deployer, suite.nameCache, rf, &graph.ServerStateManager{sr})
 	r := sous.NewResolver(suite.deployer, suite.nameCache, rf, logging.SilentLogSet(), qs)
 
 	deploymentsOne, err := stateOne.Deployments()
@@ -469,7 +469,7 @@ func (suite *integrationSuite) TestResolve() {
 	rf := &sous.ResolveFilter{}
 	sr := sous.NewDummyStateManager()
 	sr.State = &stateOneTwo
-	qs := graph.NewR11nQueueSet(suite.deployer, suite.nameCache, rf, graph.StateReader{sr})
+	qs := graph.NewR11nQueueSet(suite.deployer, suite.nameCache, rf, &graph.ServerStateManager{sr})
 	r := sous.NewResolver(suite.deployer, suite.nameCache, rf, logsink, qs)
 
 	suite.T().Log("Begining OneTwo")
@@ -538,7 +538,7 @@ func (suite *integrationSuite) TestResolve() {
 		rf := &sous.ResolveFilter{}
 		sr := sous.NewDummyStateManager()
 		sr.State = &stateOneTwo
-		qs := graph.NewR11nQueueSet(suite.deployer, suite.nameCache, rf, graph.StateReader{sr})
+		qs := graph.NewR11nQueueSet(suite.deployer, suite.nameCache, rf, &graph.ServerStateManager{sr})
 		r := sous.NewResolver(deployer, suite.nameCache, rf, logging.SilentLogSet(), qs)
 
 		err = r.Begin(deploymentsTwoThree, clusterDefs.Clusters).Wait()

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -406,8 +406,11 @@ func (suite *integrationSuite) TestMissingImage() {
 	}
 
 	// ****
-	qs := graph.NewR11nQueueSet(suite.deployer, suite.nameCache)
-	r := sous.NewResolver(suite.deployer, suite.nameCache, &sous.ResolveFilter{}, logging.SilentLogSet(), qs)
+	rf := &sous.ResolveFilter{}
+	sr := sous.NewDummyStateManager()
+	sr.State = &stateOne
+	qs := graph.NewR11nQueueSet(suite.deployer, suite.nameCache, rf, graph.StateReader{sr})
+	r := sous.NewResolver(suite.deployer, suite.nameCache, rf, logging.SilentLogSet(), qs)
 
 	deploymentsOne, err := stateOne.Deployments()
 	suite.Require().NoError(err)
@@ -463,8 +466,11 @@ func (suite *integrationSuite) TestResolve() {
 	logsink, logController := logging.NewLogSinkSpy()
 
 	// ****
-	qs := graph.NewR11nQueueSet(suite.deployer, suite.nameCache)
-	r := sous.NewResolver(suite.deployer, suite.nameCache, &sous.ResolveFilter{}, logsink, qs)
+	rf := &sous.ResolveFilter{}
+	sr := sous.NewDummyStateManager()
+	sr.State = &stateOneTwo
+	qs := graph.NewR11nQueueSet(suite.deployer, suite.nameCache, rf, graph.StateReader{sr})
+	r := sous.NewResolver(suite.deployer, suite.nameCache, rf, logsink, qs)
 
 	suite.T().Log("Begining OneTwo")
 	err = r.Begin(deploymentsOneTwo, clusterDefs.Clusters).Wait()
@@ -529,8 +535,11 @@ func (suite *integrationSuite) TestResolve() {
 		client := singularity.NewRectiAgent(suite.nameCache)
 		deployer := singularity.NewDeployer(client, logging.SilentLogSet())
 
-		qs := graph.NewR11nQueueSet(suite.deployer, suite.nameCache)
-		r := sous.NewResolver(deployer, suite.nameCache, &sous.ResolveFilter{}, logging.SilentLogSet(), qs)
+		rf := &sous.ResolveFilter{}
+		sr := sous.NewDummyStateManager()
+		sr.State = &stateOneTwo
+		qs := graph.NewR11nQueueSet(suite.deployer, suite.nameCache, rf, graph.StateReader{sr})
+		r := sous.NewResolver(deployer, suite.nameCache, rf, logging.SilentLogSet(), qs)
 
 		err = r.Begin(deploymentsTwoThree, clusterDefs.Clusters).Wait()
 		if err != nil {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -489,32 +489,32 @@ func (suite *integrationSuite) TestResolve() {
 	//time.Sleep(3 * time.Second)
 	WaitForSingularity()
 
-	suite.T().Log("492")
+	log.Print("492")
 	clusters := []string{"test-cluster"}
-	suite.T().Log("494")
+	log.Print("494")
 	ds, which := suite.deploymentWithRepo(clusters, repoOne)
-	suite.T().Log("496")
+	log.Print("496")
 	deps := ds.Snapshot()
-	suite.T().Log("498")
+	log.Print("498")
 	if suite.NotEqual(none, which, "opentable/one not successfully deployed") {
 		one := deps[which]
 		suite.Equal(1, one.NumInstances)
 	}
-	suite.T().Log("503")
+	log.Print("503")
 
-	suite.T().Log("505")
+	log.Print("505")
 	which = suite.findRepo(ds, repoTwo)
-	suite.T().Log("507")
+	log.Print("507")
 	if suite.NotEqual(none, which, "opentable/two not successfully deployed") {
 		two := deps[which]
 		suite.Equal(1, two.NumInstances)
 	}
-	suite.T().Log("512")
+	log.Print("512")
 
 	dispositions := []string{}
-	suite.T().Log("515")
+	log.Print("515")
 	for _, call := range logController.CallsTo("LogMessage") {
-		suite.T().Log("517")
+		log.Print("517")
 		if lm, is := call.PassedArgs().Get(1).(logging.LogMessage); is {
 			lm.EachField(func(name string, val interface{}) {
 				if disp, is := val.(string); is && name == "sous-diff-disposition" {
@@ -523,12 +523,12 @@ func (suite *integrationSuite) TestResolve() {
 			})
 		}
 	}
-	suite.T().Log("526")
+	log.Print("526")
 	sort.Strings(dispositions)
-	suite.T().Log("528")
+	log.Print("528")
 	expectedDispositions := []string{"added", "added", "removed", "removed", "removed", "removed"}
 	if !suite.Equal(expectedDispositions, dispositions) {
-		suite.T().Logf("All log messages:\n")
+		log.Printf("All log messages:\n")
 		for _, call := range logController.CallsTo("LogMessage") {
 			if msg, is := call.PassedArgs().Get(1).(logging.LogMessage); is {
 				m := map[string]interface{}{}
@@ -536,9 +536,9 @@ func (suite *integrationSuite) TestResolve() {
 					m[k] = v
 				})
 				m["message"] = msg.Message()
-				suite.T().Log(spew.Sprintf("%#v", m))
+				log.Print(spew.Sprintf("%#v", m))
 			} else {
-				suite.T().Logf("NOT A LOG MESSAGE: %+#v", call.PassedArgs().Get(1))
+				log.Printf("NOT A LOG MESSAGE: %+#v", call.PassedArgs().Get(1))
 			}
 
 		}
@@ -546,7 +546,7 @@ func (suite *integrationSuite) TestResolve() {
 	}
 
 	// ****
-	suite.T().Log("Resolving from one+two to two+three")
+	log.Print("Resolving from one+two to two+three")
 
 	// XXX Let's hope this is a temporary solution to a testing issue
 	// The problem is laid out in DCOPS-7625

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -170,6 +170,7 @@ func (suite *integrationSuite) BeforeTest(suiteName, testName string) {
 }
 
 func (suite *integrationSuite) deployDefaultContainers() {
+	suite.T().Log("Deploying default containers.")
 	nilStartup := sous.Startup{SkipCheck: true}
 	timeout := 500
 	startup := sous.Startup{
@@ -185,6 +186,7 @@ func (suite *integrationSuite) deployDefaultContainers() {
 
 	// This deployment fails immediately, and never results in a successful deployment at that singularity request.
 	registerAndDeploy(ip, "test-cluster", "supposed-to-fail", "github.com/opentable/homer-says-doh", "fails-labels", "1-fails", []int32{}, nilStartup)
+	suite.T().Log("Deploying default containers; waiting for singularity.")
 	WaitForSingularity()
 }
 
@@ -487,22 +489,32 @@ func (suite *integrationSuite) TestResolve() {
 	//time.Sleep(3 * time.Second)
 	WaitForSingularity()
 
+	suite.T().Log("492")
 	clusters := []string{"test-cluster"}
+	suite.T().Log("494")
 	ds, which := suite.deploymentWithRepo(clusters, repoOne)
+	suite.T().Log("496")
 	deps := ds.Snapshot()
+	suite.T().Log("498")
 	if suite.NotEqual(none, which, "opentable/one not successfully deployed") {
 		one := deps[which]
 		suite.Equal(1, one.NumInstances)
 	}
+	suite.T().Log("503")
 
+	suite.T().Log("505")
 	which = suite.findRepo(ds, repoTwo)
+	suite.T().Log("507")
 	if suite.NotEqual(none, which, "opentable/two not successfully deployed") {
 		two := deps[which]
 		suite.Equal(1, two.NumInstances)
 	}
+	suite.T().Log("512")
 
 	dispositions := []string{}
+	suite.T().Log("515")
 	for _, call := range logController.CallsTo("LogMessage") {
+		suite.T().Log("517")
 		if lm, is := call.PassedArgs().Get(1).(logging.LogMessage); is {
 			lm.EachField(func(name string, val interface{}) {
 				if disp, is := val.(string); is && name == "sous-diff-disposition" {
@@ -511,7 +523,9 @@ func (suite *integrationSuite) TestResolve() {
 			})
 		}
 	}
+	suite.T().Log("526")
 	sort.Strings(dispositions)
+	suite.T().Log("528")
 	expectedDispositions := []string{"added", "added", "removed", "removed", "removed", "removed"}
 	if !suite.Equal(expectedDispositions, dispositions) {
 		suite.T().Logf("All log messages:\n")

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -490,32 +490,22 @@ func (suite *integrationSuite) TestResolve() {
 	//time.Sleep(3 * time.Second)
 	WaitForSingularity()
 
-	log.Print("492")
 	clusters := []string{"test-cluster"}
-	log.Print("494")
 	ds, which := suite.deploymentWithRepo(clusters, repoOne)
-	log.Print("496")
 	deps := ds.Snapshot()
-	log.Print("498")
 	if suite.NotEqual(none, which, "opentable/one not successfully deployed") {
 		one := deps[which]
 		suite.Equal(1, one.NumInstances)
 	}
-	log.Print("503")
 
-	log.Print("505")
 	which = suite.findRepo(ds, repoTwo)
-	log.Print("507")
 	if suite.NotEqual(none, which, "opentable/two not successfully deployed") {
 		two := deps[which]
 		suite.Equal(1, two.NumInstances)
 	}
-	log.Print("512")
 
 	dispositions := []string{}
-	log.Print("515")
 	for _, call := range logController.CallsTo("LogMessage") {
-		log.Print("517")
 		if lm, is := call.PassedArgs().Get(1).(logging.LogMessage); is {
 			lm.EachField(func(name string, val interface{}) {
 				if disp, is := val.(string); is && name == "sous-diff-disposition" {
@@ -524,9 +514,7 @@ func (suite *integrationSuite) TestResolve() {
 			})
 		}
 	}
-	log.Print("526")
 	sort.Strings(dispositions)
-	log.Print("528")
 	expectedDispositions := []string{"added", "added", "removed", "removed", "removed", "removed"}
 	if !suite.Equal(expectedDispositions, dispositions) {
 		log.Printf("All log messages:\n")

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"os"
 	"sort"
 	"testing"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -573,7 +573,7 @@ func (suite *integrationSuite) TestResolve() {
 																																							up
 																																					gofmt?
 			                                                                          `
-		suite.T().Logf("Singularity error:%s... - will try %d more times", spew.Sdump(err)[0:len(suffix)], tries)
+		log.Printf("Singularity error:%s... - will try %d more times", spew.Sdump(err)[0:len(suffix)], tries)
 		time.Sleep(2 * time.Second)
 	}
 

--- a/integration/test-one/Dockerfile
+++ b/integration/test-one/Dockerfile
@@ -11,7 +11,7 @@ RUN rm /srv/config.sample.js
 WORKDIR /
 
 LABEL \
-  com.opentable.sous.repo_url=github.com/opentable/three \
+  com.opentable.sous.repo_url=github.com/opentable/one \
   com.opentable.sous.repo_offset= \
   com.opentable.sous.version=1.1.1 \
   com.opentable.sous.revision=91495f1b1630084e301241100ecf2e775f6b672c

--- a/integration/test-one/Dockerfile
+++ b/integration/test-one/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:latest
 
 ENV package grafana-1.9.1
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl mini-httpd uuid-runtime
+RUN apt-get update --fix-missing
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl uuid-runtime mini-httpd
 
 RUN curl -s http://grafanarel.s3.amazonaws.com/$package.tar.gz | tar -xz --strip-components=1 -C /srv
 COPY config.js /srv/
@@ -11,9 +11,9 @@ RUN rm /srv/config.sample.js
 WORKDIR /
 
 LABEL \
-  com.opentable.sous.repo_url=github.com/opentable/one \
+  com.opentable.sous.repo_url=github.com/opentable/three \
   com.opentable.sous.repo_offset= \
   com.opentable.sous.version=1.1.1 \
   com.opentable.sous.revision=91495f1b1630084e301241100ecf2e775f6b672c
 
-CMD mini-httpd -d /srv -p $PORT0 -D
+CMD mini_httpd -d /srv -p $PORT0 -D

--- a/integration/test-three/Dockerfile
+++ b/integration/test-three/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:latest
 
 ENV package grafana-1.9.1
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl mini-httpd uuid-runtime
+RUN apt-get update --fix-missing
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl uuid-runtime mini-httpd
 
 RUN curl -s http://grafanarel.s3.amazonaws.com/$package.tar.gz | tar -xz --strip-components=1 -C /srv
 COPY config.js /srv/
@@ -16,4 +16,4 @@ LABEL \
   com.opentable.sous.version=1.1.1 \
   com.opentable.sous.revision=91495f1b1630084e301241100ecf2e775f6b672c
 
-CMD mini-httpd -d /srv -p $PORT0 -D
+CMD mini_httpd -d /srv -p $PORT0 -D

--- a/integration/test-two/Dockerfile
+++ b/integration/test-two/Dockerfile
@@ -11,7 +11,7 @@ RUN rm /srv/config.sample.js
 WORKDIR /
 
 LABEL \
-  com.opentable.sous.repo_url=github.com/opentable/three \
+  com.opentable.sous.repo_url=github.com/opentable/two \
   com.opentable.sous.repo_offset= \
   com.opentable.sous.version=1.1.1 \
   com.opentable.sous.revision=91495f1b1630084e301241100ecf2e775f6b672c

--- a/integration/test-two/Dockerfile
+++ b/integration/test-two/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:latest
 
 ENV package grafana-1.9.1
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl mini-httpd uuid-runtime
+RUN apt-get update --fix-missing
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y curl uuid-runtime mini-httpd
 
 RUN curl -s http://grafanarel.s3.amazonaws.com/$package.tar.gz | tar -xz --strip-components=1 -C /srv
 COPY config.js /srv/
@@ -11,9 +11,9 @@ RUN rm /srv/config.sample.js
 WORKDIR /
 
 LABEL \
-  com.opentable.sous.repo_url=github.com/opentable/two \
+  com.opentable.sous.repo_url=github.com/opentable/three \
   com.opentable.sous.repo_offset= \
   com.opentable.sous.version=1.1.1 \
   com.opentable.sous.revision=91495f1b1630084e301241100ecf2e775f6b672c
 
-CMD mini-httpd -d /srv -p $PORT0 -D
+CMD mini_httpd -d /srv -p $PORT0 -D

--- a/lib/deployer.go
+++ b/lib/deployer.go
@@ -26,6 +26,7 @@ func NewDummyDeployer() Deployer {
 	return d
 }
 
+// NewDeployerSpy returns a spy implementation of Deployer.
 func NewDeployerSpy() (Deployer, *spies.Spy) {
 	spy := spies.NewSpy()
 

--- a/lib/deployer.go
+++ b/lib/deployer.go
@@ -8,7 +8,7 @@ type (
 	Deployer interface {
 		RunningDeployments(reg Registry, from Clusters) (DeployStates, error)
 		Rectify(*DeployablePair) DiffResolution
-		Status(Registry, Clusters, *DeployablePair) (DeployState, error)
+		Status(Registry, Clusters, *DeployablePair) (*DeployState, error)
 	}
 
 	// DeployerSpy is a noop deployer.
@@ -22,7 +22,7 @@ func NewDummyDeployer() Deployer {
 	d, c := NewDeployerSpy()
 	c.MatchMethod("RunningDeployments", spies.AnyArgs, NewDeployStates(), nil)
 	c.MatchMethod("Rectify", spies.AnyArgs, DiffResolution{})
-	c.MatchMethod("Status", spies.AnyArgs, DeployState{}, nil)
+	c.MatchMethod("Status", spies.AnyArgs, &DeployState{}, nil)
 	return d
 }
 
@@ -45,7 +45,7 @@ func (dd *DeployerSpy) Rectify(p *DeployablePair) DiffResolution {
 }
 
 // Status implements Deployer
-func (dd *DeployerSpy) Status(r Registry, c Clusters, p *DeployablePair) (DeployState, error) {
+func (dd *DeployerSpy) Status(r Registry, c Clusters, p *DeployablePair) (*DeployState, error) {
 	res := dd.Called(r, c, p)
-	return res.Get(0).(DeployState), res.Error(1)
+	return res.Get(0).(*DeployState), res.Error(1)
 }

--- a/lib/deployer.go
+++ b/lib/deployer.go
@@ -1,30 +1,51 @@
 package sous
 
+import "github.com/nyarly/spies"
+
 type (
 	// Deployer describes a complete deployment system, which is able to create,
 	// read, update, and delete deployments.
 	Deployer interface {
 		RunningDeployments(reg Registry, from Clusters) (DeployStates, error)
 		Rectify(*DeployablePair) DiffResolution
+		Status(Registry, Clusters, *DeployablePair) (DeployState, error)
 	}
 
-	// DummyDeployer is a noop deployer.
-	DummyDeployer struct {
-		deps DeployStates
+	// DeployerSpy is a noop deployer.
+	DeployerSpy struct {
+		*spies.Spy
 	}
 )
 
 // NewDummyDeployer creates a DummyDeployer
-func NewDummyDeployer() *DummyDeployer {
-	return &DummyDeployer{deps: NewDeployStates()}
+func NewDummyDeployer() Deployer {
+	d, c := NewDeployerSpy()
+	c.MatchMethod("RunningDeployments", spies.AnyArgs, NewDeployStates(), nil)
+	c.MatchMethod("Rectify", spies.AnyArgs, DiffResolution{})
+	c.MatchMethod("Status", spies.AnyArgs, DeployState{}, nil)
+	return d
+}
+
+func NewDeployerSpy() (Deployer, *spies.Spy) {
+	spy := spies.NewSpy()
+
+	return &DeployerSpy{Spy: spy}, spy
 }
 
 // RunningDeployments implements Deployer
-func (dd *DummyDeployer) RunningDeployments(reg Registry, from Clusters) (DeployStates, error) {
-	return dd.deps, nil
+func (dd *DeployerSpy) RunningDeployments(reg Registry, from Clusters) (DeployStates, error) {
+	res := dd.Called(reg, from)
+	return res.Get(0).(DeployStates), res.Error(1)
 }
 
 // Rectify implements Deployer
-func (dd *DummyDeployer) Rectify(*DeployablePair) DiffResolution {
-	return DiffResolution{}
+func (dd *DeployerSpy) Rectify(p *DeployablePair) DiffResolution {
+	res := dd.Called(p)
+	return res.Get(0).(DiffResolution)
+}
+
+// Status implements Deployer
+func (dd *DeployerSpy) Status(r Registry, c Clusters, p *DeployablePair) (DeployState, error) {
+	res := dd.Called(r, c, p)
+	return res.Get(0).(DeployState), res.Error(1)
 }

--- a/lib/deploystate.go
+++ b/lib/deploystate.go
@@ -49,6 +49,18 @@ func (ds DeployStates) IgnoringStatus() Deployments {
 	return deployments
 }
 
+// Final reports whether we should expect this DeployState to be finished -
+// in other words, DeployState.Final() -> false implies that a subsequent
+// DeployState will have a different status; polling components will want to poll again.
+func (ds DeployState) Final() bool {
+	switch ds.Status {
+	default:
+		return false
+	case DeployStatusActive, DeployStatusFailed:
+		return true
+	}
+}
+
 // Diff computes the list of differences between two DeployStates and returns
 // "true" if they're different, along with a list of differences
 func (ds *DeployState) Diff(o *DeployState) (bool, []string) {

--- a/lib/rectification.go
+++ b/lib/rectification.go
@@ -45,12 +45,17 @@ func (r *Rectification) Begin(d Deployer, reg Registry, rf *ResolveFilter, state
 			clusters := state.Defs.Clusters
 			clusters = rf.FilteredClusters(clusters)
 
-			depState, err := d.Status(reg, clusters, &r.Pair)
-			if err != nil {
-				r.Resolution.Error = WrapResolveError(err)
-				return
+			for {
+				depState, err := d.Status(reg, clusters, &r.Pair)
+				if err != nil {
+					r.Resolution.Error = WrapResolveError(err)
+					return
+				}
+				r.Resolution.DeployState = depState
+				if depState.Final() {
+					return
+				}
 			}
-			r.Resolution.DeployState = depState
 
 		}()
 	})

--- a/lib/rectification.go
+++ b/lib/rectification.go
@@ -24,7 +24,7 @@ func NewRectification(dp DeployablePair) *Rectification {
 // Begin begins applying sr.Pair using d Deployer. Call Result to get the
 // result. Begin can be called multiple times but performs its function only
 // once.
-func (r *Rectification) Begin(d Deployer, reg Registry) {
+func (r *Rectification) Begin(d Deployer, reg Registry, clusters Clusters) {
 	r.once.Do(func() {
 		// For it to be sensible to separate Begin and Wait,
 		// this needs to happen async
@@ -34,6 +34,8 @@ func (r *Rectification) Begin(d Deployer, reg Registry) {
 				r.Pair = *pair
 			}
 			r.Resolution = d.Rectify(&r.Pair)
+
+			d.Status(reg, clusters, &r.Pair)
 
 			close(r.done)
 		}()

--- a/lib/rectification.go
+++ b/lib/rectification.go
@@ -26,12 +26,17 @@ func NewRectification(dp DeployablePair) *Rectification {
 // once.
 func (r *Rectification) Begin(d Deployer, reg Registry) {
 	r.once.Do(func() {
-		if r.Pair.Post.BuildArtifact == nil {
-			pair, _ := HandlePairsByRegistry(reg, &r.Pair)
-			r.Pair = *pair
-		}
-		r.Resolution = d.Rectify(&r.Pair)
-		close(r.done)
+		// For it to be sensible to separate Begin and Wait,
+		// this needs to happen async
+		go func() {
+			if r.Pair.Post.BuildArtifact == nil {
+				pair, _ := HandlePairsByRegistry(reg, &r.Pair)
+				r.Pair = *pair
+			}
+			r.Resolution = d.Rectify(&r.Pair)
+
+			close(r.done)
+		}()
 	})
 }
 

--- a/lib/rectification.go
+++ b/lib/rectification.go
@@ -1,23 +1,32 @@
 package sous
 
-import "sync"
+import (
+	"context"
+	"sync"
+	"time"
+)
 
 // Rectification represents the rectification of a single DeployablePair.
 type Rectification struct {
 	// Pair is not a pointer as it's considered an immutable instruction.
 	Pair DeployablePair
 	// Resolution is the final resolution of this single rectification.
+	sync.RWMutex
 	Resolution DiffResolution
-	once       sync.Once
-	done       chan struct{}
+
+	once   sync.Once
+	ctx    context.Context
+	cancel func()
 }
 
 // NewRectification is used to rectify differences on a single Deployment.
 // After this its useful life is over.
 func NewRectification(dp DeployablePair) *Rectification {
+	c, cancel := context.WithCancel(context.Background())
 	return &Rectification{
-		Pair: dp,
-		done: make(chan struct{}),
+		Pair:   dp,
+		ctx:    c,
+		cancel: cancel,
 	}
 }
 
@@ -29,30 +38,40 @@ func (r *Rectification) Begin(d Deployer, reg Registry, rf *ResolveFilter, state
 		// For it to be sensible to separate Begin and Wait,
 		// this needs to happen async
 		go func() {
-			defer close(r.done)
+			defer r.cancel()
 			if r.Pair.Post.BuildArtifact == nil {
 				pair, _ := HandlePairsByRegistry(reg, &r.Pair)
 				r.Pair = *pair
 			}
+			r.Lock()
 			r.Resolution = d.Rectify(&r.Pair)
+			r.Unlock()
 
 			state, err := stateReader.ReadState()
 			if err != nil {
+				r.Lock()
 				r.Resolution.Error = WrapResolveError(err)
+				r.Unlock()
 				return
 			}
 
 			clusters := state.Defs.Clusters
 			clusters = rf.FilteredClusters(clusters)
 
+			// TODO constants / configs
+			tick := time.NewTicker(250 * time.Millisecond)
+			end, ec := context.WithTimeout(r.ctx, 20*time.Minute)
+			defer ec()
+
+			defer tick.Stop()
 			for {
-				depState, err := d.Status(reg, clusters, &r.Pair)
-				if err != nil {
-					r.Resolution.Error = WrapResolveError(err)
-					return
-				}
-				r.Resolution.DeployState = depState
-				if depState.Final() {
+				r.pollOnce(d, reg, clusters)
+				select {
+				case <-tick.C:
+				case <-end.Done():
+					r.Lock()
+					r.Resolution.DeployState = &DeployState{}
+					r.Unlock()
 					return
 				}
 			}
@@ -61,8 +80,28 @@ func (r *Rectification) Begin(d Deployer, reg Registry, rf *ResolveFilter, state
 	})
 }
 
+func (r *Rectification) pollOnce(d Deployer, reg Registry, clusters Clusters) {
+	// XXX thread the context from Begin into Deployer.Status
+	depState, err := d.Status(reg, clusters, &r.Pair)
+	if err != nil {
+		r.Lock()
+		r.Resolution.Error = WrapResolveError(err)
+		r.Unlock()
+		r.cancel()
+		return
+	}
+	r.Lock()
+	r.Resolution.DeployState = depState
+	r.Unlock()
+	if depState.Final() {
+		r.cancel()
+	}
+}
+
 // Wait must be called after Begin. It waits for and returns the result.
 func (r *Rectification) Wait() DiffResolution {
-	<-r.done
+	<-r.ctx.Done()
+	r.RLock()
+	defer r.RUnlock()
 	return r.Resolution
 }

--- a/lib/rectification_test.go
+++ b/lib/rectification_test.go
@@ -17,9 +17,9 @@ func TestSingleRectification_Resolve_completes(t *testing.T) {
 	})
 
 	done := make(chan struct{})
+	sr.Begin(NewDummyDeployer(), &DummyRegistry{}, Clusters{})
 
 	go func() {
-		sr.Begin(&DummyDeployer{}, &DummyRegistry{})
 		sr.Wait()
 		close(done)
 	}()

--- a/lib/rectification_test.go
+++ b/lib/rectification_test.go
@@ -17,7 +17,7 @@ func TestSingleRectification_Resolve_completes(t *testing.T) {
 	})
 
 	done := make(chan struct{})
-	sr.Begin(NewDummyDeployer(), &DummyRegistry{}, Clusters{})
+	sr.Begin(NewDummyDeployer(), &DummyRegistry{}, &ResolveFilter{}, NewDummyStateManager())
 
 	go func() {
 		sr.Wait()

--- a/lib/rectification_test.go
+++ b/lib/rectification_test.go
@@ -3,6 +3,8 @@ package sous
 import (
 	"testing"
 	"time"
+
+	"github.com/nyarly/spies"
 )
 
 func TestSingleRectification_Resolve_completes(t *testing.T) {
@@ -17,7 +19,11 @@ func TestSingleRectification_Resolve_completes(t *testing.T) {
 	})
 
 	done := make(chan struct{})
-	sr.Begin(NewDummyDeployer(), &DummyRegistry{}, &ResolveFilter{}, NewDummyStateManager())
+	dpr, c := NewDeployerSpy()
+	c.MatchMethod("Status", spies.AnyArgs, &DeployState{Status: DeployStatusActive}, nil)
+	c.MatchMethod("Rectify", spies.AnyArgs, DiffResolution{}, nil)
+
+	sr.Begin(dpr, &DummyRegistry{}, &ResolveFilter{}, NewDummyStateManager())
 
 	go func() {
 		sr.Wait()

--- a/lib/resolvestatus.go
+++ b/lib/resolvestatus.go
@@ -49,6 +49,8 @@ type (
 		Desc ResolutionType
 		// Error captures the error (if any) encountered during diff resolution
 		Error *ErrorWrapper
+
+		DeployState *DeployState
 	}
 
 	// ResolutionType marks the kind of a DiffResolution

--- a/server/handle_r11n_test.go
+++ b/server/handle_r11n_test.go
@@ -400,8 +400,21 @@ func (a R11nHandlerAsserts) wantR11nResponse(t *testing.T, body interface{}) r11
 func (a R11nHandlerAsserts) wantQueuePos(t *testing.T, r r11nResponse, wantPos int) {
 	t.Helper()
 	gotPos := r.QueuePosition
-	if gotPos != wantPos {
-		t.Errorf("got queue position %d; want %d", gotPos, wantPos)
+	switch {
+	case wantPos < 0:
+		if gotPos >= 0 {
+			t.Errorf("want queue pos < 0, got %d", gotPos)
+		}
+	case wantPos == 0:
+		if gotPos != 0 {
+			t.Errorf("want queue pos == 0, got %d", gotPos)
+		}
+	case wantPos > 0:
+		if gotPos <= 0 {
+			t.Errorf("want queue pos > 0, got %d", gotPos)
+		}
+	default:
+		panic("I don't understand how numbers work")
 	}
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -320,10 +320,10 @@
 			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
-			"checksumSHA1": "C14YBofViq1naOZy+MgYnd7V0nA=",
+			"checksumSHA1": "4krAfHiJ6MMLbtnySsbkopc4+dE=",
 			"path": "github.com/samsalisbury/psyringe",
-			"revision": "bf48489e3f670992e749ebf6f3b3a729b3d864f0",
-			"revisionTime": "2018-02-20T13:36:34Z"
+			"revision": "bc674db6e95c63c8370999d380750c48b9b309a9",
+			"revisionTime": "2018-02-22T10:34:06Z"
 		},
 		{
 			"checksumSHA1": "HlLNyPqfD8bdWbEjcV3wPzTemc8=",


### PR DESCRIPTION
This'll mean that the time between Rectification.Begin() is called and Wait() will
return will be much longer, but once it completes, the service should either be
live in Singularity or failed.

Room for future work: synchronzing the Rectification.Resolution and reporting
it on the endpoint to give "live-er" responses to users.