### PR TITLE
Release 0.5.120

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
     - TEST_COMMAND="GO_TEST_RUN=TestSmoke/git/simple make test-smoke"
     - TEST_COMMAND="GO_TEST_RUN=TestSmoke/git/split make test-smoke"
 before_deploy: git clean -fd && git reset --hard HEAD && go get github.com/karalabe/xgo
-  && make semvertagchk && bundle exec make -j2 release
+  && make semvertagchk && make tag-in-changelog-check && bundle exec make -j2 release
 deploy:
   file_glob: true
   provider: releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/)
 with respect to its command line interface and HTTP interface
 
-## [Unreleased](//github.com.opentable/sous/compare/0.5.117...master)
+## [Unreleased](//github.com/opentable/sous/compare/0.5.120...master)
+
+## [0.5.120](//github.com/opentable/sous/compare/0.5.117...0.5.120)
 ### Fixed
 * Deployments to PROD clusters will use Jenkins agents with 'mesos-prod-sc'
   label (jenkins agents in PROD) to avoid QA -> PROD type of deployments.
@@ -31,7 +33,9 @@ with respect to its command line interface and HTTP interface
   that there be a singularity-request.json file (where before it was optional).
   There is also a bunch more validation, too much to list here.
 
-## [0.5.117](//github.com.opentable/sous/compare/0.5.116...0.5.117)
+NOTE: Some features listed above as 0.5.120 were also released as 0.5.118 and 0.5.119.
+
+## [0.5.117](//github.com/opentable/sous/compare/0.5.116...0.5.117)
 ### Changed
 * Tests: Travis build times reduced by running sets of tests in parallel.
   This allows us to produce relese binaries, see note below in 0.5.116.

--- a/Makefile
+++ b/Makefile
@@ -304,10 +304,15 @@ linux-build: artifacts/$(LINUX_RELEASE_DIR)/sous
 
 semvertagchk:
 	@echo "$(SOUS_VERSION)" | egrep ^[0-9]+\.[0-9]+\.[0-9]+
+ 
+tag-in-changelog-check:
+	@grep -F "$(SOUS_VERSION)" CHANGELOG.md || { echo "Please update CHANGELOG.md to include $(SOUS_VERSION)"; exit 1; }; echo "Changelog OK"
+
+show-sous-version:
+	@echo $(SOUS_VERSION)
 
 sous-qa-setup: ./dev_support/sous_qa_setup/*.go ./util/test_with_docker/*.go
 	go build $(EXTRA_GO_FLAGS) ./dev_support/sous_qa_setup
-
 
 reject-wip:
 	test ! -f workinprogress
@@ -521,4 +526,4 @@ provision-docker-machine:
 	semvertagchk test test-gofmt test-integration setup-containers test-unit \
 	reject-wip wip staticcheck postgres-start postgres-stop postgres-connect \
 	postgres-clean postgres-create-testdb build-debug homebrew install-gotags \
-	install-debug-linux install-debug-darwin
+	install-debug-linux install-debug-darwin show-sous-version tag-in-changelog-check


### PR DESCRIPTION
We somehow skipped changelog update for 0.5.118 and 0.5.119; this PR also adds a late check that the changelog at least contains the tagged version somewhere prior to release. It's a weak check and happens late in the process. If it fails, we'll need to add a new semver tag and update the changelog to use that. Unfortunately there is nowhere earlier in the process we can detect this reliably since adding a semver tag is enough to trigger a binary release (first I considered using Danger, but that only applies to PRs not tags). Once an annotated tag is pushed it should not be changed, although I am not hardline on that in the case of failed builds, if it is changed quickly (since this is not a library we would be unlikely to break dependencies). Once any binary exists for a version in github releases, the tag should definitely not be modified under any circumstances.

In future it might be helpful to open PRs like this that update the changelog prior to tagging releases.

NOTE: This PR can be safely merged, but the merge commit should be tagged 0.5.120, which will trigger binary builds. ~That tagging is not safe to do yet, as changes here will have an impact on users so we need to communicate that first.~ EDIT: That's not true, this should be safe to tag, I was thinking #800 had been merged but not yet...