### PR TITLE
Switching back to using revid in labels #trivial

### DIFF
--- a/ext/docker/builder.go
+++ b/ext/docker/builder.go
@@ -116,7 +116,7 @@ func (b *Builder) metadataDockerfile(bp *sous.BuildProduct) io.Reader {
 		Advisories []string
 	}{
 		bp.ID,
-		Labels(sv, bp.RevisionName),
+		Labels(sv, bp.RevID),
 		bp.Advisories,
 	})
 	return &bf

--- a/lib/buildpack.go
+++ b/lib/buildpack.go
@@ -82,6 +82,8 @@ type (
 		Source SourceID
 		Kind   string
 
+		RevID string
+
 		// ID is the artifact identifier - specific to product kind; e.g. docker
 		// products have image ids.
 		// Advisories contain the QA advisories determined on the build, and convey
@@ -114,6 +116,7 @@ func (br *BuildResult) Contextualize(c *BuildContext) {
 			prdt.Advisories = make([]string, 0, len(advs))
 		}
 		prdt.Advisories = append(prdt.Advisories, advs...)
+		prdt.RevID = c.RevID()
 	}
 }
 


### PR DESCRIPTION
The docker label (used to collect information about the image)
now uses the git commit id (i.e. the revision SHA) again.