### PR TITLE
more info on can't find manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.86...HEAD)
+### Added
+* Client: add -dev flag, at the moment just affects checking for local images
+* Client: return a better message if manifestid wasn't found
+
 ## [0.5.91](//github.com/opentable/sous/compare/0.5.88...0.5.91)
 ### Added
 * Client: Added a footer after command execution that if present, will display the request id that
@@ -22,9 +27,6 @@ with respect to its command line interface and HTTP interface
 * All: don't log when status poller hasn't changed
 
 
-## [Unreleased](//github.com/opentable/sous/compare/0.5.86...HEAD)
-### Added
-* Client: add -dev flag, at the moment just affects checking for local images
 
 ## [0.5.86](//github.com/opentable/sous/compare/0.5.85...0.5.86)
 ### Added

--- a/cli/actions/deploy.go
+++ b/cli/actions/deploy.go
@@ -45,7 +45,7 @@ func (sd *Deploy) Do() error {
 
 	updater, err := sd.HTTPClient.Retrieve("./single-deployment", q, &d, nil)
 	if err != nil {
-		return errors.Errorf("\nFailed to retrieve current deployment:\n\n\tPlease check your repo, flavor, and offset.   Items are case sensative.  Use the following command to verify values sous expects.\n\n\tsous query gdm\n\nError returned: %s", err)
+		return errors.Errorf("\nFailed to retrieve current deployment:\n\n\tPlease check your repo, flavor, and offset.  Items are case sensitive.  Use the following command to verify values sous expects.\n\n\tsous query gdm\n\nError returned: %s", err)
 	}
 	messages.ReportLogFieldsMessage("SousNewDeploy.Execute Retrieved Deployment",
 		logging.ExtraDebug1Level, sd.LogSink, d)

--- a/cli/actions/deploy.go
+++ b/cli/actions/deploy.go
@@ -45,7 +45,7 @@ func (sd *Deploy) Do() error {
 
 	updater, err := sd.HTTPClient.Retrieve("./single-deployment", q, &d, nil)
 	if err != nil {
-		return errors.Errorf("Failed to retrieve current deployment: %s", err)
+		return errors.Errorf("\nFailed to retrieve current deployment:\n\n\tPlease check your repo, flavor, and offset.   Items are case sensative.  Use the following command to verify values sous expects.\n\n\tsous query gdm\n\nError returned: %s", err)
 	}
 	messages.ReportLogFieldsMessage("SousNewDeploy.Execute Retrieved Deployment",
 		logging.ExtraDebug1Level, sd.LogSink, d)

--- a/util/restful/client.go
+++ b/util/restful/client.go
@@ -386,7 +386,7 @@ func (client *LiveHTTPClient) extractBody(rz *http.Response, rzBody interface{},
 			resourceJSON: bytes.NewBuffer(rzJSON),
 		}, errors.Wrapf(err, "processing response body")
 	case rz.StatusCode < 200 || rz.StatusCode >= 300:
-		return nil, errors.Errorf("%s: %s (%v)", rz.Status, string(b), b)
+		return nil, errors.Errorf("%s: %s", rz.Status, string(b))
 	case rz.StatusCode == http.StatusConflict:
 		return nil, errors.Wrap(retryableError(fmt.Sprintf("%s: %#v", rz.Status, string(b))), "getBody")
 	}


### PR DESCRIPTION
` jc  jc-linux  ~  go  …  github.com  opentable  ot-go-static  master  255  $ 
$ sous deploy -flavor doesnotcomputer -cluster dev-ci-sf
Using server http://127.0.0.1:8888

Failed to retrieve current deployment:

        Please check your repo, flavor, and offset.   Items are case sensative.  Use the following command to verify values sous expects.

        sous query gdm

Error returned: Retrieve ./single-deployment params: map[cluster:dev-ci-sf offset: flavor:doesnotcomputer force:false repo:github.com/opentable/ot-go-static]: 404 Not Found: No manifest with ID "github.com/opentable/ot-go-static~doesnotcomputer"
 ([78 111 32 109 97 110 105 102 101 115 116 32 119 105 116 104 32 73 68 32 34 103 105 116 104 117 98 46 99 111 109 47 111 112 101 110 116 97 98 108 101 47 111 116 45 103 111 45 115 116 97 116 105 99 126 100 111 101 115 110 111 116 99 111 109 112 117 116 101 114 34 10])
Request ID:
        0b42e559-df79-4e65-aa90-125cc9f97277
`