### PR TITLE
test/smoke: don't wait before starting healthchecks #trivial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,9 @@ stop-qa-env: ## Stops and removes all docker-compose containers.
 .PHONY: start-qa-env
 start-qa-env: setup-containers
 
+.PHONY: watch-containers
+watch-containers:
+	cd integration/test-registry && docker-compose down && docker-compose up -d && watch docker-compose ps
 
 gitlog:
 	git log `git describe --abbrev=0`..HEAD

--- a/lib/state_fixture.go
+++ b/lib/state_fixture.go
@@ -19,6 +19,7 @@ type StateFixtureOpts struct {
 	ClusterSuffix string
 
 	ManifestIDOpts *ManifestIDOpts
+	ClusterFunc    func() *Cluster
 }
 
 // DefaultStateFixture provides a dummy state for tests by calling
@@ -193,9 +194,12 @@ func GenerateManifests(count int, gen func(idx int) *Manifest) Manifests {
 func StateFixture(o StateFixtureOpts) *State {
 
 	s := NewState()
+	if o.ClusterFunc == nil {
+		o.ClusterFunc = DefaultCluster
+	}
 
 	c := GenerateClusters(o.ClusterCount, func(idx int) *Cluster {
-		c := DefaultCluster()
+		c := o.ClusterFunc()
 		c.Name = fmt.Sprintf("cluster%d%s", idx+1, o.ClusterSuffix)
 		c.Env["CLUSTER_NAME"] = Var(c.Name)
 		return c

--- a/test/smoke/fixture.go
+++ b/test/smoke/fixture.go
@@ -63,6 +63,13 @@ func newFixtureConfig(testName string, s scenario) fixtureConfig {
 		ClusterCount:  3,
 		ManifestCount: 3,
 		ClusterSuffix: clusterSuffix,
+		ClusterFunc: func() *sous.Cluster {
+			c := sous.DefaultCluster()
+			c.Startup.ConnectDelay = 1
+			c.Startup.ConnectInterval = 1
+			c.Startup.Timeout = 10
+			return c
+		},
 	})
 	addURLsToState(state, envDesc)
 	return fixtureConfig{


### PR DESCRIPTION
- We were needlessly telling Singularity to wait 30s
  before hitting health endpoints.
- Also overall startup timeout down to 10s since it's all
  tiny, local images that start immediately.