### PR TITLE
Localserver #trivial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ fabric.properties
 # ctags files
 .tags
 .vagrant/
+.sous-gdm-temp/

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ PGPORT ?= 6543
 USER_ID ?= $(shell id -u)
 GROUP_ID ?= $(shell id -g)
 
+LOCAL_SERVER_LISTEN ?= localhost:7771
 
 DOCKER_HOST_IP_PARSED ?= $(shell echo "$(DOCKER_HOST)" | grep -E -o '(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)')
 DOCKER_HOST_LOCALHOST := localhost
@@ -478,6 +479,22 @@ postgres-update-schema: postgres-start
 
 postgres-clean: postgres-stop
 	$(DELETE_POSTGRES_DATA)
+
+.PHONY: local-server
+local-server:
+	@if [ -z "$(EMULATE_CLUSTER)" ]; then echo "Please set EMULATE_CLUSTER=<cluster-name>"; exit 1; fi
+	@if [ -z "$(SOUS_GDM_REPO)"]; then echo Please set SOUS_GDM_REPO e.g. git@github.com:my-org/my-gdm.git; exit 1; fi
+	@echo
+	@echo "WARNING WARNING WARNING WARNING WARNING WARNING WARNING"
+	@echo "WARNING => Starting local sous server emulating $(EMULATE_CLUSTER)"
+	@echo "WARNING => This server can only deploy to $(EMULATE_CLUSTER)"
+	@echo "WARNING => This server can read and write to $(SOUS_GDM_REPO)"
+	@echo "WARNING => This may cause inconsistent data."
+	@echo "WARNING => If you still want to proceed, set SOUS_SERVER=http://$(LOCAL_SERVER_LISTEN)"
+	@echo "WARNING => Then your local sous client will run against this server."
+	@echo "WARNING WARNING WARNING WARNING WARNING WARNING WARNING"
+	@echo
+	@export DIR=$(TMPDIR)/sous-gdm-$(DATE) && rm -rf "$$DIR" && git clone $(SOUS_GDM_REPO) $$DIR && SOUS_SIBLING_URLS='{"$(EMULATE_CLUSTER)": "http://$(LOCAL_SERVER_LISTEN)"}' SOUS_STATE_LOCATION=$$DIR SOUS_PG_HOST=$(PGHOST) SOUS_PG_PORT=$(PGPORT) SOUS_PG_USER=postgres sous server -listen $(LOCAL_SERVER_LISTEN) -autoresolver=false
 
 .PHONY: artifactory clean clean-containers clean-container-certs \
 	clean-running-containers clean-container-images coverage deb-build \

--- a/Makefile
+++ b/Makefile
@@ -494,7 +494,7 @@ local-server:
 	@echo "WARNING => Then your local sous client will run against this server."
 	@echo "WARNING WARNING WARNING WARNING WARNING WARNING WARNING"
 	@echo
-	@export DIR=$(TMPDIR)/sous-gdm-$(DATE) && rm -rf "$$DIR" && git clone $(SOUS_GDM_REPO) $$DIR && SOUS_SIBLING_URLS='{"$(EMULATE_CLUSTER)": "http://$(LOCAL_SERVER_LISTEN)"}' SOUS_STATE_LOCATION=$$DIR SOUS_PG_HOST=$(PGHOST) SOUS_PG_PORT=$(PGPORT) SOUS_PG_USER=postgres sous server -listen $(LOCAL_SERVER_LISTEN) -autoresolver=false
+	@export DIR=$(PWD)/.sous-gdm-temp && rm -rf "$$DIR" && git clone $(SOUS_GDM_REPO) $$DIR && SOUS_SIBLING_URLS='{"$(EMULATE_CLUSTER)": "http://$(LOCAL_SERVER_LISTEN)"}' SOUS_STATE_LOCATION=$$DIR SOUS_PG_HOST=$(PGHOST) SOUS_PG_PORT=$(PGPORT) SOUS_PG_USER=postgres sous server -listen $(LOCAL_SERVER_LISTEN) -autoresolver=false -d -v
 
 .PHONY: artifactory clean clean-containers clean-container-certs \
 	clean-running-containers clean-container-images coverage deb-build \

--- a/cli/actions/server.go
+++ b/cli/actions/server.go
@@ -45,6 +45,8 @@ func (ss *Server) Do() error {
 
 	reportServerMessage("Sous Server Running", ss.DeployFilterFlags, ss.ListenAddr, ss.Log)
 
+	fmt.Printf("Listening on http://%s", ss.ListenAddr)
+
 	return server.Run(ss.ListenAddr, ss.ServerHandler)
 }
 


### PR DESCRIPTION
`make local-server` allows running a sous server locally that emulates a real deployed cluster-specific sous server. This is intended for bootstrapping purposes only and comes with an embarrassment of warnings about why it's possibly a bad idea to use.