### PR TITLE
Smoke test preparations for deeper testing #trivial

### DIFF
--- a/cli/sous_init.go
+++ b/cli/sous_init.go
@@ -62,6 +62,7 @@ func (si *SousInit) AddFlags(fs *flag.FlagSet) {
 	MustAddFlags(fs, &si.Flags, OtplFlagsHelp)
 	fs.StringVar(&si.DeployFilterFlags.Flavor, "flavor", "", flavorFlagHelp)
 	fs.StringVar(&si.DeployFilterFlags.Cluster, "cluster", "", clusterFlagHelp)
+	fs.StringVar(&si.DeployFilterFlags.Repo, "repo", "", repoFlagHelp)
 	fs.StringVar(&si.flags.Kind, "kind", "", kindFlagHelp)
 	fs.BoolVar(&si.DryRunFlag, "dryrun", false, "print out the created manifest but do not save it")
 }

--- a/ext/otpl/otpl.go
+++ b/ext/otpl/otpl.go
@@ -192,7 +192,7 @@ func (mp *ManifestParser) parseSingleOTPLConfig(wd shell.Shell) *otplDeployConfi
 		return deploySpec
 	}
 	if err := wd.JSON(&request, "cat", "singularity-request.json"); err != nil {
-		messages.ReportLogFieldsMessageToConsole("failed to read singularity-request.json", logging.WarningLevel,
+		messages.ReportLogFieldsMessageToConsole("failed to read singularity-request.json: "+err.Error(), logging.WarningLevel,
 			mp.Log, err)
 		return deploySpec
 	}

--- a/lib/internalsupportfortest.go
+++ b/lib/internalsupportfortest.go
@@ -3,6 +3,7 @@ package sous
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"sync"
@@ -19,7 +20,7 @@ func SetupDB(t *testing.T, optidx ...int) *sql.DB {
 	//t.Helper()
 	name := dbNameRoot(t, optidx...)
 
-	t.Logf("Creating DB for %s called %s ...", t.Name(), name)
+	log.Printf("Creating DB for %s called %s", t.Name(), name)
 	db, err := setupDBErr(name)
 	if err != nil {
 		if os.Getenv("SOUS_TEST_NODB") != "" {
@@ -28,7 +29,6 @@ func SetupDB(t *testing.T, optidx ...int) *sql.DB {
 		}
 		t.Fatalf("Error creating test DB %q: %v (Set SOUS_TEST_NODB=yes) to skip tests that rely on the DB", name, err)
 	}
-	t.Logf("Created %s.", name)
 	return db
 }
 

--- a/test/smoke/otpl_test.go
+++ b/test/smoke/otpl_test.go
@@ -24,7 +24,7 @@ func dockerBuildAddArtifact(t *testing.T, f *TestFixture, client *TestClient, fl
 	mustDoCMD(t, client.Dir, "docker", "build", "-t", dockerRef, ".")
 	mustDoCMD(t, client.Dir, "docker", "push", dockerRef)
 
-	client.MustRun(t, "add artifact", nil, "-docker-image", dockerRepo, "-repo", repo, "-tag", tag)
+	client.MustRun(t, "artifact add", nil, "-docker-image", dockerRepo, "-repo", repo, "-tag", tag)
 }
 
 func TestOTPLInitToDeploy(t *testing.T) {
@@ -37,7 +37,7 @@ func TestOTPLInitToDeploy(t *testing.T) {
 
 	pf.RunMatrix(fixtureConfigs,
 
-		PTest{Name: "add-artifact", Test: func(t *testing.T, f *TestFixture) {
+		PTest{Name: "artifact-add", Test: func(t *testing.T, f *TestFixture) {
 			client := setupProjectSingleDockerfile(t, f, simpleServer)
 
 			flags := &sousFlags{tag: "1.2.3"}

--- a/test/smoke/otpl_test.go
+++ b/test/smoke/otpl_test.go
@@ -1,6 +1,6 @@
 //+build smoke
 
-package main
+package smoke
 
 import (
 	"fmt"
@@ -18,6 +18,7 @@ func TestOTPLInitToDeploy(t *testing.T) {
 	}
 
 	pf.RunMatrix(fixtureConfigs,
+
 		PTest{Name: "add-artifact", Test: func(t *testing.T, f *TestFixture) {
 			client := setupProjectSingleDockerfile(t, f, simpleServer)
 
@@ -33,8 +34,10 @@ func TestOTPLInitToDeploy(t *testing.T) {
 
 			client.MustRun(t, "add artifact", nil, "-docker-image", dockerRepo, "-repo", repo, "-tag", tag)
 		}},
+
 		PTest{Name: "init-simple", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, simpleServer, filemap.FileMap{
+			client := setupProject(t, f, filemap.FileMap{
+				"Dockerfile": simpleServer,
 				"config/cluster1/singularity.json": `
 				{
 					"requestId": "request1",
@@ -51,15 +54,15 @@ func TestOTPLInitToDeploy(t *testing.T) {
 					"owners": [
 					    "test-user1@example.com"
 					],
-					"slavePlacement": "SEPARATE_BY_REQUEST",
 					"instances": 3,
-					"rackSensitive": false,
-					"loadBalanced": false
 				}`,
 			})
+			client.MustRun(t, "version", nil)
 		}},
+
 		PTest{Name: "init-unknown-fields", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, simpleServer, filemap.FileMap{
+			client := setupProject(t, f, filemap.FileMap{
+				"Dockerfile": simpleServer,
 				"config/cluster1/singularity.json": `
 				{
 					"requestId": "request1",
@@ -82,7 +85,7 @@ func TestOTPLInitToDeploy(t *testing.T) {
 					"loadBalanced": false
 				}`,
 			})
-
+			client.MustRun(t, "version", nil)
 		}},
 	)
 }

--- a/test/smoke/otpl_test.go
+++ b/test/smoke/otpl_test.go
@@ -1,0 +1,39 @@
+//+build smoke
+
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestOTPLInitToDeploy(t *testing.T) {
+	pf := pfs.newParallelTestFixture(t)
+
+	fixtureConfigs := []fixtureConfig{
+		{dbPrimary: false},
+		{dbPrimary: true},
+	}
+
+	pf.RunMatrix(fixtureConfigs,
+		PTest{Name: "add-artifact", Test: func(t *testing.T, f *TestFixture) {
+			client := setupProject(t, f, simpleServer)
+
+			reg := f.Client.Config.Docker.RegistryHost
+			repo := "github.com/user1/project1"
+			tag := "1.2.3"
+			dockerTag := f.IsolatedVersionTag(t, tag)
+			dockerRepo := fmt.Sprintf("%s/%s", reg, repo)
+			dockerRef := fmt.Sprintf("%s:%s", dockerRepo, dockerTag)
+
+			mustDoCMD(t, client.Dir, "docker", "build", "-t", dockerRef, ".")
+			mustDoCMD(t, client.Dir, "docker", "push", dockerRef)
+
+			client.MustRun(t, "add artifact", nil, "-docker-image", dockerRepo, "-repo", repo, "-tag", tag)
+		}},
+		PTest{Name: "init-simple", Test: func(t *testing.T, f *TestFixture) {
+			client := setupProject(t, f, simpleServer)
+
+		}},
+	)
+}

--- a/test/smoke/otpl_test.go
+++ b/test/smoke/otpl_test.go
@@ -28,6 +28,9 @@ func dockerBuildAddArtifact(t *testing.T, f *TestFixture, client *TestClient, fl
 }
 
 func TestOTPLInitToDeploy(t *testing.T) {
+
+	t.Skipf("WIP Test")
+
 	pf := pfs.newParallelTestFixture(t)
 
 	fixtureConfigs := []fixtureConfig{

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -15,15 +15,15 @@ import (
 // Define some Dockerfiles for use in tests.
 const (
 	simpleServer = `
-FROM alpine
+FROM alpine:3.7
 CMD if [ -z "$T" ]; then T=2; fi; echo -n "Sleeping ${T}s..."; sleep $T; echo "Done"; echo "Listening on :$PORT0"; while true; do echo -e "HTTP/1.1 200 OK\n\n$(date)" | nc -l -p $PORT0; done
 `
 	sleeper = `
-FROM alpine
+FROM alpine:3.7
 CMD echo -n Sleeping for 10s...; sleep 10; echo Done
 `
 	failer = `
-FROM alpine
+FROM alpine:3.7
 CMD echo -n Failing in 10s...; sleep 10; echo Failed; exit 1
 `
 )
@@ -31,11 +31,11 @@ CMD echo -n Failing in 10s...; sleep 10; echo Failed; exit 1
 // setupProject creates a brand new git repo containing the provided Dockerfile,
 // commits that Dockerfile, runs 'sous version' and 'sous config', and returns a
 // sous TestClient in the project directory.
-func setupProjectSingleDockerfile(t *testing.T, f TestFixture, dockerfile string) *TestClient {
-	return setupProjectFileMap(t, f, filemap.FileMap{"Dockerfile": dockerfile})
+func setupProjectSingleDockerfile(t *testing.T, f *TestFixture, dockerfile string) *TestClient {
+	return setupProject(t, f, filemap.FileMap{"Dockerfile": dockerfile})
 }
 
-func setupProject(t *testing.T, f TestFixture, fm filemap.FileMap) *TestClient {
+func setupProject(t *testing.T, f *TestFixture, fm filemap.FileMap) *TestClient {
 	t.Helper()
 	// Setup project git repo.
 	projectDir := makeGitRepo(t, f.Client.BaseDir, "projects/project1", GitRepoSpec{
@@ -55,7 +55,6 @@ func setupProject(t *testing.T, f TestFixture, fm filemap.FileMap) *TestClient {
 
 	// cd into project dir
 	client.Dir = projectDir
-	client.ClusterSuffix = f.ClusterSuffix
 
 	// Dump sous version & config.
 	t.Logf("Sous version: %s", client.MustRun(t, "version", nil))
@@ -75,6 +74,22 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
+// initBuild is a macro to fast-forward to tests to a point where we have
+// initialised the project, transformed the manifest, and performed a build.
+func initBuild(t *testing.T, client *TestClient, flags *sousFlags, transforms ...ManifestTransform) {
+	client.MustRun(t, "init", flags.SousInitFlags())
+	client.TransformManifest(t, flags.ManifestIDFlags(), transforms...)
+	client.MustRun(t, "build", flags.SourceIDFlags())
+}
+
+// initBuildDeploy is a macro for fast-forwarding tests to a point where we have
+// initialised the project as a kind project, built it with -tag tag and
+// deployed that tag successfully to cluster.
+func initBuildDeploy(t *testing.T, client *TestClient, flags *sousFlags, transforms ...ManifestTransform) {
+	initBuild(t, client, flags, transforms...)
+	client.MustRun(t, "deploy", flags.DeploymentIDFlags())
+}
+
 func TestInitToDeploy(t *testing.T) {
 	pf := pfs.newParallelTestFixture(t)
 
@@ -87,10 +102,10 @@ func TestInitToDeploy(t *testing.T) {
 
 		PTest{Name: "simple", Test: func(t *testing.T, f *TestFixture) {
 			client := setupProjectSingleDockerfile(t, f, simpleServer)
-			client.MustRun(t, "init", nil, "-kind", "http-service")
-			client.TransformManifest(t, nil, setMinimalMemAndCPUNumInst1)
-			client.MustRun(t, "build", nil, "-tag", "1.2.3")
-			client.MustRun(t, "deploy", nil, "-cluster", "cluster1", "-tag", "1.2.3")
+
+			flags := &sousFlags{kind: "http-service", tag: "1.2.3", cluster: "cluster1"}
+
+			initBuildDeploy(t, client, flags, setMinimalMemAndCPUNumInst1)
 
 			did := sous.DeploymentID{
 				ManifestID: sous.ManifestID{
@@ -107,20 +122,23 @@ func TestInitToDeploy(t *testing.T) {
 			assertNonNilHealthCheckOnLatestDeploy(t, f, reqID)
 		}},
 
-		PTest{Name: "zero-instances", Test: func(t *testing.T, f *TestFixture) {
+		PTest{Name: "fail-zero-instances", Test: func(t *testing.T, f *TestFixture) {
 			client := setupProjectSingleDockerfile(t, f, simpleServer)
-			client.MustRun(t, "init", nil, "-kind", "http-service")
-			client.TransformManifest(t, nil, setMinimalMemAndCPUNumInst0)
-			client.MustRun(t, "build", nil, "-tag", "1.2.3")
+
+			flags := &sousFlags{kind: "http-service", tag: "1.2.3"}
+
+			initBuild(t, client, flags, setMinimalMemAndCPUNumInst0)
 
 			client.MustFail(t, "deploy", nil, "-cluster", "cluster1", "-tag", "1.2.3")
 		}},
 
-		PTest{Name: "fails", Test: func(t *testing.T, f *TestFixture) {
+		PTest{Name: "fail-container-crash", Test: func(t *testing.T, f *TestFixture) {
 			client := setupProjectSingleDockerfile(t, f, failer)
-			client.MustRun(t, "init", nil, "-kind", "http-service")
-			client.TransformManifest(t, nil, setMinimalMemAndCPUNumInst1)
-			client.MustRun(t, "build", nil, "-tag", "1.2.3")
+
+			flags := &sousFlags{kind: "http-service", tag: "1.2.3"}
+
+			initBuild(t, client, flags, setMinimalMemAndCPUNumInst1)
+
 			client.MustFail(t, "deploy", nil, "-cluster", "cluster1", "-tag", "1.2.3")
 
 			did := sous.DeploymentID{
@@ -140,19 +158,20 @@ func TestInitToDeploy(t *testing.T) {
 
 		PTest{Name: "flavors", Test: func(t *testing.T, f *TestFixture) {
 			client := setupProjectSingleDockerfile(t, f, simpleServer)
-			flavor := "flavor1"
-			flavorFlag := &sousFlags{flavor: flavor}
-			client.MustRun(t, "init", flavorFlag, "-kind", "http-service")
-			client.TransformManifest(t, flavorFlag, setMinimalMemAndCPUNumInst1)
-			client.MustRun(t, "build", nil, "-tag", "1.2.3")
-			client.MustRun(t, "deploy", flavorFlag, "-cluster", "cluster1", "-tag", "1.2.3")
+
+			flags := &sousFlags{
+				kind: "http-service", tag: "1.2.3", cluster: "cluster1",
+				flavor: "flavor1",
+			}
+
+			initBuildDeploy(t, client, flags, setMinimalMemAndCPUNumInst1)
 
 			did := sous.DeploymentID{
 				ManifestID: sous.ManifestID{
 					Source: sous.SourceLocation{
 						Repo: "github.com/user1/repo1",
 					},
-					Flavor: flavor,
+					Flavor: "flavor1",
 				},
 				Cluster: "cluster1",
 			}
@@ -165,12 +184,14 @@ func TestInitToDeploy(t *testing.T) {
 
 		PTest{Name: "pause-unpause", Test: func(t *testing.T, f *TestFixture) {
 			client := setupProjectSingleDockerfile(t, f, simpleServer)
-			client.MustRun(t, "init", nil, "-kind", "http-service")
-			client.TransformManifest(t, nil, setMinimalMemAndCPUNumInst1)
-			client.MustRun(t, "build", nil, "-tag", "1")
+
+			flags := &sousFlags{kind: "http-service", tag: "1", cluster: "cluster1"}
+
+			initBuildDeploy(t, client, flags, setMinimalMemAndCPUNumInst1)
+
+			// Prepare a couple more builds...
 			client.MustRun(t, "build", nil, "-tag", "2")
 			client.MustRun(t, "build", nil, "-tag", "3")
-			client.MustRun(t, "deploy", nil, "-cluster", "cluster1", "-tag", "1")
 
 			did := sous.DeploymentID{
 				ManifestID: sous.ManifestID{
@@ -195,8 +216,10 @@ func TestInitToDeploy(t *testing.T) {
 
 		PTest{Name: "scheduled", Test: func(t *testing.T, f *TestFixture) {
 			client := setupProjectSingleDockerfile(t, f, sleeper)
-			client.MustRun(t, "init", nil, "-kind", "scheduled")
-			client.TransformManifest(t, nil, func(m sous.Manifest) sous.Manifest {
+
+			flags := &sousFlags{kind: "scheduled", tag: "1.2.3", cluster: "cluster1"}
+
+			initBuildDeploy(t, client, flags, func(m sous.Manifest) sous.Manifest {
 				clusterName := "cluster1" + f.ClusterSuffix
 				d := m.Deployments[clusterName]
 				d.NumInstances = 1
@@ -207,8 +230,6 @@ func TestInitToDeploy(t *testing.T) {
 
 				return m
 			})
-			client.MustRun(t, "build", nil, "-tag", "1.2.3")
-			client.MustRun(t, "deploy", nil, "-cluster", "cluster1", "-tag", "1.2.3")
 
 			did := sous.DeploymentID{
 				ManifestID: sous.ManifestID{

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -87,7 +87,7 @@ func initBuild(t *testing.T, client *TestClient, flags *sousFlags, transforms ..
 // deployed that tag successfully to cluster.
 func initBuildDeploy(t *testing.T, client *TestClient, flags *sousFlags, transforms ...ManifestTransform) {
 	initBuild(t, client, flags, transforms...)
-	client.MustRun(t, "deploy", flags.DeploymentIDFlags())
+	client.MustRun(t, "deploy", flags.SousDeployFlags())
 }
 
 func TestInitToDeploy(t *testing.T) {

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -4,7 +4,6 @@ package smoke
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"testing"
 
@@ -332,31 +331,4 @@ func TestInitToDeploy(t *testing.T) {
 			assertActiveStatus(t, f, customID1) // This works because we do not yet do cleanup.
 		}},
 	)
-}
-
-func TestOTPLInitToDeploy(t *testing.T) {
-	pf := pfs.newParallelTestFixture(t)
-
-	fixtureConfigs := []fixtureConfig{
-		{dbPrimary: false},
-		{dbPrimary: true},
-	}
-
-	pf.RunMatrix(fixtureConfigs, PTest{
-		Name: "add-artifact", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, simpleServer)
-
-			reg := f.Client.Config.Docker.RegistryHost
-			repo := "github.com/user1/project1"
-			tag := "1.2.3"
-			dockerTag := f.IsolatedVersionTag(t, tag)
-			dockerRepo := fmt.Sprintf("%s/%s", reg, repo)
-			dockerRef := fmt.Sprintf("%s:%s", dockerRepo, dockerTag)
-
-			mustDoCMD(t, client.Dir, "docker", "build", "-t", dockerRef, ".")
-			mustDoCMD(t, client.Dir, "docker", "push", dockerRef)
-
-			client.MustRun(t, "artifact add", nil, "-docker-image", dockerRepo, "-repo", repo, "-tag", tag)
-		},
-	})
 }

--- a/test/smoke/testclient_test.go
+++ b/test/smoke/testclient_test.go
@@ -44,6 +44,50 @@ type sousFlags struct {
 	tag     string
 }
 
+// ManifestIDFlags returns a derived set of flags only keeping those that play a
+// part in identifying a manifest.
+func (f *sousFlags) ManifestIDFlags() *sousFlags {
+	if f == nil {
+		return nil
+	}
+	return &sousFlags{
+		repo:   f.repo,
+		offset: f.offset,
+		flavor: f.flavor,
+	}
+}
+
+// ManifestIDFlags returns a derived set of flags only keeping those that play a
+// part in identifying a deployment.
+func (f *sousFlags) DeploymentIDFlags() *sousFlags {
+	if f == nil {
+		return nil
+	}
+	didFlags := f.ManifestIDFlags()
+	didFlags.cluster = f.cluster
+	return didFlags
+}
+
+// SousInitFlags returns a derived set of flags only keeping those that play a
+// part in the 'sous init' command.
+func (f *sousFlags) SousInitFlags() *sousFlags {
+	if f == nil {
+		return nil
+	}
+	initFlags := f.ManifestIDFlags()
+	initFlags.kind = f.kind
+	return initFlags
+}
+
+func (f *sousFlags) SourceIDFlags() *sousFlags {
+	if f == nil {
+		return nil
+	}
+	sidFlags := f.ManifestIDFlags()
+	sidFlags.tag = f.tag
+	return sidFlags
+}
+
 func (f *sousFlags) Args() []string {
 	if f == nil {
 		return nil
@@ -289,14 +333,18 @@ func (c *TestClient) MustFail(t *testing.T, subcmd string, f *sousFlags, args ..
 	}
 }
 
-func (c *TestClient) TransformManifest(t *testing.T, getSetFlags *sousFlags, f func(m sous.Manifest) sous.Manifest) {
+// TransformManifest applies each of transforms in order to the retrieved
+// manifest, then calls 'sous manifest set' to apply them. Any failure is fatal.
+func (c *TestClient) TransformManifest(t *testing.T, getSetFlags *sousFlags, transforms ...ManifestTransform) {
 	t.Helper()
 	manifest := c.MustRun(t, "manifest get", getSetFlags)
 	var m sous.Manifest
 	if err := yaml.Unmarshal([]byte(manifest), &m); err != nil {
 		t.Fatalf("manifest get returned invalid YAML: %s\nInvalid YAML was:\n%s", err, manifest)
 	}
-	m = f(m)
+	for _, f := range transforms {
+		m = f(m)
+	}
 	manifestBytes, err := yaml.Marshal(m)
 	if err != nil {
 		t.Fatalf("failed to marshal updated manifest: %s\nInvalid manifest was:\n% #v", err, m)

--- a/test/smoke/testclient_test.go
+++ b/test/smoke/testclient_test.go
@@ -68,6 +68,15 @@ func (f *sousFlags) DeploymentIDFlags() *sousFlags {
 	return didFlags
 }
 
+func (f *sousFlags) SousDeployFlags() *sousFlags {
+	if f == nil {
+		return nil
+	}
+	deployFlags := f.DeploymentIDFlags()
+	deployFlags.tag = f.tag
+	return deployFlags
+}
+
 // SousInitFlags returns a derived set of flags only keeping those that play a
 // part in the 'sous init' command.
 func (f *sousFlags) SousInitFlags() *sousFlags {
@@ -188,8 +197,8 @@ func (c *TestClient) insertClusterSuffix(t *testing.T, args []string) []string {
 
 func (c *TestClient) Cmd(t *testing.T, subcmd string, f *sousFlags, args ...string) (*exec.Cmd, context.CancelFunc) {
 	t.Helper()
-	args = c.insertClusterSuffix(t, args)
-	cmd, cancel := mkCMD(c.Dir, c.BinPath, allArgs(subcmd, f, args)...)
+	args = c.insertClusterSuffix(t, allArgs(subcmd, f, args))
+	cmd, cancel := mkCMD(c.Dir, c.BinPath, args...)
 	cmd.Env = append(cmd.Env, fmt.Sprintf("SOUS_CONFIG_DIR=%s", c.ConfigDir))
 	return cmd, cancel
 }

--- a/test/smoke/testclient_test.go
+++ b/test/smoke/testclient_test.go
@@ -366,8 +366,8 @@ func (c *TestClient) TransformManifest(t *testing.T, getSetFlags *sousFlags, tra
 	}
 }
 
-func (c *TestClient) SetSingularityRequestID(t *testing.T, getSetFlags *sousFlags, clusterName, singReqID string) {
-	c.TransformManifest(t, nil, func(m sous.Manifest) sous.Manifest {
+func (c *TestClient) setSingularityRequestID(t *testing.T, clusterName, singReqID string) ManifestTransform {
+	return func(m sous.Manifest) sous.Manifest {
 		clusterName := c.Fixture.IsolatedClusterName(clusterName)
 		d, ok := m.Deployments[clusterName]
 		if !ok {
@@ -379,5 +379,5 @@ func (c *TestClient) SetSingularityRequestID(t *testing.T, getSetFlags *sousFlag
 		m.Deployments[clusterName] = d
 		m.Deployments = setMemAndCPUForAll(m.Deployments)
 		return m
-	})
+	}
 }

--- a/test/smoke/testfixture_test.go
+++ b/test/smoke/testfixture_test.go
@@ -28,13 +28,14 @@ type TestFixture struct {
 	knownToFail   bool
 }
 
+var sousBin = mustGetSousBin()
+
 func newTestFixture(t *testing.T, envDesc desc.EnvDesc, parent *ParallelTestFixture, nextAddr func() string, fcfg fixtureConfig) *TestFixture {
 	t.Helper()
 	t.Parallel()
 	if testing.Short() {
 		t.Skipf("-short flag present")
 	}
-	sousBin := getSousBin(t)
 	baseDir := getDataDir(t)
 
 	clusterSuffix := strings.Replace(t.Name(), "/", "_", -1)

--- a/test/smoke/testmanifesttransforms_test.go
+++ b/test/smoke/testmanifesttransforms_test.go
@@ -4,6 +4,8 @@ package smoke
 
 import sous "github.com/opentable/sous/lib"
 
+type ManifestTransform func(sous.Manifest) sous.Manifest
+
 func setMemAndCPUForAll(ds sous.DeploySpecs) sous.DeploySpecs {
 	for c := range ds {
 		d := ds[c]

--- a/test/smoke/testutils_test.go
+++ b/test/smoke/testutils_test.go
@@ -42,17 +42,17 @@ func getEnvDesc() desc.EnvDesc {
 	return envDesc
 }
 
-func getSousBin(t *testing.T) string {
+func mustGetSousBin() string {
 	sousBin := os.Getenv("SMOKE_TEST_BINARY")
 	if sousBin != "" {
-		t.Logf("Using sous binary %q (from $SMOKE_TEST_BINARY)", sousBin)
+		log.Printf("Using sous binary %q (from $SMOKE_TEST_BINARY)", sousBin)
 		return sousBin
 	}
 	sousBin, err := exec.LookPath("sous")
 	if err != nil {
-		t.Fatalf("sous not found in path")
+		log.Panicf("sous not found in path and $SMOKE_TEST_BINARY not set")
 	}
-	t.Logf("Using sous binary %q (from $PATH)", sousBin)
+	log.Printf("Using sous binary %q (from $PATH)", sousBin)
 	return sousBin
 }
 
@@ -182,7 +182,7 @@ func getDataDir(t *testing.T) string {
 		t.Fatalf("Test data dir already exists and is not empty: %q", baseDir)
 	}
 
-	t.Logf("Writing test data to %q (from %s)", baseDir, from)
+	log.Printf("Test data in %q (from %s)", baseDir, from)
 	if err := os.MkdirAll(baseDir, 0777); err != nil {
 		t.Fatalf("Failed to create smoke test data dir %q: %s", baseDir, err)
 	}


### PR DESCRIPTION
Numerous small fixes to output made in preparation for deeper testing.

- Test macros introduced that perform initialisation and shorten test cases.
- setupProject now accepts a `filemap.FileMap` to allow more complex projects than single dockerfiles to be tested (this is necessary for `-offset` flag tests and otpl-deploy integration tests.
- Test output is now more terse so successful tests take up a lot less vertical space reducing noise.