### PR TITLE
Fix race in ResolveRecorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface
 
 ## [Unreleased](//github.com.opentable/sous/compare/0.5.117...master)
+### Fixed
+* A race condition during whole-cluster resolutions meant the final status
+  was sometimes inaccurately recorded. Real world implications of this are not
+  completely clear, users are not expected to notice much difference.
 
 ## [0.5.117](//github.com.opentable/sous/compare/0.5.116...0.5.117)
 ### Changed

--- a/lib/resolvestatus.go
+++ b/lib/resolvestatus.go
@@ -127,13 +127,13 @@ func NewResolveRecorder(intended Deployments, ls logging.LogSink, f func(*Resolv
 	// Execute the main function (f) over this resolve recorder.
 	go func() {
 		f(rr)
-		close(rr.Log)
 		rr.write(func() {
+			defer close(rr.finished)
+			defer close(rr.Log)
 			rr.status.Finished = time.Now()
 			if rr.err == nil {
 				rr.status.Phase = "finished"
 			}
-			close(rr.finished)
 		})
 	}()
 	return rr


### PR DESCRIPTION
This has been sporadically failing unit tests for a few weeks, likely due to changes in logging code exacerbating an already existing race condition. The race was real, and possibly affected stability of whole-cluster rectifications, or at least made them take longer in some cases.