### PR TITLE
Splitcontainer smoke tests #trivial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 - "./bin/vendor-check"
 script:
 - bundle exec danger
-- make test-smoke
+- SMOKE_TEST_QUIET=YES make test-smoke
 - make -j3 test
 - make reject-wip
 after_script:

--- a/Makefile
+++ b/Makefile
@@ -502,7 +502,7 @@ local-server:
 
 .PHONY: provision-docker-machine
 provision-docker-machine:
-	docker-machine create -d virtualbox --virtualbox-memory "2048" default
+	docker-machine create -d virtualbox --virtualbox-memory "4096" default
 
 .PHONY: artifactory clean clean-containers clean-container-certs \
 	clean-running-containers clean-container-images coverage deb-build \

--- a/test/smoke/build_splitcontainer_test.go
+++ b/test/smoke/build_splitcontainer_test.go
@@ -4,42 +4,7 @@ package smoke
 
 import (
 	"testing"
-
-	"github.com/opentable/sous/util/filemap"
 )
-
-func simpleServerSplitContainer() filemap.FileMap {
-	return filemap.FileMap{
-		"Dockerfile": `
-			FROM alpine:3.2
-			ENV SOUS_RUN_IMAGE_SPEC=/image-spec.json
-			COPY image-spec.json /
-			RUN mkdir /server
-			COPY server.sh /server/
-			`,
-		"image-spec.json": `
-			{
-			  "image": {
-			    "type": "Docker",
-				"from": "alpine:3.2"
-			  },
-			  "files": [
-			    {
-				  "source": {"dir": "/server"},
-			      "dest": {"dir": "/"}
-			    }
-			  ],
-			  "exec": ["/server/server.sh"]
-			}
-			`,
-		"server.sh": `#!/usr/bin/env sh
-			echo "Listening on :$PORT0"
-			while true; do
-			  echo -e "HTTP/1.1 200 OK\n\n$(date)" | nc -l -p $PORT0
-			done
-			`,
-	}
-}
 
 func TestSplitContainer(t *testing.T) {
 

--- a/test/smoke/build_splitcontainer_test.go
+++ b/test/smoke/build_splitcontainer_test.go
@@ -1,0 +1,61 @@
+//+build smoke
+
+package smoke
+
+import (
+	"testing"
+
+	"github.com/opentable/sous/util/filemap"
+)
+
+func simpleServerSplitContainer() filemap.FileMap {
+	return filemap.FileMap{
+		"Dockerfile": `
+			FROM alpine:3.2
+			ENV SOUS_RUN_IMAGE_SPEC=/image-spec.json
+			COPY image-spec.json /
+			RUN mkdir /server
+			COPY server.sh /server/
+			`,
+		"image-spec.json": `
+			{
+			  "image": {
+			    "type": "Docker",
+				"from": "alpine:3.2"
+			  },
+			  "files": [
+			    {
+				  "source": {"dir": "/server"},
+			      "dest": {"dir": "/"}
+			    }
+			  ],
+			  "exec": ["/server/server.sh"]
+			}
+			`,
+		"server.sh": `#!/usr/bin/env sh
+			echo "Listening on :$PORT0"
+			while true; do
+			  echo -e "HTTP/1.1 200 OK\n\n$(date)" | nc -l -p $PORT0
+			done
+			`,
+	}
+}
+
+func TestSplitContainer(t *testing.T) {
+
+	pf := pfs.newParallelTestFixture(t)
+
+	fixtureConfigs := []fixtureConfig{
+		{dbPrimary: false},
+		{dbPrimary: true},
+	}
+
+	pf.RunMatrix(fixtureConfigs,
+		PTest{Name: "simple-splitcontainer", Test: func(t *testing.T, f *TestFixture) {
+			client := setupProject(t, f, simpleServerSplitContainer())
+			client.MustRun(t, "init", nil, "-kind", "http-service")
+			client.MustRun(t, "build", nil, "-tag", "1")
+			client.MustRun(t, "deploy", nil, "-cluster", "cluster1", "-tag", "1")
+		}},
+	)
+}

--- a/test/smoke/build_splitcontainer_test.go
+++ b/test/smoke/build_splitcontainer_test.go
@@ -17,7 +17,7 @@ func TestSplitContainer(t *testing.T) {
 
 	pf.RunMatrix(fixtureConfigs,
 		PTest{Name: "simple-splitcontainer", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, simpleServerSplitContainer())
+			client := f.setupProject(t, simpleServerSplitContainer())
 			client.MustRun(t, "init", nil, "-kind", "http-service")
 			client.MustRun(t, "build", nil, "-tag", "1")
 			client.MustRun(t, "deploy", nil, "-cluster", "cluster1", "-tag", "1")

--- a/test/smoke/configmatrix_test.go
+++ b/test/smoke/configmatrix_test.go
@@ -1,0 +1,12 @@
+//+build smoke
+
+package smoke
+
+func fixtureConfigs() []fixtureConfig {
+	return []fixtureConfig{
+		{dbPrimary: false, projects: projects.SingleDockerfile},
+		{dbPrimary: true, projects: projects.SingleDockerfile},
+		{dbPrimary: false, projects: projects.SplitBuild},
+		{dbPrimary: true, projects: projects.SplitBuild},
+	}
+}

--- a/test/smoke/otpl_test.go
+++ b/test/smoke/otpl_test.go
@@ -41,7 +41,7 @@ func TestOTPLInitToDeploy(t *testing.T) {
 	pf.RunMatrix(fixtureConfigs,
 
 		PTest{Name: "artifact-add", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, f.Projects.HTTPServer())
+			client := f.setupProject(t, f.Projects.HTTPServer())
 
 			flags := &sousFlags{tag: "1.2.3"}
 
@@ -50,7 +50,7 @@ func TestOTPLInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "build-init-deploy", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, f.Projects.HTTPServer().Merge(filemap.FileMap{
+			client := f.setupProject(t, f.Projects.HTTPServer().Merge(filemap.FileMap{
 				"config/cluster1/singularity.json": `
 				{
 					"requestId": "request1",
@@ -86,7 +86,7 @@ func TestOTPLInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "fail-unknown-fields", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, f.Projects.HTTPServer().Merge(filemap.FileMap{
+			client := f.setupProject(t, f.Projects.HTTPServer().Merge(filemap.FileMap{
 				"config/cluster1/singularity.json": `
 				{
 					"requestId": "request1",

--- a/test/smoke/otpl_test.go
+++ b/test/smoke/otpl_test.go
@@ -41,7 +41,7 @@ func TestOTPLInitToDeploy(t *testing.T) {
 	pf.RunMatrix(fixtureConfigs,
 
 		PTest{Name: "artifact-add", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProjectSingleDockerfile(t, f, simpleServer)
+			client := setupProject(t, f, f.Projects.HTTPServer())
 
 			flags := &sousFlags{tag: "1.2.3"}
 
@@ -50,8 +50,7 @@ func TestOTPLInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "build-init-deploy", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, filemap.FileMap{
-				"Dockerfile": simpleServer,
+			client := setupProject(t, f, f.Projects.HTTPServer().Merge(filemap.FileMap{
 				"config/cluster1/singularity.json": `
 				{
 					"requestId": "request1",
@@ -70,7 +69,7 @@ func TestOTPLInitToDeploy(t *testing.T) {
 					],
 					"instances": 3
 				}`,
-			})
+			}))
 
 			flags := &sousFlags{
 				kind:    "http-service",
@@ -87,8 +86,7 @@ func TestOTPLInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "fail-unknown-fields", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, filemap.FileMap{
-				"Dockerfile": simpleServer,
+			client := setupProject(t, f, f.Projects.HTTPServer().Merge(filemap.FileMap{
 				"config/cluster1/singularity.json": `
 				{
 					"requestId": "request1",
@@ -110,7 +108,7 @@ func TestOTPLInitToDeploy(t *testing.T) {
 					"rackSensitive": false,
 					"loadBalanced": false
 				}`,
-			})
+			}))
 			client.MustRun(t, "version", nil)
 		}},
 	)

--- a/test/smoke/paralleltestfixture_test.go
+++ b/test/smoke/paralleltestfixture_test.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-
-	sous "github.com/opentable/sous/lib"
 )
 
 type (
@@ -19,11 +17,6 @@ type (
 		// NumFreeAddrs determines how many free addresses are guaranteed by this
 		// test fixture.
 		NumFreeAddrs int
-	}
-
-	fixtureConfig struct {
-		dbPrimary  bool
-		startState *sous.State
 	}
 
 	ParallelTestFixture struct {
@@ -88,13 +81,6 @@ func (pfs *ParallelTestFixtureSet) newParallelTestFixture(t *testing.T) *Paralle
 	defer pfs.mu.Unlock()
 	pfs.fixtures[t.Name()] = pf
 	return pf
-}
-
-func (fcfg fixtureConfig) Desc() string {
-	if fcfg.dbPrimary {
-		return "DB"
-	}
-	return "GIT"
 }
 
 func (pf *ParallelTestFixture) recordTestStarted(t *testing.T) {

--- a/test/smoke/paralleltestfixture_test.go
+++ b/test/smoke/paralleltestfixture_test.go
@@ -137,7 +137,7 @@ func (pf *ParallelTestFixture) recordTestStatus(t *testing.T) {
 
 	statusString := "UNKNOWN"
 	status := &statusString
-	defer alwaysPrintf("Finished running %s: %s", name, *status)
+	defer func() { alwaysPrintf("Finished running %s: %s", name, *status) }()
 
 	if !started {
 		t.Fatalf("test %q reported as finished, but not started", name)

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -27,15 +27,10 @@ func initBuildDeploy(t *testing.T, client *TestClient, flags *sousFlags, transfo
 func TestInitToDeploy(t *testing.T) {
 	pf := pfs.newParallelTestFixture(t)
 
-	fixtureConfigs := []fixtureConfig{
-		{dbPrimary: false},
-		{dbPrimary: true},
-	}
-
-	pf.RunMatrix(fixtureConfigs,
+	pf.RunMatrix(fixtureConfigs(),
 
 		PTest{Name: "simple", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProjectSingleDockerfile(t, f, simpleServer)
+			client := setupProject(t, f, f.Projects.HTTPServer())
 
 			flags := &sousFlags{kind: "http-service", tag: "1.2.3", cluster: "cluster1"}
 
@@ -57,7 +52,7 @@ func TestInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "fail-zero-instances", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProjectSingleDockerfile(t, f, simpleServer)
+			client := setupProject(t, f, f.Projects.HTTPServer())
 
 			flags := &sousFlags{kind: "http-service", tag: "1.2.3"}
 
@@ -67,7 +62,7 @@ func TestInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "fail-container-crash", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProjectSingleDockerfile(t, f, failer)
+			client := setupProject(t, f, f.Projects.Failer())
 
 			flags := &sousFlags{kind: "http-service", tag: "1.2.3"}
 
@@ -91,7 +86,7 @@ func TestInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "flavors", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProjectSingleDockerfile(t, f, simpleServer)
+			client := setupProject(t, f, f.Projects.HTTPServer())
 
 			flags := &sousFlags{
 				kind: "http-service", tag: "1.2.3", cluster: "cluster1",
@@ -117,7 +112,7 @@ func TestInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "pause-unpause", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProjectSingleDockerfile(t, f, simpleServer)
+			client := setupProject(t, f, f.Projects.HTTPServer())
 
 			flags := &sousFlags{kind: "http-service", tag: "1", cluster: "cluster1"}
 
@@ -149,7 +144,7 @@ func TestInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "scheduled", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProjectSingleDockerfile(t, f, sleeper)
+			client := setupProject(t, f, f.Projects.Sleeper())
 
 			flags := &sousFlags{kind: "scheduled", tag: "1.2.3", cluster: "cluster1"}
 
@@ -181,7 +176,7 @@ func TestInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "custom-reqid-first-deploy", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProjectSingleDockerfile(t, f, simpleServer)
+			client := setupProject(t, f, f.Projects.HTTPServer())
 
 			flags := &sousFlags{kind: "http-service", tag: "1.2.3", cluster: "cluster1"}
 
@@ -198,7 +193,7 @@ func TestInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "custom-reqid-second-deploy", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProjectSingleDockerfile(t, f, simpleServer)
+			client := setupProject(t, f, f.Projects.HTTPServer())
 
 			flags := &sousFlags{kind: "http-service", tag: "1.2.3", cluster: "cluster1"}
 
@@ -235,7 +230,7 @@ func TestInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "change-reqid", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProjectSingleDockerfile(t, f, simpleServer)
+			client := setupProject(t, f, f.Projects.HTTPServer())
 
 			flags := &sousFlags{kind: "http-service", tag: "1.2.3", cluster: "cluster1"}
 

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -30,29 +30,21 @@ func TestInitToDeploy(t *testing.T) {
 	pf.RunMatrix(fixtureConfigs(),
 
 		PTest{Name: "simple", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, f.Projects.HTTPServer())
+			_, reqID := f.DIDAndDefaultReqID(t, "github.com/user1/repo1", "", "", "cluster1")
+
+			client := f.setupProject(t, f.Projects.HTTPServer())
 
 			flags := &sousFlags{kind: "http-service", tag: "1.2.3", cluster: "cluster1"}
 
 			initBuildDeploy(t, client, flags, setMinimalMemAndCPUNumInst1)
 
-			did := sous.DeploymentID{
-				ManifestID: sous.ManifestID{
-					Source: sous.SourceLocation{
-						Repo: "github.com/user1/repo1",
-					},
-				},
-				Cluster: "cluster1",
-			}
-
-			reqID := f.Singularity.DefaultReqID(t, did)
 			assertActiveStatus(t, f, reqID)
 			assertSingularityRequestTypeService(t, f, reqID)
 			assertNonNilHealthCheckOnLatestDeploy(t, f, reqID)
 		}},
 
 		PTest{Name: "fail-zero-instances", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, f.Projects.HTTPServer())
+			client := f.setupProject(t, f.Projects.HTTPServer())
 
 			flags := &sousFlags{kind: "http-service", tag: "1.2.3"}
 
@@ -62,7 +54,7 @@ func TestInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "fail-container-crash", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, f.Projects.Failer())
+			client := f.setupProject(t, f.Projects.Failer())
 
 			flags := &sousFlags{kind: "http-service", tag: "1.2.3"}
 
@@ -86,7 +78,7 @@ func TestInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "flavors", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, f.Projects.HTTPServer())
+			client := f.setupProject(t, f.Projects.HTTPServer())
 
 			flags := &sousFlags{
 				kind: "http-service", tag: "1.2.3", cluster: "cluster1",
@@ -112,7 +104,7 @@ func TestInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "pause-unpause", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, f.Projects.HTTPServer())
+			client := f.setupProject(t, f.Projects.HTTPServer())
 
 			flags := &sousFlags{kind: "http-service", tag: "1", cluster: "cluster1"}
 
@@ -144,7 +136,7 @@ func TestInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "scheduled", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, f.Projects.Sleeper())
+			client := f.setupProject(t, f.Projects.Sleeper())
 
 			flags := &sousFlags{kind: "scheduled", tag: "1.2.3", cluster: "cluster1"}
 
@@ -176,7 +168,7 @@ func TestInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "custom-reqid-first-deploy", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, f.Projects.HTTPServer())
+			client := f.setupProject(t, f.Projects.HTTPServer())
 
 			flags := &sousFlags{kind: "http-service", tag: "1.2.3", cluster: "cluster1"}
 
@@ -193,7 +185,7 @@ func TestInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "custom-reqid-second-deploy", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, f.Projects.HTTPServer())
+			client := f.setupProject(t, f.Projects.HTTPServer())
 
 			flags := &sousFlags{kind: "http-service", tag: "1.2.3", cluster: "cluster1"}
 
@@ -230,7 +222,7 @@ func TestInitToDeploy(t *testing.T) {
 		}},
 
 		PTest{Name: "change-reqid", Test: func(t *testing.T, f *TestFixture) {
-			client := setupProject(t, f, f.Projects.HTTPServer())
+			client := f.setupProject(t, f.Projects.HTTPServer())
 
 			flags := &sousFlags{kind: "http-service", tag: "1.2.3", cluster: "cluster1"}
 

--- a/test/smoke/testclient_test.go
+++ b/test/smoke/testclient_test.go
@@ -281,7 +281,7 @@ func (c *TestClient) ConfigureCommand(t *testing.T, subcmd string, f *sousFlags,
 	if !quiet() {
 		stdout, stderr := prefixWithTestName(t, clientName)
 		stdoutWriters = append(stdoutWriters, stdout)
-		stderrWriters = append(stdoutWriters, stderr)
+		stderrWriters = append(stderrWriters, stderr)
 	}
 
 	cmd.Stdout = io.MultiWriter(stdoutWriters...)

--- a/test/smoke/testclient_test.go
+++ b/test/smoke/testclient_test.go
@@ -261,23 +261,35 @@ func (c *TestClient) Run(t *testing.T, subcmd string, f *sousFlags, args ...stri
 func (c *TestClient) ConfigureCommand(t *testing.T, subcmd string, f *sousFlags, args ...string) *CmdWithHooks {
 	t.Helper()
 	cmd, cancel := c.Cmd(t, subcmd, f, args...)
-	stdout, stderr := prefixWithTestName(t, "client1")
 
 	qArgs := quotedArgs(args)
+
 	outFile, errFile, combinedFile :=
 		openFileAppendOnly(t, c.LogDir, "stdout"),
 		openFileAppendOnly(t, c.LogDir, "stderr"),
 		openFileAppendOnly(t, c.LogDir, "combined")
+
 	allFiles := io.MultiWriter(outFile, errFile, combinedFile)
 
 	executed := newExecutedCMD(subcmd, qArgs)
 
-	cmd.Stdout = io.MultiWriter(stdout, outFile, combinedFile, executed.Stdout, executed.Combined)
-	cmd.Stderr = io.MultiWriter(stderr, errFile, combinedFile, executed.Stderr, executed.Combined)
+	stdoutWriters := []io.Writer{outFile, combinedFile, executed.Stdout, executed.Combined}
+	stderrWriters := []io.Writer{errFile, combinedFile, executed.Stderr, executed.Combined}
+
+	clientName := "client1"
+
+	if !quiet() {
+		stdout, stderr := prefixWithTestName(t, clientName)
+		stdoutWriters = append(stdoutWriters, stdout)
+		stderrWriters = append(stdoutWriters, stderr)
+	}
+
+	cmd.Stdout = io.MultiWriter(stdoutWriters...)
+	cmd.Stderr = io.MultiWriter(stderrWriters...)
 
 	preRun := func() {
 		prettyCmd := fmt.Sprintf("$ sous %s\n", strings.Join(allArgs(subcmd, f, qArgs), " "))
-		fmt.Fprintf(os.Stderr, "==> %s", prettyCmd)
+		fmt.Fprintf(os.Stderr, "%s:%s:command > %s\n", t.Name(), clientName, prettyCmd)
 		relPath := mustGetRelPath(t, c.BaseDir, cmd.Dir)
 		fmt.Fprintf(allFiles, "%s %s", relPath, prettyCmd)
 	}

--- a/test/smoke/testfixture_test.go
+++ b/test/smoke/testfixture_test.go
@@ -25,7 +25,22 @@ type TestFixture struct {
 	Parent        *ParallelTestFixture
 	TestName      string
 	UserEmail     string
+	Projects      ProjectList
 	knownToFail   bool
+}
+
+type fixtureConfig struct {
+	dbPrimary  bool
+	startState *sous.State
+	projects   ProjectList
+}
+
+func (fcfg fixtureConfig) Desc() string {
+	store := "GIT"
+	if fcfg.dbPrimary {
+		store = "DB"
+	}
+	return fmt.Sprintf("%s/%s", store, fcfg.projects.GroupName)
 }
 
 var sousBin = mustGetSousBin()
@@ -78,6 +93,7 @@ func newTestFixture(t *testing.T, envDesc desc.EnvDesc, parent *ParallelTestFixt
 		Parent:        parent,
 		TestName:      t.Name(),
 		UserEmail:     userEmail,
+		Projects:      fcfg.projects,
 	}
 	client := makeClient(tf, baseDir, sousBin)
 	if err := client.Configure(primaryServer, envDesc.RegistryName(), userEmail); err != nil {

--- a/test/smoke/testfixture_test.go
+++ b/test/smoke/testfixture_test.go
@@ -103,6 +103,20 @@ func newTestFixture(t *testing.T, envDesc desc.EnvDesc, parent *ParallelTestFixt
 	return tf
 }
 
+func (f *TestFixture) DIDAndDefaultReqID(t *testing.T, repo, offset, flavor, cluster string) (sous.DeploymentID, string) {
+	did := sous.DeploymentID{
+		ManifestID: sous.ManifestID{
+			Source: sous.SourceLocation{
+				Repo: repo,
+				Dir:  offset,
+			},
+			Flavor: flavor,
+		},
+		Cluster: cluster,
+	}
+	return did, f.Singularity.DefaultReqID(t, did)
+}
+
 // IsolatedClusterName returns a cluster name unique to this test fixture.
 func (f *TestFixture) IsolatedClusterName(baseName string) string {
 	return baseName + f.ClusterSuffix

--- a/test/smoke/testmain_test.go
+++ b/test/smoke/testmain_test.go
@@ -1,0 +1,20 @@
+//+build smoke
+
+package smoke
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+var pfs = newParallelTestFixtureSet(PTFOpts{
+	NumFreeAddrs: 128,
+})
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	exitCode := m.Run()
+	pfs.PrintSummary()
+	os.Exit(exitCode)
+}

--- a/test/smoke/testpids_test.go
+++ b/test/smoke/testpids_test.go
@@ -24,6 +24,9 @@ func writePID(t *testing.T, pid int) {
 	if err != nil {
 		t.Fatalf("cannot inspect proc %d: %s", pid, err)
 	}
+	if psProc == nil {
+		t.Fatal("psProc is nil")
+	}
 
 	var f *os.File
 	if s, err := os.Stat(pidFile); err != nil {

--- a/test/smoke/testpids_test.go
+++ b/test/smoke/testpids_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	ps "github.com/mitchellh/go-ps"
 )
@@ -25,7 +26,15 @@ func writePID(t *testing.T, pid int) {
 		t.Fatalf("cannot inspect proc %d: %s", pid, err)
 	}
 	if psProc == nil {
-		t.Fatal("psProc is nil")
+		time.Sleep(time.Second)
+		psProc, err := ps.FindProcess(pid)
+		if err != nil {
+			t.Fatalf("cannot inspect proc %d: %s", pid, err)
+		}
+		if psProc == nil {
+			t.Logf("Warning! Possibly orphaned PID: %d", pid)
+			return
+		}
 	}
 
 	var f *os.File

--- a/test/smoke/testprojects_test.go
+++ b/test/smoke/testprojects_test.go
@@ -157,14 +157,7 @@ func splitBuild(p Program) filemap.FileMap {
 	}
 }
 
-// setupProject creates a brand new git repo containing the provided Dockerfile,
-// commits that Dockerfile, runs 'sous version' and 'sous config', and returns a
-// sous TestClient in the project directory.
-func setupProjectSingleDockerfile(t *testing.T, f *TestFixture, dockerfile string) *TestClient {
-	return setupProject(t, f, filemap.FileMap{"Dockerfile": dockerfile})
-}
-
-func setupProject(t *testing.T, f *TestFixture, fm filemap.FileMap) *TestClient {
+func (f *TestFixture) setupProject(t *testing.T, fm filemap.FileMap) *TestClient {
 	t.Helper()
 	// Setup project git repo.
 	projectDir := makeGitRepo(t, f.Client.BaseDir, "projects/project1", GitRepoSpec{

--- a/test/smoke/testprojects_test.go
+++ b/test/smoke/testprojects_test.go
@@ -5,6 +5,7 @@ package smoke
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"testing"
 
@@ -185,10 +186,14 @@ func setupProject(t *testing.T, f *TestFixture, fm filemap.FileMap) *TestClient 
 	client.Dir = projectDir
 
 	// Dump sous version & config.
-	if testing.Verbose() {
+	if !quiet() {
 		log.Printf("Sous version: %s", client.MustRun(t, "version", nil))
 		client.MustRun(t, "config", nil)
 	}
 
 	return client
+}
+
+func quiet() bool {
+	return os.Getenv("SMOKE_TEST_QUIET") == "YES"
 }

--- a/test/smoke/testprojects_test.go
+++ b/test/smoke/testprojects_test.go
@@ -4,6 +4,7 @@ package smoke
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 
@@ -74,12 +75,17 @@ func failer() filemap.FileMap {
 	return singleDockerfile(failImmediately)
 }
 
+// String returns p as a string with spaces trimmed.
+func (p Program) String() string {
+	return strings.TrimSpace(string(p))
+}
+
 func (p Program) FormatForDockerfile() string {
-	return strings.Replace(string(p), "\n", "\\\n", -1)
+	return strings.Replace(p.String(), "\n", " \\\n", -1)
 }
 
 func (p Program) FormatAsShellFile() string {
-	return fmt.Sprintf("#!/usr/bin/env sh\n%s", p)
+	return fmt.Sprintf("#!/usr/bin/env sh\n\n%s", p)
 }
 
 func singleDockerfile(p Program) filemap.FileMap {
@@ -179,8 +185,10 @@ func setupProject(t *testing.T, f *TestFixture, fm filemap.FileMap) *TestClient 
 	client.Dir = projectDir
 
 	// Dump sous version & config.
-	t.Logf("Sous version: %s", client.MustRun(t, "version", nil))
-	client.MustRun(t, "config", nil)
+	if testing.Verbose() {
+		log.Printf("Sous version: %s", client.MustRun(t, "version", nil))
+		client.MustRun(t, "config", nil)
+	}
 
 	return client
 }

--- a/test/smoke/testprojects_test.go
+++ b/test/smoke/testprojects_test.go
@@ -1,0 +1,93 @@
+//+build smoke
+
+package smoke
+
+import (
+	"testing"
+
+	"github.com/opentable/sous/util/filemap"
+)
+
+// Define some Dockerfiles for use in tests.
+const (
+	simpleServer = `
+FROM alpine:3.7
+CMD if [ -z "$T" ]; then T=2; fi; echo -n "Sleeping ${T}s..."; sleep $T; echo "Done"; echo "Listening on :$PORT0"; while true; do echo -e "HTTP/1.1 200 OK\n\n$(date)" | nc -l -p $PORT0; done
+`
+	sleeper = `
+FROM alpine:3.7
+CMD echo -n Sleeping for 10s...; sleep 10; echo Done
+`
+	failer = `
+FROM alpine:3.7
+CMD echo -n Failing in 10s...; sleep 10; echo Failed; exit 1
+`
+)
+
+func simpleServerSplitContainer() filemap.FileMap {
+	return filemap.FileMap{
+		"Dockerfile": `
+			FROM alpine:3.7
+			ENV SOUS_RUN_IMAGE_SPEC=/image-spec.json
+			COPY image-spec.json /
+			RUN mkdir /server
+			COPY server.sh /server/
+			`,
+		"image-spec.json": `
+			{
+			  "image": {
+			    "type": "Docker",
+				"from": "alpine:3.2"
+			  },
+			  "files": [
+			    {
+				  "source": {"dir": "/server"},
+			      "dest": {"dir": "/"}
+			    }
+			  ],
+			  "exec": ["/server/server.sh"]
+			}
+			`,
+		"server.sh": `#!/usr/bin/env sh
+			echo "Listening on :$PORT0"
+			while true; do
+			  echo -e "HTTP/1.1 200 OK\n\n$(date)" | nc -l -p $PORT0
+			done
+			`,
+	}
+}
+
+// setupProject creates a brand new git repo containing the provided Dockerfile,
+// commits that Dockerfile, runs 'sous version' and 'sous config', and returns a
+// sous TestClient in the project directory.
+func setupProjectSingleDockerfile(t *testing.T, f *TestFixture, dockerfile string) *TestClient {
+	return setupProject(t, f, filemap.FileMap{"Dockerfile": dockerfile})
+}
+
+func setupProject(t *testing.T, f *TestFixture, fm filemap.FileMap) *TestClient {
+	t.Helper()
+	// Setup project git repo.
+	projectDir := makeGitRepo(t, f.Client.BaseDir, "projects/project1", GitRepoSpec{
+		UserName:  "Sous User 1",
+		UserEmail: "sous-user1@example.com",
+		OriginURL: "git@github.com:user1/repo1.git",
+	})
+	if err := fm.Write(projectDir); err != nil {
+		t.Fatalf("filemap.Write: %s", err)
+	}
+	for filePath := range fm {
+		mustDoCMD(t, projectDir, "git", "add", filePath)
+	}
+	mustDoCMD(t, projectDir, "git", "commit", "-m", "Initial Commit")
+
+	client := f.Client
+
+	// cd into project dir
+	client.Dir = projectDir
+
+	// Dump sous version & config.
+	t.Logf("Sous version: %s", client.MustRun(t, "version", nil))
+	client.MustRun(t, "config", nil)
+
+	return client
+}

--- a/util/filemap/filemap.go
+++ b/util/filemap/filemap.go
@@ -23,6 +23,21 @@ func (f FileMap) Mine(dir, path string) bool {
 	return ok
 }
 
+// Merge attempts to merge 2 filemaps, if any keys conflict it panics.
+func (f FileMap) Merge(o FileMap) FileMap {
+	n := FileMap{}
+	for k, v := range f {
+		n[k] = v
+	}
+	for k, v := range o {
+		if _, exists := n[k]; exists {
+			panic(fmt.Sprintf("merging filemaps failed: duplicate key: %q", k))
+		}
+		n[k] = v
+	}
+	return n
+}
+
 // Clean deletes each file defined in f, it leaves any created directories
 // in place. If you want to nuke everything, just use os.RemoveAll(dir).
 func (f FileMap) Clean(dir string) error {


### PR DESCRIPTION
Adds builder type as a dimension to all other smoke tests.
This doubles the number of tests, and thus requires a lot of ram (for safety 4G) to run the tests. Full test run takes about 8 minutes locally.

Opening a PR to see if Travis can handle this or not. Most likely we need to do 2 things:

1) Run smoke tests selectively on each PR, run full suite nightly, and
2) Have tests clean up as they go (killing Singularity requests) to reduce memory footprint required.

If this all passes happily in Travis, and on core committer's machines, should be safe to merge, otherwise I'll address the above issues first.