### PR TITLE
SOUS-919: Primary store toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ with respect to its command line interface and HTTP interface
 
 
 ## [Unreleased](//github.com/opentable/sous/compare/0.5.93...HEAD)
+### Added
+* Server: state storage toggle behind a feature flag - servers can be
+  configured to use the database as the source of truth.
+
 ### Changed
 * Client: Slack add additional channels to send via config
-
 
 ## [0.5.93](//github.com/opentable/sous/compare/0.5.92...0.5.93)
 ### Changed

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,12 @@ type (
 		Server string `env:"SOUS_SERVER"`
 		// Database contains configuration for the local Postgresql DB.
 		Database storage.PostgresConfig
+		// DatabasePrimary controls whether the PostgreSQL database is the primary
+		// datastore, or the git repo at StateLocation is.
+		// As of May 30, 2018, this is being added as a temporary feature flag. The
+		// idea is to use it to transition to DB only and then change the behavior
+		// to be (unconditionally) DatabasePrimary=true.
+		DatabasePrimary bool `env:"SOUS_DATABASE_IS_PRIMARY"`
 		// SiblingURLs is a temporary measure for setting up a distributed cluster
 		// of sous servers. Each server must be configured with accessible URLs for
 		// all the servers in production, as named by cluster.

--- a/graph/actions_test.go
+++ b/graph/actions_test.go
@@ -37,7 +37,7 @@ func fixtureGraph(t *testing.T) *SousGraph {
 		}
 	})
 	tg.Replace(func(ls LogSink) gitStateManager {
-		return gitStateManager{sous.NewDummyStateManager()}
+		return gitStateManager{StateManager: sous.NewDummyStateManager()}
 	})
 	tg.Replace(func() LogSink {
 		return LogSink{logging.SilentLogSet()}

--- a/graph/actions_test.go
+++ b/graph/actions_test.go
@@ -36,10 +36,8 @@ func fixtureGraph(t *testing.T) *SousGraph {
 			return &docker.NameCache{}, nil
 		}
 	})
-	tg.Replace(func(ls LogSink) gitStateManagerFactory {
-		return func() gitStateManager {
-			return gitStateManager{sous.NewDummyStateManager()}
-		}
+	tg.Replace(func(ls LogSink) gitStateManager {
+		return gitStateManager{sous.NewDummyStateManager()}
 	})
 	tg.Replace(func() LogSink {
 		return LogSink{logging.SilentLogSet()}

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -624,10 +624,15 @@ func newInMemoryClient(srvr ServerHandler, log LogSink) (HTTPClient, error) {
 }
 
 func newServerStateManager(c LocalSousConfig, log LogSink, gm gitStateManager, dm distStateManager) (*ServerStateManager, error) {
-	primary := gm
-	secondary := dm
+	var primary, secondary sous.StateManager
+	primary = gm
+	secondary = dm
 
-	duplex := storage.NewDuplexStateManager(primary.StateManager, secondary.StateManager, log.Child("duplex-state"))
+	if c.DatabasePrimary {
+		primary, secondary = secondary, primary
+	}
+
+	duplex := storage.NewDuplexStateManager(primary, secondary, log.Child("duplex-state"))
 	return &ServerStateManager{StateManager: duplex}, nil
 }
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -630,6 +630,19 @@ func newServerStateManager(c LocalSousConfig, log LogSink, gm gitStateManager, d
 
 	if c.DatabasePrimary {
 		primary, secondary = secondary, primary
+		logging.Deliver(log,
+			logging.InformationLevel,
+			logging.SousGenericV1,
+			logging.GetCallerInfo(),
+			logging.MessageField("database is primary datastore"),
+		)
+	} else {
+		logging.Deliver(log,
+			logging.InformationLevel,
+			logging.SousGenericV1,
+			logging.GetCallerInfo(),
+			logging.MessageField("git is primary datastore"),
+		)
 	}
 
 	duplex := storage.NewDuplexStateManager(primary, secondary, log.Child("duplex-state"))


### PR DESCRIPTION
Adds a configuration option `DatabasePrimary` (overridden with
`SOUS_DATABASE_IS_PRIMARY`) which selects which of the datastores to "prefer."
The other is merely updated, but not considered for the current state. This is
the current behavior, with Git as primary and Postgres as secondary.

When the DatabasePrimary config is set, Postgres is considered the sole source
of truth.  This should **not** yet be used in deployment - running smoke tests
with this enabled makes it clear that the "empty" database isn't complete
enough (the tests fail).

It's possible that the has-been-run-as-secondary database is ready to be used
as primary, but I'd like to have a from-scratch solution ready before we try to
roll that out.  We could try it, I suppose in dev and see what happens...

Regardless, this work is ready to merge, and _can_ be deployed. It just
shouldn't be toggled on yet.