### PR TITLE
Exit early from resolving Singularity in integration tests for failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ with respect to its command line interface and HTTP interface.
 * Server: /deploy-queue-item now returns correct queue position and Resolution field.
 * Server: /single-deployment validation now correctly validates only after taking
   into consideration default values.
+* Server: integration tests disregard failed deployments as blockers in certain cases
+
 
 ## [0.5.76](//github.com/opentable/sous/compare/0.5.72...0.5.76)
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -550,10 +550,10 @@ func (suite *integrationSuite) TestResolve() {
 		r := sous.NewResolver(deployer, suite.nameCache, rf, logging.SilentLogSet(), qs)
 
 		err := r.Begin(deploymentsTwoThree, clusterDefs.Clusters).Wait()
-		if err == nil {
-			// err was nil, so no need to keep retrying.
+		if !sous.AnyTransientResolveErrors(err) {
 			break
 		}
+
 		//suite.Require().NotRegexp(`Pending deploy already in progress`, err.Error())
 		suffix := `           this is dumb but it would suck to panic during tests
                                                                             what


### PR DESCRIPTION
This should fix one of the causes of slow integration tests