### PR TITLE
#trivial Remove global logger from 3 types

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -430,7 +430,7 @@ func newBuildContext(wd LocalWorkDirShell, c *sous.SourceContext) *sous.BuildCon
 	return &sous.BuildContext{Sh: sh, Source: *c}
 }
 
-func newBuildConfig(f *config.DeployFilterFlags, p *config.PolicyFlags, bc *sous.BuildContext) *sous.BuildConfig {
+func newBuildConfig(ls logging.LogSet, f *config.DeployFilterFlags, p *config.PolicyFlags, bc *sous.BuildContext) *sous.BuildConfig {
 	offset := f.Offset
 	if offset == "" {
 		offset = bc.Source.OffsetDir
@@ -443,6 +443,7 @@ func newBuildConfig(f *config.DeployFilterFlags, p *config.PolicyFlags, bc *sous
 		Strict:     p.Strict,
 		ForceClone: p.ForceClone,
 		Context:    bc,
+		LogSet:     ls,
 	}
 	cfg.Resolve()
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -78,6 +78,9 @@ type (
 	MetricsHandler struct{ http.Handler }
 	// LogSink wraps logging.LogSink
 	LogSink struct{ logging.LogSink }
+	// DefaultLogSink depends only on a semv.Version so can be used prior to reading
+	// any configuration.
+	DefaultLogSink struct{ logging.LogSink }
 	// ClusterManager simply wraps the sous.ClusterManager interface
 	ClusterManager struct{ sous.ClusterManager }
 	// StateManager simply wraps the sous.StateManager interface
@@ -187,6 +190,7 @@ func AddLogs(graph adder) {
 	graph.Add(
 		newLogSet,
 		newLogSink,
+		newDefaultLogSink,
 		newMetricsHandler,
 	)
 }
@@ -343,6 +347,10 @@ func newLogSet(v semv.Version, config PossiblyInvalidConfig) (*logging.LogSet, e
 		return ls, initErr(err, "validating logging configuration")
 	}
 	return ls, nil
+}
+
+func newDefaultLogSink(v semv.Version) DefaultLogSink {
+	return DefaultLogSink{LogSink: logging.NewLogSet(v, "", "", os.Stderr)}
 }
 
 func newLogSink(v *config.Verbosity, set *logging.LogSet) LogSink {

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -450,12 +450,13 @@ func newBuildConfig(ls logging.LogSet, f *config.DeployFilterFlags, p *config.Po
 	return &cfg
 }
 
-func newBuildManager(bc *sous.BuildConfig, sl sous.Selector, lb sous.Labeller, rg sous.Registrar) *sous.BuildManager {
+func newBuildManager(ls logging.LogSink, bc *sous.BuildConfig, sl sous.Selector, lb sous.Labeller, rg sous.Registrar) *sous.BuildManager {
 	return &sous.BuildManager{
 		BuildConfig: bc,
 		Selector:    sl,
 		Labeller:    lb,
 		Registrar:   rg,
+		LogSink:     ls,
 	}
 }
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -47,7 +47,10 @@ type (
 	ProfilingServer bool
 
 	// LocalSousConfig is the configuration for Sous.
-	LocalSousConfig struct{ *config.Config }
+	LocalSousConfig struct {
+		*config.Config
+		LogSink LogSink
+	}
 	// LocalWorkDir is the user's current working directory when they invoke Sous.
 	LocalWorkDir string
 	// LocalWorkDirShell is a shell for working in the user's current working
@@ -430,7 +433,7 @@ func newBuildContext(wd LocalWorkDirShell, c *sous.SourceContext) *sous.BuildCon
 	return &sous.BuildContext{Sh: sh, Source: *c}
 }
 
-func newBuildConfig(ls logging.LogSet, f *config.DeployFilterFlags, p *config.PolicyFlags, bc *sous.BuildContext) *sous.BuildConfig {
+func newBuildConfig(ls LogSink, f *config.DeployFilterFlags, p *config.PolicyFlags, bc *sous.BuildContext) *sous.BuildConfig {
 	offset := f.Offset
 	if offset == "" {
 		offset = bc.Source.OffsetDir
@@ -443,14 +446,14 @@ func newBuildConfig(ls logging.LogSet, f *config.DeployFilterFlags, p *config.Po
 		Strict:     p.Strict,
 		ForceClone: p.ForceClone,
 		Context:    bc,
-		LogSet:     ls,
+		LogSink:    ls,
 	}
 	cfg.Resolve()
 
 	return &cfg
 }
 
-func newBuildManager(ls logging.LogSink, bc *sous.BuildConfig, sl sous.Selector, lb sous.Labeller, rg sous.Registrar) *sous.BuildManager {
+func newBuildManager(ls LogSink, bc *sous.BuildConfig, sl sous.Selector, lb sous.Labeller, rg sous.Registrar) *sous.BuildManager {
 	return &sous.BuildManager{
 		BuildConfig: bc,
 		Selector:    sl,

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -190,7 +190,9 @@ func TestStateManagerSelectsDuplex(t *testing.T) {
 	}
 }
 
-var silentLogSink = LogSink{LogSink: logging.SilentLogSet()}
+var silentLogSink = DefaultLogSink{LogSink: nonDefaultSilentLogSink}
+
+var nonDefaultSilentLogSink = LogSink{LogSink: logging.SilentLogSet()}
 
 func TestNewBuildConfig(t *testing.T) {
 	f := &config.DeployFilterFlags{}
@@ -212,7 +214,7 @@ func TestNewBuildConfig(t *testing.T) {
 		},
 	}
 
-	cfg := newBuildConfig(silentLogSink, f, p, bc)
+	cfg := newBuildConfig(nonDefaultSilentLogSink, f, p, bc)
 	if cfg.Tag != `1.2.3` {
 		t.Errorf("Build config's tag wasn't 1.2.3: %#v", cfg.Tag)
 	}

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -190,6 +190,8 @@ func TestStateManagerSelectsDuplex(t *testing.T) {
 	}
 }
 
+var silentLogSink = LogSink{LogSink: logging.SilentLogSet()}
+
 func TestNewBuildConfig(t *testing.T) {
 	f := &config.DeployFilterFlags{}
 	p := &config.PolicyFlags{}
@@ -210,7 +212,7 @@ func TestNewBuildConfig(t *testing.T) {
 		},
 	}
 
-	cfg := newBuildConfig(f, p, bc)
+	cfg := newBuildConfig(silentLogSink, f, p, bc)
 	if cfg.Tag != `1.2.3` {
 		t.Errorf("Build config's tag wasn't 1.2.3: %#v", cfg.Tag)
 	}

--- a/graph/local_config.go
+++ b/graph/local_config.go
@@ -41,8 +41,8 @@ var printConfigWarningOnce sync.Once
 // RawConfig is a config.Config that's been read from disk but not validated.
 type RawConfig PossiblyInvalidConfig
 
-func newRawConfig(u config.LocalUser, defaultConfig DefaultConfig, gcl *ConfigLoader) (RawConfig, error) {
-	v, err := newPossiblyInvalidConfig(u.ConfigFile(), defaultConfig, gcl)
+func newRawConfig(ls LogSink, u config.LocalUser, defaultConfig DefaultConfig, gcl *ConfigLoader) (RawConfig, error) {
+	v, err := newPossiblyInvalidConfig(ls, u.ConfigFile(), defaultConfig, gcl)
 	return RawConfig(v), initErr(err, "reading config file")
 }
 
@@ -66,7 +66,7 @@ func newConfigLoader(ls logging.LogSink) *ConfigLoader {
 	return &ConfigLoader{ConfigLoader: cl}
 }
 
-func newPossiblyInvalidConfig(path string, defaultConfig DefaultConfig, gcl *ConfigLoader) (PossiblyInvalidConfig, error) {
+func newPossiblyInvalidConfig(ls LogSink, path string, defaultConfig DefaultConfig, gcl *ConfigLoader) (PossiblyInvalidConfig, error) {
 	cl := gcl.ConfigLoader
 
 	pic := defaultConfig
@@ -89,7 +89,10 @@ func newPossiblyInvalidConfig(path string, defaultConfig DefaultConfig, gcl *Con
 			logging.ReportErrorConsole(logging.Log, errors.Wrapf(err, "Newly initialised config file is invalid"))
 			logging.ReportConsoleMsg(logging.Log, logging.WarningLevel, fmt.Sprintf("Please correct the issue by editing %s", path))
 		}
-		lsc := &LocalSousConfig{pic.Config}
+		lsc := &LocalSousConfig{
+			Config:  pic.Config,
+			LogSink: ls,
+		}
 		lsc.Save(path)
 		logging.ReportConsoleMsg(logging.Log, logging.InformationLevel, fmt.Sprintf("initialized config file: %s", path))
 	}()
@@ -168,13 +171,13 @@ func (c *LocalSousConfig) Bytes() []byte {
 
 // GetValue retreives and returns a particular value from the configuration
 func (c *LocalSousConfig) GetValue(name string) (string, error) {
-	v, err := configloader.New().GetValue(c.Config, name)
+	v, err := configloader.New(c.LogSink).GetValue(c.Config, name)
 	return fmt.Sprint(v), err
 }
 
 // SetValue stores a particular value on the config
 func (c *LocalSousConfig) SetValue(path, name, value string) error {
-	if err := configloader.New().SetValidValue(c.Config, name, value); err != nil {
+	if err := configloader.New(c.LogSink).SetValidValue(c.Config, name, value); err != nil {
 		return err
 	}
 	return c.Save(path)

--- a/graph/local_config.go
+++ b/graph/local_config.go
@@ -61,8 +61,8 @@ func newLocalSousConfig(pic PossiblyInvalidConfig) (v LocalSousConfig, err error
 	return v, errors.Wrapf(err, "tip: run 'sous config' to see and manipulate your configuration")
 }
 
-func newConfigLoader() *ConfigLoader {
-	cl := configloader.New()
+func newConfigLoader(ls logging.LogSink) *ConfigLoader {
+	cl := configloader.New(ls.Child("configloader"))
 	return &ConfigLoader{ConfigLoader: cl}
 }
 

--- a/graph/local_config_test.go
+++ b/graph/local_config_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/opentable/sous/config"
 	"github.com/opentable/sous/util/configloader"
+	"github.com/opentable/sous/util/logging"
 )
 
 func remove(path string) error {
@@ -27,9 +28,9 @@ func TestNewConfig(t *testing.T) {
 		}
 	}()
 
-	gcl := newConfigLoader()
+	gcl := newConfigLoader(silentLogSink)
 
-	written, err := newPossiblyInvalidConfig(path, DefaultConfig{&config.Config{}}, gcl)
+	written, err := newPossiblyInvalidConfig(silentLogSink, path, DefaultConfig{&config.Config{}}, gcl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +38,7 @@ func TestNewConfig(t *testing.T) {
 		t.Fatal("Config file not created:", path, ":", err)
 	}
 
-	read, err := newPossiblyInvalidConfig(path, DefaultConfig{&config.Config{}}, gcl)
+	read, err := newPossiblyInvalidConfig(silentLogSink, path, DefaultConfig{&config.Config{}}, gcl)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +53,7 @@ func TestNewConfig(t *testing.T) {
 func TestLoadConfig(t *testing.T) {
 	path := "./testdata/config.yaml"
 
-	cl := configloader.New()
+	cl := configloader.New(logging.SilentLogSet())
 	config := config.Config{}
 	err := cl.Load(&config, path)
 

--- a/lib/build_config.go
+++ b/lib/build_config.go
@@ -15,6 +15,7 @@ type (
 		Repo, Offset, Tag, Revision string
 		Strict, ForceClone          bool
 		Context                     *BuildContext
+		LogSet                      logging.LogSet
 	}
 
 	// An AdvisoryName is the type for advisory tokens.
@@ -134,7 +135,7 @@ func (c *BuildConfig) NewContext() *BuildContext {
 
 func (c *BuildConfig) chooseRemoteURL() string {
 	if c.Repo == "" {
-		messages.ReportLogFieldsMessage("Using best guest", logging.DebugLevel, logging.Log, c.Context.Source.PrimaryRemoteURL)
+		messages.ReportLogFieldsMessage("Using best guest", logging.DebugLevel, c.LogSet, c.Context.Source.PrimaryRemoteURL)
 		return c.Context.Source.PrimaryRemoteURL
 	}
 	return c.Repo
@@ -238,7 +239,7 @@ func (c *BuildConfig) Advisories(ctx *BuildContext) []string {
 		if !hasTag {
 			advs = append(advs, string(EphemeralTag))
 		} else if s.NearestTagRevision != s.Revision {
-			messages.ReportLogFieldsMessage("NearestTagRevision != Revision", logging.DebugLevel, logging.Log, s.NearestTagRevision, s.Revision)
+			messages.ReportLogFieldsMessage("NearestTagRevision != Revision", logging.DebugLevel, c.LogSet, s.NearestTagRevision, s.Revision)
 			advs = append(advs, string(TagNotHead))
 		}
 	}

--- a/lib/build_config.go
+++ b/lib/build_config.go
@@ -15,7 +15,7 @@ type (
 		Repo, Offset, Tag, Revision string
 		Strict, ForceClone          bool
 		Context                     *BuildContext
-		LogSet                      logging.LogSet
+		LogSink                     logging.LogSink
 	}
 
 	// An AdvisoryName is the type for advisory tokens.
@@ -135,7 +135,7 @@ func (c *BuildConfig) NewContext() *BuildContext {
 
 func (c *BuildConfig) chooseRemoteURL() string {
 	if c.Repo == "" {
-		messages.ReportLogFieldsMessage("Using best guest", logging.DebugLevel, c.LogSet, c.Context.Source.PrimaryRemoteURL)
+		messages.ReportLogFieldsMessage("Using best guest", logging.DebugLevel, c.LogSink, c.Context.Source.PrimaryRemoteURL)
 		return c.Context.Source.PrimaryRemoteURL
 	}
 	return c.Repo
@@ -239,7 +239,7 @@ func (c *BuildConfig) Advisories(ctx *BuildContext) []string {
 		if !hasTag {
 			advs = append(advs, string(EphemeralTag))
 		} else if s.NearestTagRevision != s.Revision {
-			messages.ReportLogFieldsMessage("NearestTagRevision != Revision", logging.DebugLevel, c.LogSet, s.NearestTagRevision, s.Revision)
+			messages.ReportLogFieldsMessage("NearestTagRevision != Revision", logging.DebugLevel, c.LogSink, s.NearestTagRevision, s.Revision)
 			advs = append(advs, string(TagNotHead))
 		}
 	}

--- a/lib/build_config_test.go
+++ b/lib/build_config_test.go
@@ -3,6 +3,7 @@ package sous
 import (
 	"testing"
 
+	"github.com/opentable/sous/util/logging"
 	"github.com/opentable/sous/util/shell"
 	"github.com/stretchr/testify/assert"
 )
@@ -37,6 +38,7 @@ func TestPresentExplicitRepo(t *testing.T) {
 				},
 			},
 		},
+		LogSink: logging.SilentLogSet(),
 	}
 
 	ctx := bc.NewContext()
@@ -59,6 +61,7 @@ func TestMissingExplicitRepo(t *testing.T) {
 				},
 			},
 		},
+		LogSink: logging.SilentLogSet(),
 	}
 
 	ctx := bc.NewContext()
@@ -83,6 +86,7 @@ func TestAbsentRepoConfig(t *testing.T) {
 				},
 			},
 		},
+		LogSink: logging.SilentLogSet(),
 	}
 
 	ctx := bc.NewContext()
@@ -105,6 +109,7 @@ func TestNoRepo(t *testing.T) {
 				},
 			},
 		},
+		LogSink: logging.SilentLogSet(),
 	}
 
 	ctx := bc.NewContext()
@@ -124,6 +129,7 @@ func TestNotRequestedRevision(t *testing.T) {
 				Revision: "100100100",
 			},
 		},
+		LogSink: logging.SilentLogSet(),
 	}
 
 	ctx := bc.NewContext()
@@ -143,6 +149,7 @@ func TestUsesRequestedTag(t *testing.T) {
 				Revision: "abcd",
 			},
 		},
+		LogSink: logging.SilentLogSet(),
 	}
 
 	ctx := bc.NewContext()
@@ -159,6 +166,7 @@ func TestAdvisesOfDefaultVersion(t *testing.T) {
 				Revision: "abcd",
 			},
 		},
+		LogSink: logging.SilentLogSet(),
 	}
 
 	ctx := bc.NewContext()
@@ -182,6 +190,7 @@ func TestTagNotHead(t *testing.T) {
 				},
 			},
 		},
+		LogSink: logging.SilentLogSet(),
 	}
 
 	ctx := bc.NewContext()
@@ -204,6 +213,7 @@ func TestEphemeralTag(t *testing.T) {
 				NearestTagRevision: "3541",
 			},
 		},
+		LogSink: logging.SilentLogSet(),
 	}
 	/*
 		bc := BuildConfig{
@@ -251,6 +261,7 @@ func TestContextualization(t *testing.T) {
 				NearestTagRevision: "3541",
 			},
 		},
+		LogSink: logging.SilentLogSet(),
 	}
 
 	ctx := bc.NewContext()
@@ -298,6 +309,7 @@ func TestSetsOffset(t *testing.T) {
 				NearestTagRevision: "def0",
 			},
 		},
+		LogSink: logging.SilentLogSet(),
 	}
 
 	ctx := bc.NewContext()
@@ -314,6 +326,7 @@ func TestDirtyWorkspaceAdvisory(t *testing.T) {
 				DirtyWorkingTree: true,
 			},
 		},
+		LogSink: logging.SilentLogSet(),
 	}
 
 	ctx := bc.NewContext()
@@ -332,6 +345,7 @@ func TestUnpushedRevisionAdvisory(t *testing.T) {
 				RevisionUnpushed: true,
 			},
 		},
+		LogSink: logging.SilentLogSet(),
 	}
 
 	ctx := bc.NewContext()
@@ -350,6 +364,7 @@ func TestPermissiveGuard(t *testing.T) {
 				RevisionUnpushed: true,
 			},
 		},
+		LogSink: logging.SilentLogSet(),
 	}
 
 	ctx := bc.NewContext()
@@ -381,6 +396,7 @@ func TestProductionReady(t *testing.T) {
 				},
 			},
 		},
+		LogSink: logging.SilentLogSet(),
 	}
 
 	ctx := bc.NewContext()
@@ -389,7 +405,9 @@ func TestProductionReady(t *testing.T) {
 }
 
 func TestBuildConfig_GuardRegister(t *testing.T) {
-	c := &BuildConfig{}
+	c := &BuildConfig{
+		LogSink: logging.SilentLogSet(),
+	}
 	bc := &BuildContext{}
 	bc.Advisories = []string{"dirty workspace"}
 	err := c.GuardRegister(contextualizedResults(bc))

--- a/lib/build_manager.go
+++ b/lib/build_manager.go
@@ -17,7 +17,7 @@ type (
 		Selector
 		Labeller
 		Registrar
-		LogSet logging.LogSet
+		LogSink logging.LogSink
 	}
 )
 
@@ -46,7 +46,7 @@ func (m *BuildManager) Build() (*BuildResult, error) {
 // advisories; warns about the advisories and does not register otherwise.
 func (m *BuildManager) RegisterAndWarnAdvisories(br *BuildResult) error {
 	if err := m.BuildConfig.GuardRegister(br); err != nil {
-		logging.ReportError(m.LogSet, err)
+		logging.ReportError(m.LogSink, err)
 	}
 	return m.Register(br)
 }

--- a/lib/build_manager.go
+++ b/lib/build_manager.go
@@ -17,6 +17,7 @@ type (
 		Selector
 		Labeller
 		Registrar
+		LogSet logging.LogSet
 	}
 )
 
@@ -45,7 +46,7 @@ func (m *BuildManager) Build() (*BuildResult, error) {
 // advisories; warns about the advisories and does not register otherwise.
 func (m *BuildManager) RegisterAndWarnAdvisories(br *BuildResult) error {
 	if err := m.BuildConfig.GuardRegister(br); err != nil {
-		logging.ReportError(logging.Log, err)
+		logging.ReportError(m.LogSet, err)
 	}
 	return m.Register(br)
 }

--- a/lib/build_manager_test.go
+++ b/lib/build_manager_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/opentable/sous/util/logging"
 )
 
 func rootedBuildManager(root, offset string) *BuildManager {
@@ -17,6 +19,7 @@ func rootedBuildManager(root, offset string) *BuildManager {
 				},
 			},
 		},
+		LogSink: logging.SilentLogSet(),
 	}
 }
 
@@ -127,6 +130,7 @@ func TestBuildManager_RegisterAndWarnAdvisories_withAdvisories(t *testing.T) {
 	br := contextualizedResults(bc)
 	m := &BuildManager{
 		Registrar: FakeRegistrar{},
+		LogSink:   logging.SilentLogSet(),
 	}
 	if err := m.RegisterAndWarnAdvisories(br); err != nil {
 		t.Fatal(err)

--- a/lib/deploy_config.go
+++ b/lib/deploy_config.go
@@ -113,7 +113,6 @@ func (dc *DeployConfig) String() string {
 
 // Equal is used to compare DeployConfigs
 func (dc *DeployConfig) Equal(o DeployConfig) bool {
-	messages.ReportLogFieldsMessage("checking equal", logging.ExtraDebug1Level, logging.Log, dc, o)
 	diff, _ := dc.Diff(o)
 	return !diff
 }
@@ -181,19 +180,15 @@ func (dc DeployConfig) Clone() (c DeployConfig) {
 
 // Equal compares Envs
 func (e Env) Equal(o Env) bool {
-	messages.ReportLogFieldsMessage("Envs", logging.ExtraDebug1Level, logging.Log, e, o)
 	if len(e) != len(o) {
-		messages.ReportLogFieldsMessage("Envs !=", logging.ExtraDebug1Level, logging.Log, e, o, len(e), len(o))
 		return false
 	}
 
 	for name, value := range e {
 		if ov, ok := o[name]; !ok || ov != value {
-			messages.ReportLogFieldsMessage("Envs: !=", logging.ExtraDebug1Level, logging.Log, e, o, name, value, ov)
 			return false
 		}
 	}
-	messages.ReportLogFieldsMessage("Envs: == !", logging.ExtraDebug1Level, logging.Log, e, o)
 	return true
 }
 

--- a/util/configloader/configloader.go
+++ b/util/configloader/configloader.go
@@ -17,8 +17,8 @@ import (
 )
 
 // New returns a new ConfigLoader.
-func New(ls logging.LogSet) ConfigLoader {
-	return &configLoader{LogSet: ls}
+func New(ls logging.LogSink) ConfigLoader {
+	return &configLoader{LogSink: ls}
 }
 
 type (
@@ -49,8 +49,7 @@ type (
 	}
 
 	configLoader struct {
-		LogSet logging.LogSet
-		// Log is called with debug level logs about how values are resolved.
+		LogSink logging.LogSink
 	}
 )
 
@@ -65,7 +64,7 @@ func (cl *configLoader) Load(target interface{}, filePath string) error {
 		}
 		// I'd like to say "override with e.g. SOUS_CONFIG_FILE", but the
 		// construction of the path happens elsewhere.
-		messages.ReportLogFieldsMessage("No config file found using defaults.", logging.InformationLevel, cl.LogSet, filePath)
+		messages.ReportLogFieldsMessage("No config file found using defaults.", logging.InformationLevel, cl.LogSink, filePath)
 	} else {
 		if err := cl.loadYAMLFile(target, filePath); err != nil {
 			return err
@@ -186,7 +185,7 @@ func (cl *configLoader) overrideField(sf reflect.StructField, originalVal reflec
 	if !present {
 		return nil
 	}
-	messages.ReportLogFieldsMessage("Environment configuration OVERRIDE", logging.DebugLevel, cl.LogSet, envName, envVal)
+	messages.ReportLogFieldsMessage("Environment configuration OVERRIDE", logging.DebugLevel, cl.LogSink, envName, envVal)
 	var finalVal reflect.Value
 	switch originalVal.Interface().(type) {
 	default:

--- a/util/configloader/configloader.go
+++ b/util/configloader/configloader.go
@@ -17,8 +17,8 @@ import (
 )
 
 // New returns a new ConfigLoader.
-func New() ConfigLoader {
-	return &configLoader{}
+func New(ls logging.LogSet) ConfigLoader {
+	return &configLoader{LogSet: ls}
 }
 
 type (
@@ -49,6 +49,7 @@ type (
 	}
 
 	configLoader struct {
+		LogSet logging.LogSet
 		// Log is called with debug level logs about how values are resolved.
 	}
 )
@@ -64,7 +65,7 @@ func (cl *configLoader) Load(target interface{}, filePath string) error {
 		}
 		// I'd like to say "override with e.g. SOUS_CONFIG_FILE", but the
 		// construction of the path happens elsewhere.
-		messages.ReportLogFieldsMessage("No config file found using defaults.", logging.InformationLevel, logging.Log, filePath)
+		messages.ReportLogFieldsMessage("No config file found using defaults.", logging.InformationLevel, cl.LogSet, filePath)
 	} else {
 		if err := cl.loadYAMLFile(target, filePath); err != nil {
 			return err
@@ -185,7 +186,7 @@ func (cl *configLoader) overrideField(sf reflect.StructField, originalVal reflec
 	if !present {
 		return nil
 	}
-	messages.ReportLogFieldsMessage("Environment configuration OVERRIDE", logging.DebugLevel, logging.Log, envName, envVal)
+	messages.ReportLogFieldsMessage("Environment configuration OVERRIDE", logging.DebugLevel, cl.LogSet, envName, envVal)
 	var finalVal reflect.Value
 	switch originalVal.Interface().(type) {
 	default:

--- a/util/configloader/configloader_test.go
+++ b/util/configloader/configloader_test.go
@@ -3,6 +3,8 @@ package configloader
 import (
 	"os"
 	"testing"
+
+	"github.com/opentable/sous/util/logging"
 )
 
 type TestConfig struct {
@@ -26,7 +28,7 @@ func (tc *TestConfig) FillDefaults() error {
 }
 
 func TestLoad(t *testing.T) {
-	cl := New()
+	cl := New(logging.SilentLogSet())
 	c := TestConfig{}
 	if err := cl.Load(&c, "testdata/test_config.yaml"); err != nil {
 		t.Fatal(err)
@@ -38,7 +40,7 @@ func TestLoad(t *testing.T) {
 }
 
 func TestLoad_Defaults(t *testing.T) {
-	cl := New()
+	cl := New(logging.SilentLogSet())
 	c := TestConfig{}
 	if err := cl.Load(&c, "testdata/test_empty_config.yaml"); err != nil {
 		t.Fatal(err)
@@ -50,7 +52,7 @@ func TestLoad_Defaults(t *testing.T) {
 }
 
 func TestLoad_Env(t *testing.T) {
-	cl := New()
+	cl := New(logging.SilentLogSet())
 	c := TestConfig{}
 
 	expected := "other value"
@@ -75,7 +77,7 @@ func TestLoad_Env(t *testing.T) {
 }
 
 func TestLoad_EmptyEnv(t *testing.T) {
-	cl := New()
+	cl := New(logging.SilentLogSet())
 	c := TestConfig{}
 
 	expected := ""
@@ -95,7 +97,7 @@ func TestLoad_EmptyEnv(t *testing.T) {
 }
 
 func TestLoad_Map(t *testing.T) {
-	cl := New()
+	cl := New(logging.SilentLogSet())
 	c := TestedMap{}
 
 	s := `{"env1": "foo", "env2": "bar"}`


### PR DESCRIPTION
Beginning work on removing global logger...

Note I've removed some logs in `.Equal` methods, they need to be reinstated at call sites. It does not seem reasonable to inject a logger into these DTOs, but callers of `.Equal` should have more context so once reinstated the logs should be a lot more useful.\

**UPDATE** it has been proposed that we might not need the removed logging lines at all, I agree that these are trace-level logs that probably aren't generally useful, so I'm happy to just leave them removed.