### PR TITLE
test-registry: zk 3.4 mesos 1.3.1 sing 0.19.2 #trivial

### DIFF
--- a/integration/test-registry/docker-compose.yml
+++ b/integration/test-registry/docker-compose.yml
@@ -17,14 +17,14 @@ gitserver:
 
 # FROM HERE DOWN: Singularity test setup
 zk:
-  image: bobrik/zookeeper
+  image: zookeeper:3.4
   net: host
   environment:
-    ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=no,clientPort=2181
+    ZK_CONFIG: tickTime=2000,initLimit=10,syncLimit=5,maxClientCnxns=128,forceSync=yes,clientPort=2181
     ZK_ID: 1
 
 master:
-  image: mesosphere/mesos-master:1.1.1
+  image: mesosphere/mesos-master:1.3.1
   net: host
   environment:
     MESOS_ZK: zk://localhost:2181/mesos
@@ -36,7 +36,7 @@ master:
     MESOS_ROLES: "OPS"
 
 slave:
-  image: hubspot/singularityexecutorslave:0.19.0-SNAPSHOT
+  image: hubspot/singularityexecutorslave:0.19.2
   command: mesos-slave
   net: host
   environment:

--- a/integration/test-registry/singularityservice/Dockerfile
+++ b/integration/test-registry/singularityservice/Dockerfile
@@ -1,2 +1,2 @@
-FROM hubspot/singularityservice:0.19.0-SNAPSHOT
+FROM hubspot/singularityservice:0.19.2
 COPY singularity.yaml /etc/singularity/singularity.yaml


### PR DESCRIPTION
- Mesos and zookeeper now match what we're running in all envs.
- Singularity matches latest version in QA.