### PR TITLE
Smoke test cover 'deploy' #trivial

### DIFF
--- a/lib/state_fixture.go
+++ b/lib/state_fixture.go
@@ -10,6 +10,7 @@ import (
 type StateFixtureOpts struct {
 	ClusterCount  int
 	ManifestCount int
+	ClusterSuffix string
 }
 
 // DefaultStateFixture provides a dummy state for tests by calling
@@ -47,7 +48,7 @@ func StateFixture(o StateFixtureOpts) *State {
 	c := Clusters{}
 	// For each cluster add it to defs and add a deployment to each manifest.
 	for clusterN := 0; clusterN < o.ClusterCount; clusterN++ {
-		clusterName := fmt.Sprintf("cluster%d", clusterN)
+		clusterName := fmt.Sprintf("cluster%d%s", clusterN, o.ClusterSuffix)
 		c[clusterName] = &Cluster{
 			Name:    clusterName,
 			Kind:    "singularity",

--- a/test/smoke/newdeploy_test.go
+++ b/test/smoke/newdeploy_test.go
@@ -3,7 +3,7 @@
 package smoke
 
 import (
-	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/opentable/go-singularity/dtos"
@@ -25,10 +25,34 @@ FROM alpine
 CMD echo -n Failing in 10s...; sleep 10; echo Failed; exit 1
 `
 
+func setMemAndCPUForAll(ds sous.DeploySpecs) sous.DeploySpecs {
+	for c := range ds {
+		ds[c].Resources["memory"] = "1"
+		ds[c].Resources["cpus"] = "0.001"
+	}
+	return ds
+}
+
+func setMinimalMemAndCPUNumInst1(m sous.Manifest) sous.Manifest {
+	return transformEachDeployment(m, func(d sous.DeploySpec) sous.DeploySpec {
+		d.Resources["memory"] = "1"
+		d.Resources["cpus"] = "0.001"
+		d.NumInstances = 1
+		return d
+	})
+}
+
+func transformEachDeployment(m sous.Manifest, f func(sous.DeploySpec) sous.DeploySpec) sous.Manifest {
+	for c, d := range m.Deployments {
+		m.Deployments[c] = f(d)
+	}
+	return m
+}
+
 // setupProject creates a brand new git repo containing the provided Dockerfile,
 // commits that Dockerfile, runs 'sous version' and 'sous config', and returns a
 // sous TestClient in the project directory.
-func setupProject(t *testing.T, f TestFixture, dockerfile string) TestClient {
+func setupProject(t *testing.T, f TestFixture, dockerfile string) *TestClient {
 	t.Helper()
 	// Setup project git repo.
 	projectDir := makeGitRepo(t, f.BaseDir, "projects/project1", GitRepoSpec{
@@ -42,12 +66,13 @@ func setupProject(t *testing.T, f TestFixture, dockerfile string) TestClient {
 
 	client := f.Client
 
+	// cd into project dir
+	client.Dir = projectDir
+	client.ClusterSuffix = f.ClusterSuffix
+
 	// Dump sous version & config.
 	t.Logf("Sous version: %s", client.MustRun(t, "version", nil))
 	client.MustRun(t, "config", nil)
-
-	// cd into project dir
-	client.Dir = projectDir
 
 	return client
 }
@@ -98,16 +123,32 @@ func assertActiveStatus(t *testing.T, f TestFixture, did sous.DeploymentID) {
 
 func TestSousDeploy(t *testing.T) {
 
+	resetSingularity(t)
+
+	stopPIDs(t)
+
+	// numFreeAddrs determines the maximum number of parallel sous servers
+	// that can be run by the tests. At some point this may need to be increased.
+	numFreeAddrs := 128
+	freeAddrs := freePortAddrs(t, "127.0.0.1", numFreeAddrs, 6601, 9000)
+	var nextAddrIndex int64
+	nextAddr := func() string {
+		i := atomic.AddInt64(&nextAddrIndex, 1)
+		if i == int64(numFreeAddrs) {
+			panic("ran out of free ports; increase numFreeAddrs")
+		}
+		return freeAddrs[i]
+	}
+
 	for _, deployCommand := range []string{"newdeploy", "deploy"} {
 		t.Run(deployCommand, func(t *testing.T) {
+			t.Parallel()
 
 			t.Run("simple", func(t *testing.T) {
-				f := newTestFixture(t)
+				f := newTestFixture(t, nextAddr)
 				client := setupProject(t, f, simpleServer)
 				client.MustRun(t, "init", nil, "-kind", "http-service")
-				client.TransformManifestAsString(t, nil, func(manifest string) string {
-					return strings.Replace(manifest, "NumInstances: 0", "NumInstances: 1", -1)
-				})
+				client.TransformManifest(t, nil, setMinimalMemAndCPUNumInst1)
 				client.MustRun(t, "build", nil, "-tag", "1.2.3")
 				client.MustRun(t, deployCommand, nil, "-cluster", "cluster1", "-tag", "1.2.3")
 
@@ -126,12 +167,10 @@ func TestSousDeploy(t *testing.T) {
 			})
 
 			t.Run("fails", func(t *testing.T) {
-				f := newTestFixture(t)
+				f := newTestFixture(t, nextAddr)
 				client := setupProject(t, f, failer)
 				client.MustRun(t, "init", nil, "-kind", "http-service")
-				client.TransformManifestAsString(t, nil, func(manifest string) string {
-					return strings.Replace(manifest, "NumInstances: 0", "NumInstances: 1", -1)
-				})
+				client.TransformManifest(t, nil, setMinimalMemAndCPUNumInst1)
 				client.MustRun(t, "build", nil, "-tag", "1.2.3")
 				client.MustFail(t, deployCommand, nil, "-cluster", "cluster1", "-tag", "1.2.3")
 
@@ -150,14 +189,12 @@ func TestSousDeploy(t *testing.T) {
 			})
 
 			t.Run("flavors", func(t *testing.T) {
-				f := newTestFixture(t)
+				f := newTestFixture(t, nextAddr)
 				client := setupProject(t, f, simpleServer)
 				flavor := "flavor1"
 				flavorFlag := &sousFlags{flavor: flavor}
 				client.MustRun(t, "init", flavorFlag, "-kind", "http-service")
-				client.TransformManifestAsString(t, flavorFlag, func(manifest string) string {
-					return strings.Replace(manifest, "NumInstances: 0", "NumInstances: 1", -1)
-				})
+				client.TransformManifest(t, flavorFlag, setMinimalMemAndCPUNumInst1)
 				client.MustRun(t, "build", nil, "-tag", "1.2.3")
 				client.MustRun(t, deployCommand, flavorFlag, "-cluster", "cluster1", "-tag", "1.2.3")
 
@@ -177,12 +214,10 @@ func TestSousDeploy(t *testing.T) {
 			})
 
 			t.Run("pause-unpause", func(t *testing.T) {
-				f := newTestFixture(t)
+				f := newTestFixture(t, nextAddr)
 				client := setupProject(t, f, simpleServer)
 				client.MustRun(t, "init", nil, "-kind", "http-service")
-				client.TransformManifestAsString(t, nil, func(manifest string) string {
-					return strings.Replace(manifest, "NumInstances: 0", "NumInstances: 1", -1)
-				})
+				client.TransformManifest(t, nil, setMinimalMemAndCPUNumInst1)
 				client.MustRun(t, "build", nil, "-tag", "1")
 				client.MustRun(t, "build", nil, "-tag", "2")
 				client.MustRun(t, "build", nil, "-tag", "3")
@@ -211,14 +246,18 @@ func TestSousDeploy(t *testing.T) {
 			})
 
 			t.Run("scheduled", func(t *testing.T) {
-				f := newTestFixture(t)
+				f := newTestFixture(t, nextAddr)
 				client := setupProject(t, f, sleeper)
 				client.MustRun(t, "init", nil, "-kind", "scheduled")
 				client.TransformManifest(t, nil, func(m sous.Manifest) sous.Manifest {
-					d := m.Deployments["cluster1"]
+					clusterName := "cluster1" + f.ClusterSuffix
+					d := m.Deployments[clusterName]
 					d.NumInstances = 1
 					d.Schedule = "*/5 * * * *"
-					m.Deployments["cluster1"] = d
+					m.Deployments[clusterName] = d
+
+					m.Deployments = setMemAndCPUForAll(m.Deployments)
+
 					return m
 				})
 				client.MustRun(t, "build", nil, "-tag", "1.2.3")

--- a/test/smoke/testbunchofsousservers_test.go
+++ b/test/smoke/testbunchofsousservers_test.go
@@ -22,7 +22,7 @@ type TestBunchOfSousServers struct {
 	Instances    []*Instance
 }
 
-func newBunchOfSousServers(t *testing.T, state *sous.State, baseDir string) (*TestBunchOfSousServers, error) {
+func newBunchOfSousServers(t *testing.T, state *sous.State, baseDir string, nextFreeAddr func() string) (*TestBunchOfSousServers, error) {
 	if err := os.MkdirAll(baseDir, 0777); err != nil {
 		return nil, err
 	}
@@ -33,11 +33,10 @@ func newBunchOfSousServers(t *testing.T, state *sous.State, baseDir string) (*Te
 	}
 
 	count := len(state.Defs.Clusters)
-	addrs := freePortAddrs(t, "127.0.0.1", count, 6601, 9000)
 	instances := make([]*Instance, count)
 	for i := 0; i < count; i++ {
 		clusterName := state.Defs.Clusters.Names()[i]
-		inst, err := makeInstance(t, i, clusterName, baseDir, addrs[i])
+		inst, err := makeInstance(t, i, clusterName, baseDir, nextFreeAddr())
 		if err != nil {
 			return nil, errors.Wrapf(err, "making test instance %d", i)
 		}

--- a/test/smoke/testpids_test.go
+++ b/test/smoke/testpids_test.go
@@ -8,12 +8,17 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	ps "github.com/mitchellh/go-ps"
 )
 
+var pidMutex sync.Mutex
+
 func writePID(t *testing.T, pid int) {
+	pidMutex.Lock()
+	defer pidMutex.Unlock()
 	psProc, err := ps.FindProcess(pid)
 	if err != nil {
 		t.Fatalf("cannot inspect proc %d: %s", pid, err)
@@ -50,6 +55,8 @@ func writePID(t *testing.T, pid int) {
 }
 
 func stopPIDs(t *testing.T) {
+	pidMutex.Lock()
+	defer pidMutex.Unlock()
 	t.Helper()
 	d, err := ioutil.ReadFile(pidFile)
 	if err != nil {

--- a/test/smoke/testsingularity_utils_test.go
+++ b/test/smoke/testsingularity_utils_test.go
@@ -17,8 +17,9 @@ import (
 )
 
 type Singularity struct {
-	URL    string
-	client *sing.Client
+	URL           string
+	client        *sing.Client
+	ClusterSuffix string
 }
 
 func NewSingularity(baseURL string) *Singularity {
@@ -27,7 +28,7 @@ func NewSingularity(baseURL string) *Singularity {
 
 func (s *Singularity) PauseRequestForDeployment(t *testing.T, did sous.DeploymentID) {
 	t.Helper()
-	reqID := mustGetReqID(t, did)
+	reqID := s.mustGetReqID(t, did)
 	if _, err := s.client.Pause(reqID, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +62,7 @@ func (s *Singularity) PauseRequestForDeployment(t *testing.T, did sous.Deploymen
 
 func (s *Singularity) UnpauseRequestForDeployment(t *testing.T, did sous.DeploymentID) {
 	t.Helper()
-	reqID := mustGetReqID(t, did)
+	reqID := s.mustGetReqID(t, did)
 	if _, err := s.client.Unpause(reqID, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +81,7 @@ func (s *Singularity) UnpauseRequestForDeployment(t *testing.T, did sous.Deploym
 
 func (s *Singularity) GetRequestForDeployment(t *testing.T, did sous.DeploymentID) *dtos.SingularityRequestParent {
 	t.Helper()
-	reqID := mustGetReqID(t, did)
+	reqID := s.mustGetReqID(t, did)
 	req, err := s.client.GetRequest(reqID, false)
 	if err != nil {
 		t.Fatalf("getting request: %s", err)
@@ -90,7 +91,7 @@ func (s *Singularity) GetRequestForDeployment(t *testing.T, did sous.DeploymentI
 
 func (s *Singularity) GetLatestDeployForDeployment(t *testing.T, did sous.DeploymentID) *dtos.SingularityDeployHistory {
 	t.Helper()
-	reqID := mustGetReqID(t, did)
+	reqID := s.mustGetReqID(t, did)
 	deps, err := s.client.GetDeploys(reqID, 100, 0)
 	if err != nil {
 		t.Fatalf("getting deployments for request: %s", err)
@@ -114,8 +115,9 @@ func (s *Singularity) GetLatestDeployForDeployment(t *testing.T, did sous.Deploy
 	return dep
 }
 
-func mustGetReqID(t *testing.T, did sous.DeploymentID) string {
+func (s *Singularity) mustGetReqID(t *testing.T, did sous.DeploymentID) string {
 	t.Helper()
+	did.Cluster = did.Cluster + s.ClusterSuffix
 	reqID, err := singularity.MakeRequestID(did)
 	if err != nil {
 		t.Fatalf("making singularity request ID: %s", err)


### PR DESCRIPTION
Covers 'deploy' as well as 'newdeploy' and covers a failing task. There have been reports of misreporting deployment success, this is an attempt to reproduce the issue. So far it does not reproduce the issue.

**UPDATE** doubling the number of tests (by running on deploy as well as newdeploy) made these tests take about 15 mins on my machine; too long. By making them run in parallel, they now complete in 2m20s on my machine.