### PR TITLE
Treat memory as a long for logging purposes

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,5 @@
-{ pkgs ? import ~/dev/nixpkgs {} }:
-#{ pkgs ? import <nixpkgs> {} }:
+#{ pkgs ? import ~/dev/nixpkgs {} }:
+{ pkgs ? import <nixpkgs> {} }:
 
 let
   inherit (pkgs) lib stdenv bundlerEnv;
@@ -12,13 +12,7 @@ let
 in
   stdenv.mkDerivation {
     name = "sous-env";
-    src = ./.;
+    #src = ./.;
 
-    buildInputs = [
-      rubyEnv
-      pkgs.proselint
-      pkgs.postgresql100
-      pkgs.liquibase
-      pkgs.go
-    ];
+    buildInputs = with pkgs; [ rubyEnv proselint postgresql100 liquibase go ];
   }

--- a/util/logging/fieldspecializations.go
+++ b/util/logging/fieldspecializations.go
@@ -6,25 +6,24 @@ import (
 )
 
 type (
-	resourceField float64
 	//CPUResourceField is a specialization of float64 to handle details of ELK.
-	CPUResourceField resourceField
+	CPUResourceField float64
 	//MemResourceField is a specialization of float64 to handle details of ELK.
-	MemResourceField resourceField
+	MemResourceField int64
 )
 
 // EachField implements EachFielder on CPUResourceField.
 func (f CPUResourceField) EachField(fn FieldReportFn) {
-	fn(SousResourceCpus, resourceField(f))
+	fn(SousResourceCpus, f)
 }
 
 // EachField implements EachFielder on CPUResourceField.
 func (f MemResourceField) EachField(fn FieldReportFn) {
-	fn(SousResourceMemory, resourceField(f))
+	fn(SousResourceMemory, f)
 }
 
 // MarshalJSON implements json.Marshaller on CPUResourceField.
-func (f resourceField) MarshalJSON() ([]byte, error) {
+func (f CPUResourceField) MarshalJSON() ([]byte, error) {
 	buf := &bytes.Buffer{}
 	fmt.Fprintf(buf, "%#g", f)
 	return buf.Bytes(), nil

--- a/util/logging/fieldspecializations_test.go
+++ b/util/logging/fieldspecializations_test.go
@@ -14,7 +14,7 @@ func TestCPUResourceField(t *testing.T) {
 	enc.Encode(map[string]interface{}{"test": CPUResourceField(2)})
 
 	t.Log(buf.String())
-	assert.Regexp(t, `2[.]0`, buf.String())
+	assert.Regexp(t, `{"test":2[.]0`, buf.String())
 }
 
 func TestMemoryResourceField(t *testing.T) {
@@ -23,5 +23,5 @@ func TestMemoryResourceField(t *testing.T) {
 	enc.Encode(map[string]interface{}{"test": MemResourceField(200)})
 
 	t.Log(buf.String())
-	assert.Regexp(t, `200`, buf.String())
+	assert.Regexp(t, `{"test":200}`, buf.String())
 }

--- a/util/logging/fieldspecializations_test.go
+++ b/util/logging/fieldspecializations_test.go
@@ -8,11 +8,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestResourceField(t *testing.T) {
+func TestCPUResourceField(t *testing.T) {
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
-	enc.Encode(map[string]interface{}{"test": resourceField(2)})
+	enc.Encode(map[string]interface{}{"test": CPUResourceField(2)})
 
 	t.Log(buf.String())
 	assert.Regexp(t, `2[.]0`, buf.String())
+}
+
+func TestMemoryResourceField(t *testing.T) {
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.Encode(map[string]interface{}{"test": MemResourceField(200)})
+
+	t.Log(buf.String())
+	assert.Regexp(t, `200`, buf.String())
 }


### PR DESCRIPTION
Keep stuff outta the DLQ