### PR TITLE
restful: Client.Retrieve check content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface
 
+## [Unreleased](//github.com/opentable/sous/compare/0.5.109...master)
+### Fixed
+* Both: Update how server errors get passed to client, if not json make more
+  readable.
+
+
 ## [0.5.109](//github.com/opentable/sous/compare/0.5.104...0.5.109)
-## Added
+### Added
 * Singularity request ID is now configurable per-deployment in the manifest.
   Changing SingularityRequestID results in the next deployment being done to
   the new SingularityRequestID, and the old singularity request being deleted.


### PR DESCRIPTION
- Now we quit early if the content-type is not JSON
- Also a change to processing in the case we are in an error state,
  do not continue with enriching state.
- Error message is now a simple string with the 'GET \<url\>: \<error\>' for clarity.