### PR TITLE
Manifest edit fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.100...master)
+### Fixed
+* CLI: 'sous manifest edit' was sometimes silently failing to apply changes on macOS,
+  changes to how we re-read the temp file resolve this.
+
+### Changed
+* CLI: 'sous manifest edit' now uses a temp file with a .yaml extension so text
+  editors are more likely to apply the right highlighting and auto formatting.
 
 ## [0.5.100](//github.com/opentable/sous/compare/0.5.93...0.5.100)
 ### Added

--- a/cli/sous_manifest_edit.go
+++ b/cli/sous_manifest_edit.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/opentable/sous/graph"
 	"github.com/opentable/sous/util/cmdr"
 	"github.com/opentable/sous/util/restful"
+	"github.com/opentable/sous/util/tempfile"
 	"github.com/pkg/errors"
 )
 
@@ -34,8 +34,7 @@ func (sme *SousManifestEdit) AddFlags(fs *flag.FlagSet) {
 // Execute implements Executor on SousManifestEdit.
 func (sme *SousManifestEdit) Execute(args []string) cmdr.Result {
 	var up restful.Updater
-	file, err := ioutil.TempFile("", "sous_manifest")
-
+	file, err := tempfile.New("", "sous_manifest", ".yaml")
 	if err != nil {
 		return EnsureErrorResult(err)
 	}

--- a/cli/sous_manifest_edit.go
+++ b/cli/sous_manifest_edit.go
@@ -44,20 +44,25 @@ func (sme *SousManifestEdit) Execute(args []string) cmdr.Result {
 		return EnsureErrorResult(err)
 	}
 
-	set, err := sme.SousGraph.GetManifestSet(sme.DeployFilterFlags, &up, file)
-	if err != nil {
-		return EnsureErrorResult(err)
-	}
-
 	if err := get.Do(); err != nil {
 		return EnsureErrorResult(errors.Wrapf(err, "getting manifest into %s", file.Name()))
+	}
+
+	if err := file.Close(); err != nil {
+		return EnsureErrorResult(errors.Wrapf(err, "closing file %s", file.Name()))
 	}
 
 	if err := doEdit(file.Name()); err != nil {
 		return EnsureErrorResult(errors.Wrapf(err, "editing file at %s", file.Name()))
 	}
 
-	if _, err := file.Seek(0, 0); err != nil {
+	file, err = os.Open(file.Name())
+	if err != nil {
+		return EnsureErrorResult(errors.Wrapf(err, "reopening file %s", file.Name()))
+	}
+
+	set, err := sme.SousGraph.GetManifestSet(sme.DeployFilterFlags, &up, file)
+	if err != nil {
 		return EnsureErrorResult(err)
 	}
 

--- a/util/tempfile/tempfile.go
+++ b/util/tempfile/tempfile.go
@@ -1,0 +1,63 @@
+// Package tempfile is based on ioutil.TempFile adding support for a file
+// extension.
+package tempfile
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// Copied verbatim from stdlib...
+
+// Random number state.
+// We generate random temporary file names so that there's a good
+// chance the file doesn't exist yet - keeps the number of tries in
+// TempFile to a minimum.
+var rand uint32
+var randmu sync.Mutex
+
+func reseed() uint32 {
+	return uint32(time.Now().UnixNano() + int64(os.Getpid()))
+}
+
+func nextSuffix() string {
+	randmu.Lock()
+	r := rand
+	if r == 0 {
+		r = reseed()
+	}
+	r = r*1664525 + 1013904223 // constants from Numerical Recipes
+	rand = r
+	randmu.Unlock()
+	return strconv.Itoa(int(1e9 + r%1e9))[1:]
+}
+
+// End verbatim copy.
+
+// New creates a new temp file using the same mechanism as ioutil.TempFile,
+// but adds the supplied extension. E.g. ".yaml"
+// Based on https://golang.org/src/io/ioutil/tempfile.go?s=1285:1342#L37
+func New(dir, prefix, ext string) (f *os.File, err error) {
+	if dir == "" {
+		dir = os.TempDir()
+	}
+
+	nconflict := 0
+	for i := 0; i < 10000; i++ {
+		name := filepath.Join(dir, prefix+nextSuffix()+ext)
+		f, err = os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
+		if os.IsExist(err) {
+			if nconflict++; nconflict > 10 {
+				randmu.Lock()
+				rand = reseed()
+				randmu.Unlock()
+			}
+			continue
+		}
+		break
+	}
+	return
+}


### PR DESCRIPTION
Manifest edit was not working for me, this resolves that issue, see commit comments.
Bonus feature: to get text editors to use YAML formatting and highlighting, this adds a .yaml extension to the temp file.