### PR TITLE
Extract testmatrix package #trivial

### DIFF
--- a/test/smoke/matrix.go
+++ b/test/smoke/matrix.go
@@ -1,0 +1,39 @@
+package smoke
+
+import sous "github.com/opentable/sous/lib"
+
+type fixtureConfig struct {
+	dbPrimary  bool
+	startState *sous.State
+	projects   projectList
+	Desc       string
+}
+
+// matrix returns the defined sous smoke test matrix.
+func matrix() matrixDef {
+	m := newMatrix()
+	m.AddDimension("store", "GDM storage to use", map[string]interface{}{
+		"db":  true,
+		"git": false,
+	})
+	m.AddDimension("project", "type of project to build", map[string]interface{}{
+		"simple": projects.SingleDockerfile,
+		"split":  projects.SplitBuild,
+	})
+	return m
+}
+
+// TODO SS: Remove this from MatrixDef and write a helper func to do the same.
+func (m *matrixDef) FixtureConfigs() []fixtureConfig {
+	cs := m.combinations()
+	fcfgs := make([]fixtureConfig, len(cs))
+	for i, c := range m.combinations() {
+		m := c.Map()
+		fcfgs[i] = fixtureConfig{
+			Desc:      c.String(),
+			dbPrimary: m["store"].(bool),
+			projects:  m["project"].(projectList),
+		}
+	}
+	return fcfgs
+}

--- a/test/smoke/matrix.go
+++ b/test/smoke/matrix.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/opentable/sous/dev_support/sous_qa_setup/desc"
 	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/testmatrix"
 )
 
 type fixtureConfig struct {
@@ -26,8 +27,8 @@ type matrixCombo struct {
 }
 
 // matrix returns the defined sous smoke test matrix.
-func matrix() Matrix {
-	m := New()
+func matrix() testmatrix.Matrix {
+	m := testmatrix.New()
 	m.AddDimension("store", "GDM storage to use", map[string]interface{}{
 		"db":  true,
 		"git": false,
@@ -39,7 +40,7 @@ func matrix() Matrix {
 	return m
 }
 
-func makeFixtureConfig(t *testing.T, c Scenario) fixtureConfig {
+func makeFixtureConfig(t *testing.T, c testmatrix.Scenario) fixtureConfig {
 	envDesc := getEnvDesc()
 	clusterSuffix := strings.Replace(t.Name(), "/", "_", -1)
 	fmt.Fprintf(os.Stdout, "Cluster suffix: %s", clusterSuffix)
@@ -60,7 +61,7 @@ func makeFixtureConfig(t *testing.T, c Scenario) fixtureConfig {
 	}
 }
 
-func makeMatrixCombo(c Scenario) matrixCombo {
+func makeMatrixCombo(c testmatrix.Scenario) matrixCombo {
 	m := c.Map()
 	return matrixCombo{
 		dbPrimary: m["store"].(bool),

--- a/test/smoke/matrix.go
+++ b/test/smoke/matrix.go
@@ -3,9 +3,13 @@ package smoke
 import sous "github.com/opentable/sous/lib"
 
 type fixtureConfig struct {
-	dbPrimary  bool
+	matrix     matrixCombo
 	startState *sous.State
-	projects   projectList
+}
+
+type matrixCombo struct {
+	dbPrimary bool
+	projects  projectList
 }
 
 // matrix returns the defined sous smoke test matrix.
@@ -23,8 +27,14 @@ func matrix() matrixDef {
 }
 
 func makeFixtureConfig(c combination) fixtureConfig {
-	m := c.Map()
 	return fixtureConfig{
+		matrix: makeMatrixCombo(c),
+	}
+}
+
+func makeMatrixCombo(c combination) matrixCombo {
+	m := c.Map()
+	return matrixCombo{
 		dbPrimary: m["store"].(bool),
 		projects:  m["project"].(projectList),
 	}

--- a/test/smoke/matrix.go
+++ b/test/smoke/matrix.go
@@ -6,7 +6,6 @@ type fixtureConfig struct {
 	dbPrimary  bool
 	startState *sous.State
 	projects   projectList
-	Desc       string
 }
 
 // matrix returns the defined sous smoke test matrix.
@@ -23,17 +22,10 @@ func matrix() matrixDef {
 	return m
 }
 
-// TODO SS: Remove this from MatrixDef and write a helper func to do the same.
-func (m *matrixDef) FixtureConfigs() []fixtureConfig {
-	cs := m.combinations()
-	fcfgs := make([]fixtureConfig, len(cs))
-	for i, c := range m.combinations() {
-		m := c.Map()
-		fcfgs[i] = fixtureConfig{
-			Desc:      c.String(),
-			dbPrimary: m["store"].(bool),
-			projects:  m["project"].(projectList),
-		}
+func makeFixtureConfig(c combination) fixtureConfig {
+	m := c.Map()
+	return fixtureConfig{
+		dbPrimary: m["store"].(bool),
+		projects:  m["project"].(projectList),
 	}
-	return fcfgs
 }

--- a/test/smoke/matrix.go
+++ b/test/smoke/matrix.go
@@ -26,8 +26,8 @@ type matrixCombo struct {
 }
 
 // matrix returns the defined sous smoke test matrix.
-func matrix() matrixDef {
-	m := newMatrix()
+func matrix() Matrix {
+	m := New()
 	m.AddDimension("store", "GDM storage to use", map[string]interface{}{
 		"db":  true,
 		"git": false,
@@ -39,7 +39,7 @@ func matrix() matrixDef {
 	return m
 }
 
-func makeFixtureConfig(t *testing.T, c combination) fixtureConfig {
+func makeFixtureConfig(t *testing.T, c Scenario) fixtureConfig {
 	envDesc := getEnvDesc()
 	clusterSuffix := strings.Replace(t.Name(), "/", "_", -1)
 	fmt.Fprintf(os.Stdout, "Cluster suffix: %s", clusterSuffix)
@@ -60,7 +60,7 @@ func makeFixtureConfig(t *testing.T, c combination) fixtureConfig {
 	}
 }
 
-func makeMatrixCombo(c combination) matrixCombo {
+func makeMatrixCombo(c Scenario) matrixCombo {
 	m := c.Map()
 	return matrixCombo{
 		dbPrimary: m["store"].(bool),

--- a/test/smoke/matrixdef.go
+++ b/test/smoke/matrixdef.go
@@ -4,16 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-
-	sous "github.com/opentable/sous/lib"
 )
-
-type fixtureConfig struct {
-	dbPrimary  bool
-	startState *sous.State
-	projects   projectList
-	Desc       string
-}
 
 type matrixDef struct {
 	OrderedDimensionNames []string
@@ -82,21 +73,6 @@ func (m matrixDef) clone(include func(dimension, value string) bool) matrixDef {
 		n.Dimensions[name] = nv
 	}
 	return n
-}
-
-// TODO SS: Remove this from MatrixDef and write a helper func to do the same.
-func (m *matrixDef) FixtureConfigs() []fixtureConfig {
-	cs := m.combinations()
-	fcfgs := make([]fixtureConfig, len(cs))
-	for i, c := range m.combinations() {
-		m := c.Map()
-		fcfgs[i] = fixtureConfig{
-			Desc:      c.String(),
-			dbPrimary: m["store"].(bool),
-			projects:  m["project"].(projectList),
-		}
-	}
-	return fcfgs
 }
 
 func (m *matrixDef) combinations() []combination {

--- a/test/smoke/otpl_test.go
+++ b/test/smoke/otpl_test.go
@@ -45,7 +45,7 @@ func TestOTPL(t *testing.T) {
 
 	// FixedDimension is because otpl deploy can only work with simple dockerfile
 	// projects, not split build projects.
-	pf := newMatrixRunner(t, matrix().FixedDimension("project", "simple"))
+	pf := newRunner(t, matrix().FixedDimension("project", "simple"))
 
 	pf.Run("artifact-add", func(t *testing.T, f *testFixture) {
 		client := setupProject(t, f, f.Projects.HTTPServer())

--- a/test/smoke/otpl_test.go
+++ b/test/smoke/otpl_test.go
@@ -47,7 +47,8 @@ func TestOTPL(t *testing.T) {
 	// projects, not split build projects.
 	pf := pfs.newParallelTestFixture(t, matrix().FixedDimension("project", "simple"))
 
-	pf.Run("artifact-add", func(t *testing.T, f *testFixture) {
+	pf.Run("artifact-add", func(t *testing.T, c Context) {
+		f := c.F.(*testFixture)
 		client := f.setupProject(t, f.Projects.HTTPServer())
 
 		flags := &sousFlags{tag: "1.2.3", repo: "github.com/some-user/project1"}
@@ -66,8 +67,8 @@ func TestOTPL(t *testing.T) {
 		}
 	})
 
-	pf.Run("build-init-deploy", func(t *testing.T, f *testFixture) {
-
+	pf.Run("build-init-deploy", func(t *testing.T, c Context) {
+		f := c.F.(*testFixture)
 		client := f.setupProject(t, f.Projects.HTTPServer().Merge(filemap.FileMap{
 			"config/cluster1/singularity.json": `
 				{
@@ -106,9 +107,10 @@ func TestOTPL(t *testing.T) {
 		assertNonNilHealthCheckOnLatestDeploy(t, f, reqID)
 	})
 
-	pf.Run("fail-unknown-fields", func(t *testing.T, f *testFixture) {
+	pf.Run("fail-unknown-fields", func(t *testing.T, c Context) {
 
 		t.Skipf("WIP")
+		f := c.F.(*testFixture)
 
 		client := f.setupProject(t, f.Projects.HTTPServer().Merge(filemap.FileMap{
 			"config/cluster1/singularity.json": `

--- a/test/smoke/otpl_test.go
+++ b/test/smoke/otpl_test.go
@@ -45,11 +45,10 @@ func TestOTPL(t *testing.T) {
 
 	// FixedDimension is because otpl deploy can only work with simple dockerfile
 	// projects, not split build projects.
-	pf := pfs.newParallelTestFixture(t, matrix().FixedDimension("project", "simple"))
+	pf := newMatrixRunner(t, matrix().FixedDimension("project", "simple"))
 
-	pf.Run("artifact-add", func(t *testing.T, c Context) {
-		f := c.F.(*testFixture)
-		client := f.setupProject(t, f.Projects.HTTPServer())
+	pf.Run("artifact-add", func(t *testing.T, f *testFixture) {
+		client := setupProject(t, f, f.Projects.HTTPServer())
 
 		flags := &sousFlags{tag: "1.2.3", repo: "github.com/some-user/project1"}
 
@@ -67,9 +66,8 @@ func TestOTPL(t *testing.T) {
 		}
 	})
 
-	pf.Run("build-init-deploy", func(t *testing.T, c Context) {
-		f := c.F.(*testFixture)
-		client := f.setupProject(t, f.Projects.HTTPServer().Merge(filemap.FileMap{
+	pf.Run("build-init-deploy", func(t *testing.T, f *testFixture) {
+		client := setupProject(t, f, f.Projects.HTTPServer().Merge(filemap.FileMap{
 			"config/cluster1/singularity.json": `
 				{
 					"requestId": "request1",
@@ -107,12 +105,11 @@ func TestOTPL(t *testing.T) {
 		assertNonNilHealthCheckOnLatestDeploy(t, f, reqID)
 	})
 
-	pf.Run("fail-unknown-fields", func(t *testing.T, c Context) {
+	pf.Run("fail-unknown-fields", func(t *testing.T, f *testFixture) {
 
 		t.Skipf("WIP")
-		f := c.F.(*testFixture)
 
-		client := f.setupProject(t, f.Projects.HTTPServer().Merge(filemap.FileMap{
+		client := setupProject(t, f, f.Projects.HTTPServer().Merge(filemap.FileMap{
 			"config/cluster1/singularity.json": `
 				{
 					"requestId": "request1",

--- a/test/smoke/otpl_test.go
+++ b/test/smoke/otpl_test.go
@@ -47,31 +47,29 @@ func TestOTPL(t *testing.T) {
 	// projects, not split build projects.
 	pf := pfs.newParallelTestFixture(t, matrix().FixedDimension("project", "simple"))
 
-	pf.RunMatrix(
+	pf.Run("artifact-add", func(t *testing.T, f *testFixture) {
+		client := f.setupProject(t, f.Projects.HTTPServer())
 
-		PTest{Name: "artifact-add", Test: func(t *testing.T, f *testFixture) {
-			client := f.setupProject(t, f.Projects.HTTPServer())
+		flags := &sousFlags{tag: "1.2.3", repo: "github.com/some-user/project1"}
 
-			flags := &sousFlags{tag: "1.2.3", repo: "github.com/some-user/project1"}
+		dockerRef := dockerBuildAddArtifact(t, f, client, flags)
 
-			dockerRef := dockerBuildAddArtifact(t, f, client, flags)
+		output := client.MustRun(t, "artifact get", flags)
 
-			output := client.MustRun(t, "artifact get", flags)
+		if !strings.Contains(output, dockerRef) {
+			// TODO SS: Figure out how to do this assertion given that we do
+			// not store the Docker tag sent, only the  digest.
+			//t.Errorf("output did not contain %q; was:\n%s", dockerRef, output)
+		} else {
+			// TODO SS: Remove next line once we have the assertion above.
+			t.Logf(output)
+		}
+	})
 
-			if !strings.Contains(output, dockerRef) {
-				// TODO SS: Figure out how to do this assertion given that we do
-				// not store the Docker tag sent, only the  digest.
-				//t.Errorf("output did not contain %q; was:\n%s", dockerRef, output)
-			} else {
-				// TODO SS: Remove next line once we have the assertion above.
-				t.Logf(output)
-			}
-		}},
+	pf.Run("build-init-deploy", func(t *testing.T, f *testFixture) {
 
-		PTest{Name: "build-init-deploy", Test: func(t *testing.T, f *testFixture) {
-
-			client := f.setupProject(t, f.Projects.HTTPServer().Merge(filemap.FileMap{
-				"config/cluster1/singularity.json": `
+		client := f.setupProject(t, f.Projects.HTTPServer().Merge(filemap.FileMap{
+			"config/cluster1/singularity.json": `
 				{
 					"requestId": "request1",
 					"resources": {
@@ -80,7 +78,7 @@ func TestOTPL(t *testing.T) {
 						"numPorts": 3
 					}
 				}`,
-				"config/cluster1/singularity-request.json": `
+			"config/cluster1/singularity-request.json": `
 				{
 					"id": "request1",
 					"requestType": "SERVICE",
@@ -89,31 +87,31 @@ func TestOTPL(t *testing.T) {
 					],
 					"instances": 3
 				}`,
-			}))
+		}))
 
-			flags := &sousFlags{
-				kind:    "http-service",
-				repo:    "github.com/build-init-deploy-user/project1",
-				tag:     "1.2.3",
-				cluster: "cluster1",
-			}
+		flags := &sousFlags{
+			kind:    "http-service",
+			repo:    "github.com/build-init-deploy-user/project1",
+			tag:     "1.2.3",
+			cluster: "cluster1",
+		}
 
-			dockerBuildAddArtifactInit(t, f, client, flags, setMinimalMemAndCPUNumInst1)
+		dockerBuildAddArtifactInit(t, f, client, flags, setMinimalMemAndCPUNumInst1)
 
-			client.MustRun(t, "deploy", flags.SousDeployFlags())
+		client.MustRun(t, "deploy", flags.SousDeployFlags())
 
-			reqID := f.DefaultSingReqID(t, flags)
-			assertActiveStatus(t, f, reqID)
-			assertSingularityRequestTypeService(t, f, reqID)
-			assertNonNilHealthCheckOnLatestDeploy(t, f, reqID)
-		}},
+		reqID := f.DefaultSingReqID(t, flags)
+		assertActiveStatus(t, f, reqID)
+		assertSingularityRequestTypeService(t, f, reqID)
+		assertNonNilHealthCheckOnLatestDeploy(t, f, reqID)
+	})
 
-		PTest{Name: "fail-unknown-fields", Test: func(t *testing.T, f *testFixture) {
+	pf.Run("fail-unknown-fields", func(t *testing.T, f *testFixture) {
 
-			t.Skipf("WIP")
+		t.Skipf("WIP")
 
-			client := f.setupProject(t, f.Projects.HTTPServer().Merge(filemap.FileMap{
-				"config/cluster1/singularity.json": `
+		client := f.setupProject(t, f.Projects.HTTPServer().Merge(filemap.FileMap{
+			"config/cluster1/singularity.json": `
 				{
 					"requestId": "request1",
 					"resources": {
@@ -122,7 +120,7 @@ func TestOTPL(t *testing.T) {
 						"numPorts": 3
 					}
 				}`,
-				"config/cluster1/singularity-request.json": `
+			"config/cluster1/singularity-request.json": `
 				{
 					id: "request1",
 					"requestType": "WORKER",
@@ -134,8 +132,7 @@ func TestOTPL(t *testing.T) {
 					"rackSensitive": false,
 					"loadBalanced": false
 				}`,
-			}))
-			client.MustRun(t, "version", nil)
-		}},
-	)
+		}))
+		client.MustRun(t, "version", nil)
+	})
 }

--- a/test/smoke/otpl_test.go
+++ b/test/smoke/otpl_test.go
@@ -45,7 +45,7 @@ func TestOTPL(t *testing.T) {
 
 	// FixedDimension is because otpl deploy can only work with simple dockerfile
 	// projects, not split build projects.
-	pf := pfs.newParallelTestFixture(t, Matrix().FixedDimension("project", "simple"))
+	pf := pfs.newParallelTestFixture(t, matrix().FixedDimension("project", "simple"))
 
 	pf.RunMatrix(
 

--- a/test/smoke/paralleltestfixture.go
+++ b/test/smoke/paralleltestfixture.go
@@ -90,8 +90,8 @@ type PTest struct {
 // RunMatrix runs the provided PTests in parallel, once for each combination of
 // the matrix passed to newParallelTestFixture.
 func (pf *parallelTestFixture) RunMatrix(tests ...PTest) {
-	for _, c := range pf.Matrix.FixtureConfigs() {
-		pf.T.Run(c.Desc, func(t *testing.T) {
+	for _, c := range pf.Matrix.combinations() {
+		pf.T.Run(c.String(), func(t *testing.T) {
 			c := c
 			t.Parallel()
 			for _, pt := range tests {
@@ -228,9 +228,9 @@ func (pf *parallelTestFixture) printSummary() (total, passed, skipped, failed, m
 	return total, passed, skipped, failed, missing
 }
 
-func (pf *parallelTestFixture) newIsolatedFixture(t *testing.T, fcfg fixtureConfig) *testFixture {
+func (pf *parallelTestFixture) newIsolatedFixture(t *testing.T, c combination) *testFixture {
 	t.Helper()
 	pf.recordTestStarted(t)
 	envDesc := getEnvDesc()
-	return newTestFixture(t, envDesc, pf, pf.GetAddrs, fcfg)
+	return newTestFixture(t, envDesc, pf, pf.GetAddrs, c)
 }

--- a/test/smoke/paralleltestfixture.go
+++ b/test/smoke/paralleltestfixture.go
@@ -11,7 +11,6 @@ type (
 	parallelTestFixture struct {
 		T                  *testing.T
 		Matrix             matrixDef
-		GetAddrs           func(int) []string
 		testNames          map[string]struct{}
 		testNamesMu        sync.RWMutex
 		testNamesPassed    map[string]struct{}
@@ -35,11 +34,7 @@ func newParallelTestFixtureSet() *parallelTestFixtureSet {
 	if err := stopPIDs(); err != nil {
 		panic(err)
 	}
-	getAddrs := func(n int) []string {
-		return freePortAddrs("127.0.0.1", n, 49152, 65535)
-	}
 	return &parallelTestFixtureSet{
-		GetAddrs: getAddrs,
 		fixtures: map[string]*parallelTestFixture{},
 	}
 }
@@ -57,7 +52,6 @@ func (pfs *parallelTestFixtureSet) newParallelTestFixture(t *testing.T, m matrix
 	pf := &parallelTestFixture{
 		T:                t,
 		Matrix:           m,
-		GetAddrs:         pfs.GetAddrs,
 		testNames:        map[string]struct{}{},
 		testNamesPassed:  map[string]struct{}{},
 		testNamesSkipped: map[string]struct{}{},
@@ -231,6 +225,5 @@ func (pf *parallelTestFixture) printSummary() (total, passed, skipped, failed, m
 func (pf *parallelTestFixture) newIsolatedFixture(t *testing.T, c combination) *testFixture {
 	t.Helper()
 	pf.recordTestStarted(t)
-	envDesc := getEnvDesc()
-	return newTestFixture(t, envDesc, pf, pf.GetAddrs, c)
+	return newTestFixture(t, pf, c)
 }

--- a/test/smoke/paralleltestfixture.go
+++ b/test/smoke/paralleltestfixture.go
@@ -81,30 +81,6 @@ type PTest struct {
 	Test func(*testing.T, *testFixture)
 }
 
-// RunMatrix runs the provided PTests in parallel, once for each combination of
-// the matrix passed to newParallelTestFixture.
-func (pf *parallelTestFixture) RunMatrix(tests ...PTest) {
-	for _, c := range pf.Matrix.combinations() {
-		pf.T.Run(c.String(), func(t *testing.T) {
-			c := c
-			t.Parallel()
-			for _, pt := range tests {
-				pt := pt
-				t.Run(pt.Name, func(t *testing.T) {
-					pf.parent.wg.Add(1)
-					f := pf.newIsolatedFixture(t, c)
-					defer func() {
-						defer pf.parent.wg.Done()
-						pf.recordTestStatus(t)
-						f.Teardown(t)
-					}()
-					pt.Test(t, f)
-				})
-			}
-		})
-	}
-}
-
 // Test is a test.
 type Test func(t *testing.T, f *testFixture)
 

--- a/test/smoke/paralleltestfixture.go
+++ b/test/smoke/paralleltestfixture.go
@@ -46,9 +46,9 @@ func newParallelTestFixtureSet() *parallelTestFixtureSet {
 
 func (pfs *parallelTestFixtureSet) newParallelTestFixture(t *testing.T, m matrixDef) *parallelTestFixture {
 	if flags.printMatrix {
-		matrix := m.FixtureConfigs()
+		matrix := m.combinations()
 		for _, m := range matrix {
-			fmt.Printf("%s/%s\n", t.Name(), m.Desc)
+			fmt.Printf("%s/%s\n", t.Name(), m)
 		}
 		t.Skip("Just printing test matrix (-ls-matrix flag set)")
 	}

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -26,7 +26,7 @@ func initBuildDeploy(t *testing.T, client *sousClient, flags *sousFlags, transfo
 
 func TestSmoke(t *testing.T) {
 
-	m := newMatrixRunner(t, matrix())
+	m := newRunner(t, matrix())
 
 	m.Run("simple", func(t *testing.T, f *testFixture) {
 		client := setupProject(t, f, f.Projects.HTTPServer())

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -25,7 +25,7 @@ func initBuildDeploy(t *testing.T, client *sousClient, flags *sousFlags, transfo
 }
 
 func TestSmoke(t *testing.T) {
-	pf := pfs.newParallelTestFixture(t, Matrix())
+	pf := pfs.newParallelTestFixture(t, matrix())
 
 	pf.RunMatrix(
 

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -24,16 +24,6 @@ func initBuildDeploy(t *testing.T, client *sousClient, flags *sousFlags, transfo
 	client.MustRun(t, "deploy", flags.SousDeployFlags())
 }
 
-type matrixRunner struct{ r *Runner }
-
-func (m *matrixRunner) Run(name string, test func(*testing.T, *testFixture)) {
-	m.r.Run(name, func(t *testing.T, c Context) { test(t, c.F.(*testFixture)) })
-}
-
-func newMatrixRunner(t *testing.T, m matrixDef) matrixRunner {
-	return matrixRunner{r: sup.NewRunner(t, m)}
-}
-
 func TestSmoke(t *testing.T) {
 
 	m := newMatrixRunner(t, matrix())

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -27,7 +27,8 @@ func initBuildDeploy(t *testing.T, client *sousClient, flags *sousFlags, transfo
 func TestSmoke(t *testing.T) {
 	pf := pfs.newParallelTestFixture(t, matrix())
 
-	pf.Run("simple", func(t *testing.T, f *testFixture) {
+	pf.Run("simple", func(t *testing.T, c Context) {
+		f := c.F.(*testFixture)
 
 		client := f.setupProject(t, f.Projects.HTTPServer())
 
@@ -41,7 +42,8 @@ func TestSmoke(t *testing.T) {
 		assertNonNilHealthCheckOnLatestDeploy(t, f, reqID)
 	})
 
-	pf.Run("fail-zero-instances", func(t *testing.T, f *testFixture) {
+	pf.Run("fail-zero-instances", func(t *testing.T, c Context) {
+		f := c.F.(*testFixture)
 		client := f.setupProject(t, f.Projects.HTTPServer())
 
 		flags := &sousFlags{kind: "http-service", tag: "1.2.3", repo: "github.com/user1/repo1"}
@@ -51,7 +53,8 @@ func TestSmoke(t *testing.T) {
 		client.MustFail(t, "deploy", nil, "-cluster", "cluster1", "-tag", "1.2.3")
 	})
 
-	pf.Run("fail-container-crash", func(t *testing.T, f *testFixture) {
+	pf.Run("fail-container-crash", func(t *testing.T, c Context) {
+		f := c.F.(*testFixture)
 
 		// TODO SS: Remove this once fail-container-crash-rafactor works.
 
@@ -78,7 +81,8 @@ func TestSmoke(t *testing.T) {
 		assertNonNilHealthCheckOnLatestDeploy(t, f, reqID)
 	})
 
-	pf.Run("fail-container-crash-rafactor", func(t *testing.T, f *testFixture) {
+	pf.Run("fail-container-crash-rafactor", func(t *testing.T, c Context) {
+		f := c.F.(*testFixture)
 
 		// TODO SS: Fix this test.
 		t.Skipf("This test fails, figure out why it's not equivalent to test above.")
@@ -97,7 +101,8 @@ func TestSmoke(t *testing.T) {
 		assertNonNilHealthCheckOnLatestDeploy(t, f, reqID)
 	})
 
-	pf.Run("flavors", func(t *testing.T, f *testFixture) {
+	pf.Run("flavors", func(t *testing.T, c Context) {
+		f := c.F.(*testFixture)
 		client := f.setupProject(t, f.Projects.HTTPServer())
 
 		flags := &sousFlags{
@@ -113,7 +118,8 @@ func TestSmoke(t *testing.T) {
 		assertNonNilHealthCheckOnLatestDeploy(t, f, reqID)
 	})
 
-	pf.Run("pause-unpause", func(t *testing.T, f *testFixture) {
+	pf.Run("pause-unpause", func(t *testing.T, c Context) {
+		f := c.F.(*testFixture)
 		client := f.setupProject(t, f.Projects.HTTPServer())
 
 		flags := &sousFlags{kind: "http-service", tag: "1", cluster: "cluster1", repo: "github.com/user1/repo1"}
@@ -137,7 +143,8 @@ func TestSmoke(t *testing.T) {
 		assertActiveStatus(t, f, reqID)
 	})
 
-	pf.Run("scheduled", func(t *testing.T, f *testFixture) {
+	pf.Run("scheduled", func(t *testing.T, c Context) {
+		f := c.F.(*testFixture)
 		client := f.setupProject(t, f.Projects.Sleeper())
 
 		flags := &sousFlags{kind: "scheduled", tag: "1.2.3", cluster: "cluster1", repo: "github.com/user1/repo1"}
@@ -160,7 +167,8 @@ func TestSmoke(t *testing.T) {
 		assertNilHealthCheckOnLatestDeploy(t, f, reqID)
 	})
 
-	pf.Run("custom-reqid-first-deploy", func(t *testing.T, f *testFixture) {
+	pf.Run("custom-reqid-first-deploy", func(t *testing.T, c Context) {
+		f := c.F.(*testFixture)
 		client := f.setupProject(t, f.Projects.HTTPServer())
 
 		flags := &sousFlags{kind: "http-service", tag: "1.2.3", cluster: "cluster1", repo: "github.com/user1/repo1"}
@@ -177,7 +185,8 @@ func TestSmoke(t *testing.T) {
 		assertNonNilHealthCheckOnLatestDeploy(t, f, customID)
 	})
 
-	pf.Run("custom-reqid-second-deploy", func(t *testing.T, f *testFixture) {
+	pf.Run("custom-reqid-second-deploy", func(t *testing.T, c Context) {
+		f := c.F.(*testFixture)
 		client := f.setupProject(t, f.Projects.HTTPServer())
 
 		flags := &sousFlags{kind: "http-service", tag: "1.2.3", cluster: "cluster1", repo: "github.com/user1/repo1"}
@@ -206,7 +215,8 @@ func TestSmoke(t *testing.T) {
 		assertActiveStatus(t, f, originalReqID)
 	})
 
-	pf.Run("change-reqid", func(t *testing.T, f *testFixture) {
+	pf.Run("change-reqid", func(t *testing.T, c Context) {
+		f := c.F.(*testFixture)
 		client := f.setupProject(t, f.Projects.HTTPServer())
 
 		flags := &sousFlags{kind: "http-service", tag: "1.2.3", cluster: "cluster1", repo: "github.com/user1/repo1"}

--- a/test/smoke/testbunchofsousservers.go
+++ b/test/smoke/testbunchofsousservers.go
@@ -24,7 +24,7 @@ type bunchOfSousServers struct {
 	Stop         func() error
 }
 
-func newBunchOfSousServers(t *testing.T, baseDir string, getAddrs func(int) []string, fcfg fixtureConfig, finished <-chan struct{}) (*bunchOfSousServers, error) {
+func newBunchOfSousServers(t *testing.T, baseDir string, fcfg fixtureConfig, finished <-chan struct{}) (*bunchOfSousServers, error) {
 	if err := os.MkdirAll(baseDir, 0777); err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func newBunchOfSousServers(t *testing.T, baseDir string, getAddrs func(int) []st
 
 	count := len(state.Defs.Clusters)
 	instances := make([]*sousServer, count)
-	addrs := getAddrs(count)
+	addrs := freePortAddrs("127.0.0.1", count)
 	for i := 0; i < count; i++ {
 		clusterName := state.Defs.Clusters.Names()[i]
 		inst, err := makeInstance(t, binPath, i, clusterName, baseDir, addrs[i], finished)

--- a/test/smoke/testbunchofsousservers.go
+++ b/test/smoke/testbunchofsousservers.go
@@ -131,7 +131,7 @@ func (c *bunchOfSousServers) configure(t *testing.T, envDesc desc.EnvDesc, fcfg 
 				Host:   host,
 				Port:   dbport,
 			},
-			DatabasePrimary: fcfg.dbPrimary,
+			DatabasePrimary: fcfg.matrix.dbPrimary,
 			Docker: docker.Config{
 				RegistryHost: envDesc.RegistryName(),
 			},

--- a/test/smoke/testfixture.go
+++ b/test/smoke/testfixture.go
@@ -21,7 +21,6 @@ type testFixture struct {
 	// ClusterSuffix is used to add a suffix to each generated cluster name.
 	// This can be used to segregate parallel tests.
 	ClusterSuffix string
-	Parent        *parallelTestFixture
 	TestName      string
 	UserEmail     string
 	Projects      projectList
@@ -31,12 +30,8 @@ type testFixture struct {
 
 var sousBin = mustGetSousBin()
 
-func newTestFixture(t *testing.T, parent *parallelTestFixture, combo combination) *testFixture {
+func newTestFixture(t *testing.T, combo combination) Fixture {
 	t.Helper()
-	t.Parallel()
-	if testing.Short() {
-		t.Skipf("-short flag present")
-	}
 	baseDir := getDataDir(t)
 
 	c := makeFixtureConfig(t, combo)
@@ -64,7 +59,6 @@ func newTestFixture(t *testing.T, parent *parallelTestFixture, combo combination
 		BaseDir:       baseDir,
 		Singularity:   c.singularity,
 		ClusterSuffix: c.clusterSuffix,
-		Parent:        parent,
 		TestName:      t.Name(),
 		UserEmail:     userEmail,
 		Projects:      c.matrix.projects,

--- a/test/smoke/testfixture.go
+++ b/test/smoke/testfixture.go
@@ -32,7 +32,7 @@ type testFixture struct {
 
 var sousBin = mustGetSousBin()
 
-func newTestFixture(t *testing.T, envDesc desc.EnvDesc, parent *parallelTestFixture, getAddrs func(int) []string, fcfg fixtureConfig) *testFixture {
+func newTestFixture(t *testing.T, envDesc desc.EnvDesc, parent *parallelTestFixture, getAddrs func(int) []string, combo combination) *testFixture {
 	t.Helper()
 	t.Parallel()
 	if testing.Short() {
@@ -53,6 +53,8 @@ func newTestFixture(t *testing.T, envDesc desc.EnvDesc, parent *parallelTestFixt
 	})
 
 	addURLsToState(state, envDesc)
+
+	fcfg := makeFixtureConfig(combo)
 
 	fcfg.startState = state
 

--- a/test/smoke/testfixture.go
+++ b/test/smoke/testfixture.go
@@ -30,7 +30,7 @@ type testFixture struct {
 
 var sousBin = mustGetSousBin()
 
-func newTestFixture(t *testing.T, combo combination) Fixture {
+func newTestFixture(t *testing.T, combo Scenario) Fixture {
 	t.Helper()
 	baseDir := getDataDir(t)
 

--- a/test/smoke/testfixture.go
+++ b/test/smoke/testfixture.go
@@ -1,7 +1,6 @@
 package smoke
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -32,7 +31,7 @@ type testFixture struct {
 
 var sousBin = mustGetSousBin()
 
-func newTestFixture(t *testing.T, envDesc desc.EnvDesc, parent *parallelTestFixture, getAddrs func(int) []string, combo combination) *testFixture {
+func newTestFixture(t *testing.T, parent *parallelTestFixture, combo combination) *testFixture {
 	t.Helper()
 	t.Parallel()
 	if testing.Short() {
@@ -40,55 +39,39 @@ func newTestFixture(t *testing.T, envDesc desc.EnvDesc, parent *parallelTestFixt
 	}
 	baseDir := getDataDir(t)
 
-	clusterSuffix := strings.Replace(t.Name(), "/", "_", -1)
-	fmt.Fprintf(os.Stdout, "Cluster suffix: %s", clusterSuffix)
-
-	s9y := newSingularity(envDesc.SingularityURL())
-	s9y.ClusterSuffix = clusterSuffix
-
-	state := sous.StateFixture(sous.StateFixtureOpts{
-		ClusterCount:  3,
-		ManifestCount: 3,
-		ClusterSuffix: clusterSuffix,
-	})
-
-	addURLsToState(state, envDesc)
-
-	fcfg := makeFixtureConfig(combo)
-
-	fcfg.startState = state
+	c := makeFixtureConfig(t, combo)
 
 	finished := make(chan struct{})
 
-	c, err := newBunchOfSousServers(t, baseDir, getAddrs, fcfg, finished)
+	boss, err := newBunchOfSousServers(t, baseDir, c, finished)
 	if err != nil {
 		t.Fatalf("setting up test cluster: %s", err)
 	}
 
-	if err := c.configure(t, envDesc, fcfg); err != nil {
+	if err := boss.configure(t, c.envDesc, c); err != nil {
 		t.Fatalf("configuring test cluster: %s", err)
 	}
 
-	if err := c.Start(t, sousBin); err != nil {
+	if err := boss.Start(t, sousBin); err != nil {
 		t.Fatalf("starting test cluster: %s", err)
 	}
 
-	primaryServer := "http://" + c.Instances[0].Addr
+	primaryServer := "http://" + boss.Instances[0].Addr
 	userEmail := "sous_client1@example.com"
 
 	tf := &testFixture{
-		Cluster:       *c,
+		Cluster:       *boss,
 		BaseDir:       baseDir,
-		Singularity:   s9y,
-		ClusterSuffix: clusterSuffix,
+		Singularity:   c.singularity,
+		ClusterSuffix: c.clusterSuffix,
 		Parent:        parent,
 		TestName:      t.Name(),
 		UserEmail:     userEmail,
-		Projects:      fcfg.matrix.projects,
+		Projects:      c.matrix.projects,
 		Finished:      finished,
 	}
 	client := makeClient(t, tf, baseDir, sousBin)
-	if err := client.Configure(primaryServer, envDesc.RegistryName(), userEmail); err != nil {
+	if err := client.Configure(primaryServer, c.envDesc.RegistryName(), userEmail); err != nil {
 		t.Fatal(err)
 	}
 	tf.Client = client

--- a/test/smoke/testfixture.go
+++ b/test/smoke/testfixture.go
@@ -84,7 +84,7 @@ func newTestFixture(t *testing.T, envDesc desc.EnvDesc, parent *parallelTestFixt
 		Parent:        parent,
 		TestName:      t.Name(),
 		UserEmail:     userEmail,
-		Projects:      fcfg.projects,
+		Projects:      fcfg.matrix.projects,
 		Finished:      finished,
 	}
 	client := makeClient(t, tf, baseDir, sousBin)

--- a/test/smoke/testfixture.go
+++ b/test/smoke/testfixture.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/opentable/sous/dev_support/sous_qa_setup/desc"
 	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/testmatrix"
 	"github.com/samsalisbury/semv"
 )
 
@@ -30,7 +31,7 @@ type testFixture struct {
 
 var sousBin = mustGetSousBin()
 
-func newTestFixture(t *testing.T, combo Scenario) Fixture {
+func newTestFixture(t *testing.T, combo testmatrix.Scenario) testmatrix.Fixture {
 	t.Helper()
 	baseDir := getDataDir(t)
 

--- a/test/smoke/testflags.go
+++ b/test/smoke/testflags.go
@@ -1,6 +1,0 @@
-package smoke
-
-var flags = struct {
-	printMatrix     bool
-	printDimensions bool
-}{}

--- a/test/smoke/testmain_test.go
+++ b/test/smoke/testmain_test.go
@@ -8,11 +8,29 @@ import (
 	"testing"
 )
 
+// sup is the global matrix supervisor, used to collate all test results.
 var sup *Supervisor
 
+// matrixRunner is a wrapper around Runner allowing fully baked fixtures to be
+// passed directly to tests, rather than the test having to unwrap scenarios
+// themselves.
+type matrixRunner struct{ r *Runner }
+
+// Run is analogous to Runner.Run, but accepts a func in terms of strongly typed
+// fixture rather than having to manually unwrap scenarios.
+func (m *matrixRunner) Run(name string, test func(*testing.T, *testFixture)) {
+	m.r.Run(name, func(t *testing.T, c Context) { test(t, c.F.(*testFixture)) })
+}
+
+// newMatrixRunner should be called once at the start of every top-level package
+// test to produce that test's matrixRunner.
+func newMatrixRunner(t *testing.T, m Matrix) matrixRunner {
+	return matrixRunner{r: sup.NewRunner(t, m)}
+}
+
 func TestMain(m *testing.M) {
-	flag.BoolVar(&flags.printMatrix, "ls", false, "list test matrix names")
 	flag.BoolVar(&flags.printDimensions, "dimensions", false, "list test matrix dimensions")
+	flag.BoolVar(&flags.printMatrix, "ls", false, "list test matrix names")
 	flag.Parse()
 
 	runRealTests := !(flags.printMatrix || flags.printDimensions)

--- a/test/smoke/testmain_test.go
+++ b/test/smoke/testmain_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-var pfs *parallelTestFixtureSet
+var sup *Supervisor
 
 func TestMain(m *testing.M) {
 	flag.BoolVar(&flags.printMatrix, "ls", false, "list test matrix names")
@@ -22,11 +22,11 @@ func TestMain(m *testing.M) {
 	}
 
 	if runRealTests {
-		pfs = newParallelTestFixtureSet(newTestFixture)
+		sup = NewSupervisor(newTestFixture)
 		resetSingularity()
 	}
 	exitCode := m.Run()
-	pfs.PrintSummary()
+	sup.PrintSummary()
 	os.Exit(exitCode)
 }
 

--- a/test/smoke/testmain_test.go
+++ b/test/smoke/testmain_test.go
@@ -13,21 +13,21 @@ import (
 // sup is the global matrix supervisor, used to collate all test results.
 var sup *testmatrix.Supervisor
 
-// matrixRunner is a wrapper around Runner allowing fully baked fixtures to be
+// runner is a wrapper around Runner allowing fully baked fixtures to be
 // passed directly to tests, rather than the test having to unwrap scenarios
 // themselves.
-type matrixRunner struct{ r *testmatrix.Runner }
+type runner struct{ *testmatrix.Runner }
 
 // Run is analogous to Runner.Run, but accepts a func in terms of strongly typed
 // fixture rather than having to manually unwrap scenarios.
-func (m *matrixRunner) Run(name string, test func(*testing.T, *testFixture)) {
-	m.r.Run(name, func(t *testing.T, c testmatrix.Context) { test(t, c.F.(*testFixture)) })
+func (r *runner) Run(name string, test func(*testing.T, *testFixture)) {
+	r.Runner.Run(name, func(t *testing.T, c testmatrix.Context) { test(t, c.F.(*testFixture)) })
 }
 
-// newMatrixRunner should be called once at the start of every top-level package
+// newRunner should be called once at the start of every top-level package
 // test to produce that test's matrixRunner.
-func newMatrixRunner(t *testing.T, m testmatrix.Matrix) matrixRunner {
-	return matrixRunner{r: sup.NewRunner(t, m)}
+func newRunner(t *testing.T, m testmatrix.Matrix) runner {
+	return runner{Runner: sup.NewRunner(t, m)}
 }
 
 func TestMain(m *testing.M) {
@@ -40,7 +40,9 @@ func TestMain(m *testing.M) {
 		}
 	}
 	exitCode := m.Run()
+	//if sup != nil {
 	sup.PrintSummary()
+	//}
 	os.Exit(exitCode)
 }
 

--- a/test/smoke/testmain_test.go
+++ b/test/smoke/testmain_test.go
@@ -33,16 +33,12 @@ func newRunner(t *testing.T, m testmatrix.Matrix) runner {
 func TestMain(m *testing.M) {
 	flag.Parse()
 	testmatrix.Quiet = quiet()
-	if sup = testmatrix.Init(matrix, newTestFixture); sup != nil {
+	sup = testmatrix.Init(matrix, newTestFixture, func() error {
 		resetSingularity()
-		if err := stopPIDs(); err != nil {
-			panic(err)
-		}
-	}
+		return stopPIDs()
+	})
 	exitCode := m.Run()
-	//if sup != nil {
 	sup.PrintSummary()
-	//}
 	os.Exit(exitCode)
 }
 

--- a/test/smoke/testmain_test.go
+++ b/test/smoke/testmain_test.go
@@ -10,20 +10,6 @@ import (
 
 var pfs *parallelTestFixtureSet
 
-// Matrix returns the defined sous smoke test matrix.
-func Matrix() matrixDef {
-	m := newMatrix()
-	m.AddDimension("store", "GDM storage to use", map[string]interface{}{
-		"db":  true,
-		"git": false,
-	})
-	m.AddDimension("project", "type of project to build", map[string]interface{}{
-		"simple": projects.SingleDockerfile,
-		"split":  projects.SplitBuild,
-	})
-	return m
-}
-
 func TestMain(m *testing.M) {
 	flag.BoolVar(&flags.printMatrix, "ls", false, "list test matrix names")
 	flag.BoolVar(&flags.printDimensions, "dimensions", false, "list test matrix dimensions")
@@ -32,7 +18,7 @@ func TestMain(m *testing.M) {
 	runRealTests := !(flags.printMatrix || flags.printDimensions)
 
 	if flags.printDimensions {
-		Matrix().PrintDimensions()
+		matrix().PrintDimensions()
 	}
 
 	if runRealTests {

--- a/test/smoke/testmain_test.go
+++ b/test/smoke/testmain_test.go
@@ -6,42 +6,38 @@ import (
 	"flag"
 	"os"
 	"testing"
+
+	"github.com/opentable/sous/util/testmatrix"
 )
 
 // sup is the global matrix supervisor, used to collate all test results.
-var sup *Supervisor
+var sup *testmatrix.Supervisor
 
 // matrixRunner is a wrapper around Runner allowing fully baked fixtures to be
 // passed directly to tests, rather than the test having to unwrap scenarios
 // themselves.
-type matrixRunner struct{ r *Runner }
+type matrixRunner struct{ r *testmatrix.Runner }
 
 // Run is analogous to Runner.Run, but accepts a func in terms of strongly typed
 // fixture rather than having to manually unwrap scenarios.
 func (m *matrixRunner) Run(name string, test func(*testing.T, *testFixture)) {
-	m.r.Run(name, func(t *testing.T, c Context) { test(t, c.F.(*testFixture)) })
+	m.r.Run(name, func(t *testing.T, c testmatrix.Context) { test(t, c.F.(*testFixture)) })
 }
 
 // newMatrixRunner should be called once at the start of every top-level package
 // test to produce that test's matrixRunner.
-func newMatrixRunner(t *testing.T, m Matrix) matrixRunner {
+func newMatrixRunner(t *testing.T, m testmatrix.Matrix) matrixRunner {
 	return matrixRunner{r: sup.NewRunner(t, m)}
 }
 
 func TestMain(m *testing.M) {
-	flag.BoolVar(&flags.printDimensions, "dimensions", false, "list test matrix dimensions")
-	flag.BoolVar(&flags.printMatrix, "ls", false, "list test matrix names")
 	flag.Parse()
-
-	runRealTests := !(flags.printMatrix || flags.printDimensions)
-
-	if flags.printDimensions {
-		matrix().PrintDimensions()
-	}
-
-	if runRealTests {
-		sup = NewSupervisor(newTestFixture)
+	testmatrix.Quiet = quiet()
+	if sup = testmatrix.Init(matrix, newTestFixture); sup != nil {
 		resetSingularity()
+		if err := stopPIDs(); err != nil {
+			panic(err)
+		}
 	}
 	exitCode := m.Run()
 	sup.PrintSummary()

--- a/test/smoke/testmain_test.go
+++ b/test/smoke/testmain_test.go
@@ -22,7 +22,7 @@ func TestMain(m *testing.M) {
 	}
 
 	if runRealTests {
-		pfs = newParallelTestFixtureSet()
+		pfs = newParallelTestFixtureSet(newTestFixture)
 		resetSingularity()
 	}
 	exitCode := m.Run()

--- a/test/smoke/testprojects.go
+++ b/test/smoke/testprojects.go
@@ -154,8 +154,9 @@ func splitBuild(p program) filemap.FileMap {
 	}
 }
 
-func (f *testFixture) setupProject(t *testing.T, fm filemap.FileMap) *sousClient {
+func setupProject(t *testing.T, f *testFixture, fm filemap.FileMap) *sousClient {
 	t.Helper()
+
 	// Setup project git repo.
 	g := newGitClient(t, f, f.Client.BaseDir)
 

--- a/test/smoke/utils.go
+++ b/test/smoke/utils.go
@@ -29,6 +29,10 @@ func quiet() bool {
 	return os.Getenv("SMOKE_TEST_QUIET") == "YES"
 }
 
+func rtLog(format string, a ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", a...)
+}
+
 func addGitEnvVars(env map[string]string) {
 	env["GIT_CONFIG_NOSYSTEM"] = "yes"
 	env["HOME"] = "nowhere"
@@ -37,10 +41,6 @@ func addGitEnvVars(env map[string]string) {
 	env["GIT_COMMITTER_EMAIL"] = "tester@example.com"
 	env["GIT_AUTHOR_NAME"] = "Tester"
 	env["GIT_AUTHOR_EMAIL"] = "tester@example.com"
-}
-
-func rtLog(format string, a ...interface{}) {
-	fmt.Fprintf(os.Stderr, format+"\n", a...)
 }
 
 func getEnvDesc() desc.EnvDesc {

--- a/test/smoke/utils.go
+++ b/test/smoke/utils.go
@@ -279,10 +279,11 @@ var freePortsMu sync.Mutex
 var usedPorts = map[int]struct{}{}
 
 // freePortAddrs returns n listenable addresses on the ip provided in the
-// range min-max. Note that it does not guarantee they are still free by the
+// range 49152-65535. Note that it does not guarantee they are still free by the
 // time you come to bind to them, but makes that more likely by binding and then
 // unbinding from them.
-func freePortAddrs(ip string, n, min, max int) []string {
+func freePortAddrs(ip string, n int) []string {
+	min, max := 49152, 65535
 	freePortsMu.Lock()
 	defer freePortsMu.Unlock()
 	ports := make(map[int]net.Listener, n)

--- a/test/smoke/utils.go
+++ b/test/smoke/utils.go
@@ -34,13 +34,20 @@ func rtLog(format string, a ...interface{}) {
 }
 
 func addGitEnvVars(env map[string]string) {
-	env["GIT_CONFIG_NOSYSTEM"] = "yes"
-	env["HOME"] = "nowhere"
-	env["PREFIX"] = "nowhere"
+	env["GIT_CONFIG_NOSYSTEM"] = "1"
+	env["GIT_CONFIG_NOGLOBAL"] = "1"
+	env["HOME"] = "none"
+	env["XGD_CONFIG_HOME"] = "none"
+	env["PREFIX"] = "none"
 	env["GIT_COMMITTER_NAME"] = "Tester"
 	env["GIT_COMMITTER_EMAIL"] = "tester@example.com"
 	env["GIT_AUTHOR_NAME"] = "Tester"
 	env["GIT_AUTHOR_EMAIL"] = "tester@example.com"
+	env["PATH"] = os.Getenv("PATH")
+	env["DOCKER_HOST"] = os.Getenv("DOCKER_HOST")
+	env["DOCKER_MACHINE_NAME"] = os.Getenv("DOCKER_MACHINE_NAME")
+	env["DOCKER_TLS_VERIFY"] = os.Getenv("DOCKER_TLS_VERIFY")
+	env["DOCKER_CERT_PATH"] = os.Getenv("DOCKER_CERT_PATH")
 }
 
 func getEnvDesc() desc.EnvDesc {
@@ -236,7 +243,6 @@ var perCommandTimeout = 5 * time.Minute
 func mkCMD(dir, name string, args ...string) (*exec.Cmd, context.CancelFunc) {
 	ctx, cancel := context.WithTimeout(context.Background(), perCommandTimeout)
 	c := exec.CommandContext(ctx, name, args...)
-	c.Env = os.Environ()
 	c.Dir = dir
 	return c, cancel
 }

--- a/util/testmatrix/flags.go
+++ b/util/testmatrix/flags.go
@@ -14,20 +14,3 @@ func init() {
 	flag.BoolVar(&Flags.PrintDimensions, "dimensions", false, "list test matrix dimensions")
 	flag.BoolVar(&Flags.PrintMatrix, "ls", false, "list test matrix names")
 }
-
-// Init must be called from TestMain after flag.Parse, to initialise a new
-// Supervisor. If Init returns nil, then tests will not be run this time (e.g.
-// because we are just listing tests or printing the matrix def etc.)
-func Init(defaultMatrix func() Matrix, f FixtureFactory) *Supervisor {
-
-	runRealTests := !(Flags.PrintMatrix || Flags.PrintDimensions)
-
-	if Flags.PrintDimensions {
-		defaultMatrix().PrintDimensions()
-	}
-
-	if runRealTests {
-		return NewSupervisor(f)
-	}
-	return nil
-}

--- a/util/testmatrix/flags.go
+++ b/util/testmatrix/flags.go
@@ -1,0 +1,33 @@
+package testmatrix
+
+import (
+	"flag"
+)
+
+// Flags are extra go test flags you can pass to testmatrix.
+var Flags = struct {
+	PrintMatrix     bool
+	PrintDimensions bool
+}{}
+
+func init() {
+	flag.BoolVar(&Flags.PrintDimensions, "dimensions", false, "list test matrix dimensions")
+	flag.BoolVar(&Flags.PrintMatrix, "ls", false, "list test matrix names")
+}
+
+// Init must be called from TestMain after flag.Parse, to initialise a new
+// Supervisor. If Init returns nil, then tests will not be run this time (e.g.
+// because we are just listing tests or printing the matrix def etc.)
+func Init(defaultMatrix func() Matrix, f FixtureFactory) *Supervisor {
+
+	runRealTests := !(Flags.PrintMatrix || Flags.PrintDimensions)
+
+	if Flags.PrintDimensions {
+		defaultMatrix().PrintDimensions()
+	}
+
+	if runRealTests {
+		return NewSupervisor(f)
+	}
+	return nil
+}

--- a/util/testmatrix/init.go
+++ b/util/testmatrix/init.go
@@ -1,0 +1,18 @@
+package testmatrix
+
+// Init must be called from TestMain after flag.Parse, to initialise a new
+// Supervisor. If Init returns nil, then tests will not be run this time (e.g.
+// because we are just listing tests or printing the matrix def etc.)
+func Init(defaultMatrix func() Matrix, f FixtureFactory, beforeAll func() error) *Supervisor {
+	runRealTests := !(Flags.PrintMatrix || Flags.PrintDimensions)
+	if Flags.PrintDimensions {
+		defaultMatrix().PrintDimensions()
+	}
+	if runRealTests {
+		if err := beforeAll(); err != nil {
+			panic(err)
+		}
+		return NewSupervisor(f)
+	}
+	return nil
+}

--- a/util/testmatrix/matrix.go
+++ b/util/testmatrix/matrix.go
@@ -1,4 +1,4 @@
-package smoke
+package testmatrix
 
 import (
 	"fmt"

--- a/util/testmatrix/runner.go
+++ b/util/testmatrix/runner.go
@@ -58,6 +58,7 @@ func (pf *Runner) Run(name string, test Test) {
 	for _, c := range pf.matrix.scenarios() {
 		c := c
 		pf.t.Run(c.String()+"/"+name, func(t *testing.T) {
+			t.Parallel()
 			pf.parent.wg.Add(1)
 			f := pf.parent.fixtureFactory(t, c)
 			defer func() {

--- a/util/testmatrix/runner.go
+++ b/util/testmatrix/runner.go
@@ -7,73 +7,19 @@ import (
 	"testing"
 )
 
-type (
-	// Runner runs tests defined in a Matrix.
-	Runner struct {
-		t                  *testing.T
-		matrix             Matrix
-		testNames          map[string]struct{}
-		testNamesMu        sync.RWMutex
-		testNamesPassed    map[string]struct{}
-		testNamesPassedMu  sync.Mutex
-		testNamesSkipped   map[string]struct{}
-		testNamesSkippedMu sync.Mutex
-		testNamesFailed    map[string]struct{}
-		testNamesFailedMu  sync.Mutex
-		parent             *Supervisor
-	}
-
-	// Supervisor supervises a set of Runners, and collates their results.
-	// There should be exactly one global Supervisor in every package that uses
-	// testmatrix.
-	Supervisor struct {
-		mu             sync.Mutex
-		GetAddrs       func(int) []string
-		fixtures       map[string]*Runner
-		wg             sync.WaitGroup
-		fixtureFactory FixtureFactory
-	}
-)
-
-// NewSupervisor returns a new *Supervisor ready to produce test fixtures for
-// your tests using ff. NewSupervisor should be called at most once per package.
-// Calline NewSupervisor more than once will split up test summaries and lead to
-// less useful output. In future it may panic to prevent this.
-func NewSupervisor(ff FixtureFactory) *Supervisor {
-	return &Supervisor{
-		fixtureFactory: ff,
-		fixtures:       map[string]*Runner{},
-	}
-}
-
-// NewRunner returns a new *Runner ready to run tests with all possible
-// combinations of the provided Matrix. NewRunner should be called exactly once
-// in each top-level TestXXX(t *testing.T) function in your package. Calling it
-// more than once per top-level test may cause undefined behaviour and may
-// panic.
-func (pfs *Supervisor) NewRunner(t *testing.T, m Matrix) *Runner {
-	if Flags.PrintMatrix {
-		matrix := m.scenarios()
-		for _, m := range matrix {
-			fmt.Printf("%s/%s\n", t.Name(), m)
-		}
-		t.Skip("Just printing test matrix (-ls-matrix flag set)")
-	}
-	t.Helper()
-	t.Parallel()
-	pf := &Runner{
-		t:                t,
-		matrix:           m,
-		testNames:        map[string]struct{}{},
-		testNamesPassed:  map[string]struct{}{},
-		testNamesSkipped: map[string]struct{}{},
-		testNamesFailed:  map[string]struct{}{},
-		parent:           pfs,
-	}
-	pfs.mu.Lock()
-	defer pfs.mu.Unlock()
-	pfs.fixtures[t.Name()] = pf
-	return pf
+// Runner runs tests defined in a Matrix.
+type Runner struct {
+	t                  *testing.T
+	matrix             Matrix
+	testNames          map[string]struct{}
+	testNamesMu        sync.RWMutex
+	testNamesPassed    map[string]struct{}
+	testNamesPassedMu  sync.Mutex
+	testNamesSkipped   map[string]struct{}
+	testNamesSkippedMu sync.Mutex
+	testNamesFailed    map[string]struct{}
+	testNamesFailedMu  sync.Mutex
+	parent             *Supervisor
 }
 
 func (pf *Runner) recordTestStarted(t *testing.T) {
@@ -93,7 +39,7 @@ type Test func(*testing.T, Context)
 // FixtureFactory generates Fixtures from test and combination.
 type FixtureFactory func(*testing.T, Scenario) Fixture
 
-// Fixture is able to set up and tear down.
+// Fixture Teardown func is called after each test has finished.
 type Fixture interface {
 	Teardown(*testing.T)
 }
@@ -101,7 +47,7 @@ type Fixture interface {
 // Context is passed to each test case.
 type Context struct {
 	Scenario Scenario
-	// F is the fixture returned from FixtureFactory().F()
+	// F is the fixture returned from FixtureFactory.
 	F interface{}
 }
 
@@ -161,43 +107,6 @@ func (pf *Runner) recordTestStatus(t *testing.T) {
 		pf.testNamesFailedMu.Unlock()
 		return
 	}
-}
-
-// PrintSummary prints a summary of tests run by top-level test and as a sum
-// total. It reports tests failed, skipped, passed, and missing (when a test has
-// failed to report back any status, which should not happen under normal
-// circumstances.
-func (pfs *Supervisor) PrintSummary() {
-	pfs.wg.Wait()
-	pfs.mu.Lock()
-	defer pfs.mu.Unlock()
-	var total, passed, skipped, failed, missing []string
-	for _, pf := range pfs.fixtures {
-		t, p, s, f, m := pf.printSummary()
-		total = append(total, t...)
-		passed = append(passed, p...)
-		skipped = append(skipped, s...)
-		failed = append(failed, f...)
-		missing = append(missing, m...)
-	}
-
-	if len(failed) != 0 {
-		fmt.Printf("These tests failed:\n")
-		for _, n := range failed {
-			fmt.Printf("FAILED> %s\n", n)
-		}
-	}
-
-	if len(missing) != 0 {
-		fmt.Printf("These tests did not report status:\n")
-		for _, n := range missing {
-			fmt.Printf("MISSING> %s\n", n)
-		}
-	}
-
-	summary := fmt.Sprintf("Summary: %d failed; %d skipped; %d passed; %d missing (total %d)",
-		len(failed), len(skipped), len(passed), len(missing), len(total))
-	fmt.Fprintln(os.Stdout, summary)
 }
 
 func testNamesSlice(m map[string]struct{}) []string {

--- a/util/testmatrix/supervisor.go
+++ b/util/testmatrix/supervisor.go
@@ -64,7 +64,7 @@ func (pfs *Supervisor) NewRunner(t *testing.T, m Matrix) *Runner {
 // failed to report back any status, which should not happen under normal
 // circumstances.
 func (pfs *Supervisor) PrintSummary() {
-	pfs.wg.Wait()
+	//pfs.wg.Wait()
 	pfs.mu.Lock()
 	defer pfs.mu.Unlock()
 	var total, passed, skipped, failed, missing []string

--- a/util/testmatrix/supervisor.go
+++ b/util/testmatrix/supervisor.go
@@ -1,0 +1,97 @@
+package testmatrix
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+)
+
+// Supervisor supervises a set of Runners, and collates their results.
+// There should be exactly one global Supervisor in every package that uses
+// testmatrix.
+type Supervisor struct {
+	mu             sync.Mutex
+	GetAddrs       func(int) []string
+	fixtures       map[string]*Runner
+	wg             sync.WaitGroup
+	fixtureFactory FixtureFactory
+}
+
+// NewSupervisor returns a new *Supervisor ready to produce test fixtures for
+// your tests using ff. NewSupervisor should be called at most once per package.
+// Calline NewSupervisor more than once will split up test summaries and lead to
+// less useful output. In future it may panic to prevent this.
+func NewSupervisor(ff FixtureFactory) *Supervisor {
+	return &Supervisor{
+		fixtureFactory: ff,
+		fixtures:       map[string]*Runner{},
+	}
+}
+
+// NewRunner returns a new *Runner ready to run tests with all possible
+// combinations of the provided Matrix. NewRunner should be called exactly once
+// in each top-level TestXXX(t *testing.T) function in your package. Calling it
+// more than once per top-level test may cause undefined behaviour and may
+// panic.
+func (pfs *Supervisor) NewRunner(t *testing.T, m Matrix) *Runner {
+	if Flags.PrintMatrix {
+		matrix := m.scenarios()
+		for _, m := range matrix {
+			fmt.Printf("%s/%s\n", t.Name(), m)
+		}
+		t.Skip("Just printing test matrix (-ls-matrix flag set)")
+	}
+	t.Helper()
+	t.Parallel()
+	pf := &Runner{
+		t:                t,
+		matrix:           m,
+		testNames:        map[string]struct{}{},
+		testNamesPassed:  map[string]struct{}{},
+		testNamesSkipped: map[string]struct{}{},
+		testNamesFailed:  map[string]struct{}{},
+		parent:           pfs,
+	}
+	pfs.mu.Lock()
+	defer pfs.mu.Unlock()
+	pfs.fixtures[t.Name()] = pf
+	return pf
+}
+
+// PrintSummary prints a summary of tests run by top-level test and as a sum
+// total. It reports tests failed, skipped, passed, and missing (when a test has
+// failed to report back any status, which should not happen under normal
+// circumstances.
+func (pfs *Supervisor) PrintSummary() {
+	pfs.wg.Wait()
+	pfs.mu.Lock()
+	defer pfs.mu.Unlock()
+	var total, passed, skipped, failed, missing []string
+	for _, pf := range pfs.fixtures {
+		t, p, s, f, m := pf.printSummary()
+		total = append(total, t...)
+		passed = append(passed, p...)
+		skipped = append(skipped, s...)
+		failed = append(failed, f...)
+		missing = append(missing, m...)
+	}
+
+	if len(failed) != 0 {
+		fmt.Printf("These tests failed:\n")
+		for _, n := range failed {
+			fmt.Printf("FAILED> %s\n", n)
+		}
+	}
+
+	if len(missing) != 0 {
+		fmt.Printf("These tests did not report status:\n")
+		for _, n := range missing {
+			fmt.Printf("MISSING> %s\n", n)
+		}
+	}
+
+	summary := fmt.Sprintf("Summary: %d failed; %d skipped; %d passed; %d missing (total %d)",
+		len(failed), len(skipped), len(passed), len(missing), len(total))
+	fmt.Fprintln(os.Stdout, summary)
+}


### PR DESCRIPTION
Figure this type of thing may be useful outside of sous, so cleaned up the interface a little and moved matrix-specific stuff to its own package: `utils/testmatrix`. Eventually this package should be in its own repo. A few tweaks along the way e.g. less indentation required via `Run` func, test output less nested, many renames to make it more obvious what the various things actually do.