### PR TITLE
Logging tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ with respect to its command line interface and HTTP interface
 ### Fixed
 
 ### Changed
+- Logging: SQL log messages now include "read" or "write" in their message text.
+- Logging: messages from deployment mapping now only show up in extreme logging level (not debug).
+- Logging: messages from GDM handler now much smaller unless extreme level logging on.
+- Debug log level is now much less noisy.
 
 ### Added
 

--- a/ext/storage/postgresstatemanager_test.go
+++ b/ext/storage/postgresstatemanager_test.go
@@ -109,7 +109,7 @@ func TestPostgresStateManagerWriteState_success(t *testing.T) {
 		map[string]interface{}{
 			"@loglov3-otl":       logging.SousSql,
 			"severity":           logging.InformationLevel,
-			"call-stack-message": "SQL query",
+			"call-stack-message": "SQL query: read",
 		})
 
 	suite.require.NoError(suite.manager.WriteState(s, testUser))

--- a/lib/map_state_to_deployments.go
+++ b/lib/map_state_to_deployments.go
@@ -80,16 +80,16 @@ func (ds Deployments) PutbackManifests(defs Defs, olds Manifests, log logging.Lo
 				continue
 			}
 			if string(clusterVal) == v {
-				messages.ReportLogFieldsMessage("Redundant environment definition", logging.DebugLevel, log, k, v)
+				messages.ReportLogFieldsMessage("Redundant environment definition", logging.ExtremeLevel, log, k, v)
 				if was && hadSpec {
 					if _, present := oldSpec.Env[k]; present {
-						messages.ReportLogFieldsMessage("Env pair present in existing manifest: retained", logging.DebugLevel, log, k, v)
+						messages.ReportLogFieldsMessage("Env pair present in existing manifest: retained", logging.ExtremeLevel, log, k, v)
 					} else {
-						messages.ReportLogFieldsMessage("Env pair absent in existing manifest: deleted", logging.DebugLevel, log, k, v)
+						messages.ReportLogFieldsMessage("Env pair absent in existing manifest: deleted", logging.ExtremeLevel, log, k, v)
 						delete(spec.Env, k)
 					}
 				} else {
-					messages.ReportLogFieldsMessage("Manifest or cluster absent in existing manifest list: deleted", logging.DebugLevel, log, mid, d.ClusterName, k, v)
+					messages.ReportLogFieldsMessage("Manifest or cluster absent in existing manifest list: deleted", logging.ExtremeLevel, log, mid, d.ClusterName, k, v)
 					delete(spec.Env, k)
 				}
 			}
@@ -146,7 +146,7 @@ func (ds Deployments) RawManifests(defs Defs, log logging.LogSink) (Manifests, e
 				continue
 			}
 			if string(clusterVal) == v {
-				messages.ReportLogFieldsMessage("Redundant environment definition", logging.DebugLevel, log, k, v)
+				messages.ReportLogFieldsMessage("Redundant environment definition", logging.ExtremeLevel, log, k, v)
 			}
 		}
 		m.Deployments[d.ClusterName] = spec

--- a/server/handle_gdm.go
+++ b/server/handle_gdm.go
@@ -50,7 +50,8 @@ func (gr *GDMResource) Get(_ *restful.RouteMap, ls logging.LogSink, writer http.
 
 // Exchange implements the Handler interface
 func (h *GETGDMHandler) Exchange() (interface{}, int) {
-	reportDebugHandleGDMMessage(fmt.Sprintf("Get GDM Handler Exchange with GDM: %v", h.GDM), nil, nil, h.LogSink)
+	reportHandleGDMMessage(fmt.Sprintf("GETGDMHandler.Exchange called with GDM: %v", h.GDM), nil, nil, h.LogSink, logging.ExtremeLevel)
+	reportHandleGDMMessage("GetGDMHandler.Exchange called", nil, nil, h.LogSink, logging.DebugLevel)
 
 	data := dto.GDMWrapper{Deployments: make([]*sous.Deployment, 0)}
 	deps, err := h.GDM.Deployments()

--- a/util/sqlgen/messages.go
+++ b/util/sqlgen/messages.go
@@ -98,7 +98,7 @@ func (msg *sqlMessage) DefaultLevel() logging.Level {
 // Message implements LogMessage on sqlMessage
 func (msg *sqlMessage) Message() string {
 	if msg.err == nil {
-		return "SQL query"
+		return "SQL query: " + msg.dir.String()
 	}
 	return msg.err.Error()
 }

--- a/util/sqlgen/messages_test.go
+++ b/util/sqlgen/messages_test.go
@@ -39,7 +39,7 @@ func TestSQLMessageWrite(t *testing.T) {
 
 	logging.AssertMessageFieldlist(t, message, append(logging.StandardVariableFields, logging.IntervalVariableFields...), map[string]interface{}{
 		"@loglov3-otl":        logging.SousSql,
-		"call-stack-message":  "SQL query",
+		"call-stack-message":  "SQL query: write",
 		"severity":            logging.InformationLevel,
 		"call-stack-function": "github.com/opentable/sous/util/sqlgen.TestSQLMessageWrite",
 		"sous-sql-query":      "insert into test-table (x,y,z) = (1,2,3)",
@@ -60,7 +60,7 @@ func TestSQLMessageRead(t *testing.T) {
 
 	logging.AssertMessageFieldlist(t, message, append(logging.StandardVariableFields, logging.IntervalVariableFields...), map[string]interface{}{
 		"@loglov3-otl":        logging.SousSql,
-		"call-stack-message":  "SQL query",
+		"call-stack-message":  "SQL query: read",
 		"severity":            logging.InformationLevel,
 		"call-stack-function": "github.com/opentable/sous/util/sqlgen.TestSQLMessageRead",
 		"sous-sql-query":      "select * from test-table",


### PR DESCRIPTION
- Debug level logs significantly less noisy (around 50% of log volume moved to extreme level).
- SQL logs now include 'read' and 'write' in message e.g. `SQL query: read` for easier filtering.
- See CHANGELOG diff for more detail.