### PR TITLE
Init flags messages/fail for -kind on-demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.100...master)
+### Changed
+- CLI: Clearer -kind not recognised message.
+- CLI: sous init -kind on-demand fails sooner.
+
 
 ## [0.5.100](//github.com/opentable/sous/compare/0.5.93...0.5.100)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ with respect to its command line interface and HTTP interface
 ## [Unreleased](//github.com/opentable/sous/compare/0.5.100...master)
 ### Changed
 - CLI: Clearer -kind not recognised message.
-- CLI: sous init -kind on-demand fails sooner.
-
 
 ## [0.5.100](//github.com/opentable/sous/compare/0.5.93...0.5.100)
 ### Added

--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -73,7 +73,7 @@ func (si *SousInit) Execute(args []string) cmdr.Result {
 		return cmdr.UsageErrorf("kind %q not defined, pick one of %q or %q", kind, sous.ManifestKindScheduled, sous.ManifestKindService)
 	case sous.ManifestKindService:
 		skipHealth = false
-	case sous.ManifestKindScheduled, sous.ManifestKindOnDemand:
+	case sous.ManifestKindScheduled:
 		skipHealth = true
 	}
 

--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -70,7 +70,7 @@ func (si *SousInit) Execute(args []string) cmdr.Result {
 
 	switch kind {
 	default:
-		return cmdr.UsageErrorf("kind %q not defined, pick one of %q or %q", kind, sous.ManifestKindScheduled, sous.ManifestKindService, sous.ManifestKindOnDemand)
+		return cmdr.UsageErrorf("kind %q not defined, pick one of %q, %q or %q", kind, sous.ManifestKindScheduled, sous.ManifestKindService, sous.ManifestKindOnDemand)
 	case sous.ManifestKindService:
 		skipHealth = false
 	case sous.ManifestKindScheduled, sous.ManifestKindOnDemand:

--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -70,7 +70,7 @@ func (si *SousInit) Execute(args []string) cmdr.Result {
 
 	switch kind {
 	default:
-		return cmdr.UsageErrorf("kind not defined, pick one of %s or %s", sous.ManifestKindScheduled, sous.ManifestKindService)
+		return cmdr.UsageErrorf("kind %q not defined, pick one of %q or %q", kind, sous.ManifestKindScheduled, sous.ManifestKindService)
 	case sous.ManifestKindService:
 		skipHealth = false
 	case sous.ManifestKindScheduled, sous.ManifestKindOnDemand:

--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -70,10 +70,10 @@ func (si *SousInit) Execute(args []string) cmdr.Result {
 
 	switch kind {
 	default:
-		return cmdr.UsageErrorf("kind %q not defined, pick one of %q or %q", kind, sous.ManifestKindScheduled, sous.ManifestKindService)
+		return cmdr.UsageErrorf("kind %q not defined, pick one of %q or %q", kind, sous.ManifestKindScheduled, sous.ManifestKindService, sous.ManifestKindOnDemand)
 	case sous.ManifestKindService:
 		skipHealth = false
-	case sous.ManifestKindScheduled:
+	case sous.ManifestKindScheduled, sous.ManifestKindOnDemand:
 		skipHealth = true
 	}
 

--- a/cli/tests/sous_test.go
+++ b/cli/tests/sous_test.go
@@ -42,7 +42,7 @@ func TestSous_Init(t *testing.T) {
 	term.Stdout.ShouldHaveNumLines(0)
 	term.Stderr.ShouldHaveNumLines(1)
 
-	term.Stderr.ShouldHaveExactLine("kind not defined, pick one of scheduled or http-service")
+	term.Stderr.ShouldHaveExactLine(`kind "" not defined, pick one of "scheduled", "http-service" or "on-demand"`)
 }
 
 func TestSousConfig_validConfig(t *testing.T) {


### PR DESCRIPTION
The change to the error message should be uncontroversial. However, this change explicitly breaks any attempt to `sous init -kind on-demand`. AFAIK (looking at current usage at OpenTable) we are not supporting on-demand jobs, so best to let people know as early as possible.