### PR TITLE
Fix server crash detection in smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ var/
 .cleanprotect
 *.test
 .smoketest/
+.procman-pids
 
 
 ## Github/Gitignore: JetBrains

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
   matrix:
     - TEST_COMMAND="bundle && bundle exec danger"
     - TEST_COMMAND="make test-integration"
-    - TEST_COMMAND="make test-unit"
+    - TEST_COMMAND="make compile-tests && make test-unit"
     - TEST_COMMAND="GO_TEST_RUN=TestOTPL/db/simple make test-smoke"
     - TEST_COMMAND="GO_TEST_RUN=TestOTPL/git/simple make test-smoke" 
     - TEST_COMMAND="GO_TEST_RUN=TestSmoke/db/simple make test-smoke"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ with respect to its command line interface and HTTP interface
 ### Fixed
 
 ### Changed
+- Server: now gracefully drains connections on SIGTERM or SIGINT and writes an exit log.
 - Logging: SQL log messages now include "read" or "write" in their message text.
 - Logging: messages from deployment mapping now only show up in extreme logging level (not debug).
 - Logging: messages from GDM handler now much smaller unless extreme level logging on.

--- a/graph/actions.go
+++ b/graph/actions.go
@@ -338,7 +338,7 @@ func (di *SousGraph) GetServer(
 	gdmRepo string,
 	profiling bool,
 	enableAutoResolver bool,
-) (actions.Action, error) {
+) (*actions.Server, error) {
 	dff.Offset = "*"
 	dff.Flavor = "*"
 	profiling = profiling || os.Getenv("SOUS_PROFILING") == "enable"

--- a/graph/actions_test.go
+++ b/graph/actions_test.go
@@ -75,6 +75,53 @@ func TestActionPlumbingNormilizeGDM(t *testing.T) {
 
 }
 
+func TestGetManifestGet(t *testing.T) {
+	fg := fixtureGraph(t)
+	_, err := fg.GetManifestGet(config.DeployFilterFlags{}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetManifestSet(t *testing.T) {
+	fg := fixtureGraph(t)
+	_, err := fg.GetManifestSet(config.DeployFilterFlags{}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetGetArtifact(t *testing.T) {
+	fg := fixtureGraph(t)
+	_, err := fg.GetGetArtifact(ArtifactOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetBuild(t *testing.T) {
+	fg := fixtureGraph(t)
+	fg.Add(&config.DeployFilterFlags{}, &config.PolicyFlags{})
+	_, err := fg.GetBuild(BuildActionOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetServer(t *testing.T) {
+	fg := fixtureGraph(t)
+	dff := config.DeployFilterFlags{}
+	dryrun := ""
+	laddr := "127.0.0.1:12345"
+	gdmRepo := "somerepo"
+	profiling := false
+	enableAutoResolver := true
+	_, err := fg.GetServer(dff, dryrun, laddr, gdmRepo, profiling, enableAutoResolver)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestGetUpdate(t *testing.T) {
 	fg := fixtureGraph(t)
 	flags := fixtureDeployFilterFlags()

--- a/server/handle_state_defs.go
+++ b/server/handle_state_defs.go
@@ -54,6 +54,10 @@ func (sdr *StateDefResource) Put(_ *restful.RouteMap, _ logging.LogSink, _ http.
 
 // Exchange implements restful.Exchanger on StateDefGetHandler.
 func (sdg *StateDefGetHandler) Exchange() (interface{}, int) {
+	if sdg.State == nil {
+		// State can be nil in the case of  errors reading it.
+		return "Unable to read state, please see logs.", 500
+	}
 	return sdg.State.Defs, 200
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -44,6 +44,7 @@ func (ctx ComponentLocator) liveState() *sous.State {
 		return sous.NewState()
 	}
 	if err != nil {
+		messages.ReportLogFieldsMessage("error reading state: %s", logging.WarningLevel, ctx.LogSink, err)
 		return nil
 	}
 	return state

--- a/test/smoke/bin.go
+++ b/test/smoke/bin.go
@@ -40,8 +40,8 @@ type Bin struct {
 	Env map[string]string
 	// MassageArgs is called on the total set of args passed to the command,
 	// prior to execution; the args it returns are what is finally used.
-	MassageArgs  func([]string) []string
-	TestFinished <-chan struct{}
+	MassageArgs func([]string) []string
+	Finished    finishedChans
 
 	// ShouldStillBeRunningAfterTest should is set to true for servers etc, it
 	// enables crash detection.
@@ -50,7 +50,7 @@ type Bin struct {
 
 // NewBin returns a new minimal Bin, all files will be created in subdirectories
 // of baseDir.
-func NewBin(t *testing.T, path, name, baseDir, rootDir string, finished <-chan struct{}) Bin {
+func NewBin(t *testing.T, path, name, baseDir, rootDir string, finished finishedChans) Bin {
 	illegalChars := ":/>"
 	if strings.ContainsAny(name, illegalChars) {
 		log.Panicf("name %q contains at least one illegal character from %q", name, illegalChars)
@@ -66,7 +66,7 @@ func NewBin(t *testing.T, path, name, baseDir, rootDir string, finished <-chan s
 		InstanceName: name,
 		RootDir:      rootDir,
 		Env:          map[string]string{},
-		TestFinished: finished,
+		Finished:     finished,
 	}
 }
 

--- a/test/smoke/bin.go
+++ b/test/smoke/bin.go
@@ -41,7 +41,7 @@ type Bin struct {
 	// MassageArgs is called on the total set of args passed to the command,
 	// prior to execution; the args it returns are what is finally used.
 	MassageArgs func([]string) []string
-	Finished    finishedChans
+	Finished    *finishedChans
 
 	// ShouldStillBeRunningAfterTest should is set to true for servers etc, it
 	// enables crash detection.
@@ -50,7 +50,7 @@ type Bin struct {
 
 // NewBin returns a new minimal Bin, all files will be created in subdirectories
 // of baseDir.
-func NewBin(t *testing.T, path, name, baseDir, rootDir string, finished finishedChans) Bin {
+func NewBin(t *testing.T, path, name, baseDir, rootDir string, finished *finishedChans) Bin {
 	illegalChars := ":/>"
 	if strings.ContainsAny(name, illegalChars) {
 		log.Panicf("name %q contains at least one illegal character from %q", name, illegalChars)

--- a/test/smoke/bunchofsousservers.go
+++ b/test/smoke/bunchofsousservers.go
@@ -126,7 +126,7 @@ func (c *bunchOfSousServers) configure(t *testing.T, f fixtureConfig) error {
 		}
 		config.Logging.Basic.Level = "debug"
 		if err := i.configure(t, f, config, c.RemoteGDMDir); err != nil {
-           return errors.Wrapf(err, "configuring instance %d", i.Num)
+			return errors.Wrapf(err, "configuring instance %d", i.Num)
 		}
 	}
 	return nil

--- a/test/smoke/bunchofsousservers.go
+++ b/test/smoke/bunchofsousservers.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/opentable/sous/config"
 	"github.com/opentable/sous/ext/docker"
@@ -162,4 +163,5 @@ func (c *bunchOfSousServers) Start(t *testing.T) {
 		// Note: the value of started is only used in the closure above.
 		started = append(started, i)
 	}
+	time.Sleep(5 * time.Second)
 }

--- a/test/smoke/fixture.go
+++ b/test/smoke/fixture.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/opentable/sous/dev_support/sous_qa_setup/desc"
 	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/testagents"
 	"github.com/opentable/sous/util/testmatrix"
 	"github.com/samsalisbury/semv"
 )
@@ -111,9 +112,9 @@ func (f *fixtureBase) newEmptyDir(path string) string {
 	return path
 }
 
-func (f *fixtureBase) newBin(t *testing.T, path, instanceName string) Bin {
+func (f *fixtureBase) newBin(t *testing.T, path, instanceName string) testagents.Bin {
 	binBaseDir := f.absPath(filepath.Join("actors", instanceName))
-	return NewBin(t, path, instanceName, binBaseDir, f.BaseDir, f.Finished)
+	return testagents.NewBin(t, procMan, path, instanceName, binBaseDir, f.BaseDir, f.Finished.Finished)
 }
 
 func newConfiguredFixture(t *testing.T, s scenario, mod ...func(*fixtureConfig)) *fixture {

--- a/test/smoke/fixture.go
+++ b/test/smoke/fixture.go
@@ -158,7 +158,7 @@ func fixtureFactory(t *testing.T, s testmatrix.Scenario) testmatrix.Fixture {
 }
 
 func (f *fixture) debug(format string, a ...interface{}) {
-	rtLog("[DEBUG:FIXTURE:"+f.TestName+"]"+format, a...)
+	rtLog("[DEBUG:FIXTURE:"+f.TestName+"] "+format, a...)
 }
 
 // Teardown performs conditional cleanup of resources used in the test.

--- a/test/smoke/gitclient.go
+++ b/test/smoke/gitclient.go
@@ -2,10 +2,12 @@ package smoke
 
 import (
 	"testing"
+
+	"github.com/opentable/sous/util/testagents"
 )
 
 type gitClient struct {
-	Bin
+	testagents.Bin
 }
 
 func newGitClient(t *testing.T, f fixtureConfig, name string) *gitClient {

--- a/test/smoke/procman.go
+++ b/test/smoke/procman.go
@@ -1,0 +1,5 @@
+package smoke
+
+import "github.com/opentable/sous/util/testagents"
+
+var procMan = testagents.DefaultProcMan()

--- a/test/smoke/service.go
+++ b/test/smoke/service.go
@@ -148,10 +148,11 @@ func (s *Service) waitChan() <-chan waitResult {
 		go func() {
 			var wr waitResult
 			wr.err = s.Cmd.Wait()
-			if wr.err != nil {
+			exitCode, err := wr.exitCode()
+			if err != nil {
 				rtLog("[ERROR:%s] Ignoring wait error: %s", s.ID(), wr.err)
 			} else if !s.Cmd.ProcessState.Exited() {
-				log.Panicf("[PANIC:%s] process not exited after wait", s.ID())
+				log.Panicf("[PANIC:%s] process not exited after wait, but reports exit code %d", s.ID(), exitCode)
 			}
 			s.waitResult = wr
 			close(s.doneWaiting)

--- a/test/smoke/service.go
+++ b/test/smoke/service.go
@@ -148,7 +148,9 @@ func (s *Service) waitChan() <-chan waitResult {
 		go func() {
 			var wr waitResult
 			wr.err = s.Cmd.Wait()
-			if !s.Cmd.ProcessState.Exited() {
+			if wr.err != nil {
+				rtLog("[ERROR:%s] Ignoring wait error: %s", s.ID(), wr.err)
+			} else if !s.Cmd.ProcessState.Exited() {
 				log.Panicf("[PANIC:%s] process not exited after wait", s.ID())
 			}
 			s.waitResult = wr

--- a/test/smoke/service.go
+++ b/test/smoke/service.go
@@ -71,9 +71,10 @@ func (s *Service) wait(t *testing.T, count int, looping bool) bool {
 		s.debug("got wait result %s", wr)
 		exitCode, err := wr.exitCode()
 		if err != nil {
-			log.Panicf("[PANIC:%s]: unable to determine exit code: %s", s.ID(), err)
+			rtLog("[ERROR:%s]: unable to determine exit code: %s", s.ID(), err)
+		} else {
+			s.debug("exited with code %d; error: %v; logs follow:", exitCode, err)
 		}
-		s.debug("exited with code %d; error: %v; logs follow:", exitCode, err)
 		s.DumpTail(t, 3)
 		s.debug("end logs")
 		safeClose(s.Stopped)

--- a/test/smoke/service.go
+++ b/test/smoke/service.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 // Service represents a binary that is intended to be run as a long-running
@@ -17,6 +18,7 @@ type Service struct {
 	Bin
 	Proc            *os.Process
 	ReadyForCleanup chan struct{}
+	Stopped         chan struct{}
 }
 
 // NewService returns a new service bound to the provided binary.
@@ -25,6 +27,7 @@ func NewService(bin Bin) *Service {
 	return &Service{
 		Bin:             bin,
 		ReadyForCleanup: make(chan struct{}),
+		Stopped:         make(chan struct{}),
 	}
 }
 
@@ -50,23 +53,58 @@ func (s *Service) Start(t *testing.T, subcmd string, flags Flags, args ...string
 	writePID(t, s.Proc.Pid)
 
 	go func() {
-		s.detectPrematureExit(t, cmd)
+		if s.exitedEarly(t, cmd, 10, false) {
+			rtLog("NOT STOPPING CRASHED PROC: %s (pid %d)", s.ID(), s.Proc.Pid)
+			return
+		}
 		close(s.ReadyForCleanup)
 	}()
 }
 
-func (s *Service) detectPrematureExit(t *testing.T, cmd *exec.Cmd) {
+func debugLog(f string, a ...interface{}) {
+	rtLog("[DEBUG] "+f, a...)
+}
+
+func (s *Service) exitedEarly(t *testing.T, cmd *exec.Cmd, count int, looping bool) bool {
 	id := s.ID()
+	if looping {
+		select {
+		default:
+		case <-s.Finished.Finished:
+			// OK, test finished before this process exited.
+			debugLog("TEST FINISHED (EARLY CHECK) FOR PID %d", s.Proc.Pid)
+			// return false
+		}
+	}
+
 	select {
 	// In this case the process ended before the test finished.
 	case wr := <-s.waitChan(cmd):
-		rtLog("SERVER CRASHED (pid %d): exit code %d: %s; logs follow:", s.Proc.Pid,
-			wr.exitCode(), id)
+		if wr.exitCode() < 1 && count > 0 {
+			debugLog("FISHY EXIT CODE %d from pid %d; trying again %d time(s); %s", wr.exitCode(), wr.ps.Pid(), count-1, s.ID())
+			time.Sleep(time.Second)
+			return s.exitedEarly(t, cmd, count-1, true)
+		}
+		debugLog("SERVER CRASHED (pid %d): exit code %d: %s; logs follow:", s.Proc.Pid, wr.exitCode(), id)
 		s.DumpTail(t, 3)
-		rtLog("END SERVER CRASH LOG (pid %d)", s.Proc.Pid)
+		debugLog("END SERVER CRASH LOG (pid %d)", s.Proc.Pid)
+		safeClose(s.Stopped)
+		return true
 	// In this case the process is still running.
-	case <-s.TestFinished:
+	case <-s.Finished.Failed:
 		// OK, test finished before this process exited.
+		debugLog("TEST FINISHED [FAILED] (LATE CHECK) FOR PID %d", s.Proc.Pid)
+		if looping && count > 0 {
+			return s.exitedEarly(t, cmd, count-1, true)
+		}
+		return false
+	case <-s.Finished.Passed:
+		// OK, test finished before this process exited.
+		debugLog("TEST FINISHED [PASSED] (LATE CHECK) FOR PID %d", s.Proc.Pid)
+		if looping && count > 0 {
+			return s.exitedEarly(t, cmd, count-1, true)
+		}
+		return false
 	}
 }
 
@@ -75,8 +113,31 @@ type waitResult struct {
 	ps  *os.ProcessState
 }
 
+func fmtWaitStatus(ws syscall.WaitStatus) string {
+	return fmt.Sprintf("exited: %t; signal: %s; stopped: %t; coredump: %t; signalled: %t; continued: %t; trapCause: %d; exitstatus: %d; stopsignal: %s",
+		ws.Exited(),
+		ws.Signal(),
+		ws.Stopped(),
+		ws.CoreDump(),
+		ws.Signaled(),
+		ws.Continued(),
+		ws.TrapCause(),
+		ws.ExitStatus(),
+		ws.StopSignal(),
+	)
+}
+
+func (wr *waitResult) String() string {
+	return fmt.Sprintf("error: %v; WaitStatus: %s", wr.err, fmtWaitStatus(wr.ps.Sys().(syscall.WaitStatus)))
+}
+
 func (wr *waitResult) exitCode() int {
 	err, ps := wr.err, wr.ps
+	if !ps.Exited() {
+		debugLog("[ERR] not exited: pid: %d; waitResult: %s", ps.Pid(), wr)
+		return -2
+	}
+	debugLog("[OK] exited: pid: %d; waitResult: %s", ps.Pid(), wr)
 	if err != nil {
 		if exitCode := tryGetExitCode("Wait error", err); exitCode != -1 {
 			return exitCode
@@ -93,12 +154,13 @@ func (wr *waitResult) isCrash() bool {
 	return err != nil || (ps.Exited() && !ps.Success())
 }
 
-// WaitChan returns a channel that sends the error from os.Process.Waiting on
+// WaitChan returns a channel that sends the error from os.Process.Wait on
 // this command.
 func (s *Service) waitChan(cmd *exec.Cmd) <-chan waitResult {
-	var wr waitResult
 	c := make(chan waitResult, 1)
 	go func() {
+		defer close(c)
+		var wr waitResult
 		wr.ps, wr.err = cmd.Process.Wait()
 		c <- wr
 	}()
@@ -111,15 +173,50 @@ func tryGetExitCode(fromDesc string, from interface{}) int {
 		return ws.ExitStatus()
 	}
 	rtLog("UNABLE TO GET EXIT CODE: %s was a %T", fromDesc, from)
-	return -1
+	return -3
+}
+
+func safeClose(c chan struct{}) {
+	select {
+	default:
+		close(c)
+	case <-c:
+		// Already closed.
+	}
+}
+
+func closed(c chan struct{}) bool {
+	select {
+	default:
+		return false
+	case <-c:
+		return true
+	}
 }
 
 // Stop stops this service.
 func (s *Service) Stop() error {
+	if closed(s.Stopped) {
+		debugLog("[WAR] not stopping as already stopped")
+		return nil
+	}
+	defer safeClose(s.Stopped)
 	<-s.ReadyForCleanup
 	if s.Proc == nil {
 		return fmt.Errorf("cannot stop %s (not started)", s.InstanceName)
 	}
+	debugLog("Sending SIGTERM to pid %d", s.Proc.Pid)
+	if err := s.Proc.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("sending SIGTERM: %s", err)
+	}
+	ps, err := s.Proc.Wait()
+	if err != nil {
+		return fmt.Errorf("wait failed: %s", err)
+	}
+	if !ps.Exited() {
+		return fmt.Errorf("not stopped after wait")
+	}
+
 	if err := s.Proc.Kill(); err != nil {
 		return fmt.Errorf("cannot kill %s: %s", s.InstanceName, err)
 	}

--- a/test/smoke/sousserver.go
+++ b/test/smoke/sousserver.go
@@ -12,12 +12,13 @@ import (
 	sous "github.com/opentable/sous/lib"
 	"github.com/opentable/sous/util/filemap"
 	"github.com/opentable/sous/util/logging"
+	"github.com/opentable/sous/util/testagents"
 	"github.com/opentable/sous/util/yaml"
 	"github.com/pkg/errors"
 )
 
 type sousServer struct {
-	*Service
+	*testagents.Service
 	Addr                string
 	StateDir, ConfigDir string
 	ClusterName         string
@@ -40,7 +41,7 @@ func makeInstance(t *testing.T, f fixtureConfig, binPath string, i int, clusterN
 	bin.Env["SOUS_BUILD_NOPULL"] = "YES"
 	addGitEnvVars(bin.Env)
 
-	service := NewService(bin)
+	service := testagents.NewService(bin)
 
 	stateDir := path.Join(bin.BaseDir, "state")
 
@@ -105,5 +106,3 @@ func (i *sousServer) Start(t *testing.T) {
 	i.Service.Start(t, "server", nil, "-listen", i.Addr, "-cluster", i.ClusterName, "-autoresolver=false", fmt.Sprintf("-d=%t", serverDebug))
 
 }
-
-const pidFile = "test-server-pids"

--- a/test/smoke/testmain_test.go
+++ b/test/smoke/testmain_test.go
@@ -20,7 +20,7 @@ func TestMain(m *testing.M) {
 	sup = testmatrix.Init(matrix, fixtureFactory, func() error {
 		return firsterr.Parallel().Set(
 			func(e *error) { *e = resetSingularity() },
-			func(e *error) { *e = stopPIDs() },
+			func(e *error) { *e = procMan.StopPIDs() },
 			func(e *error) { *e = nukeDockerRegistry() },
 		)
 	})

--- a/test/smoke/utils.go
+++ b/test/smoke/utils.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/opentable/sous/dev_support/sous_qa_setup/desc"
 	sous "github.com/opentable/sous/lib"
-	"github.com/opentable/sous/util/prefixpipe"
 )
 
 // timeGoTestInvoked is used to group test data for tests run
@@ -248,21 +247,4 @@ func oneFreePort(ip string, start, min, max int) (int, string, net.Listener, err
 		return port, addr, listener, nil
 	}
 	return 0, "", nil, fmt.Errorf("unable to find a free port in range %d-%d", min, max)
-}
-
-func prefixWithTestName(t *testing.T, label string) (prefixedOut, prefixedErr io.Writer) {
-	t.Helper()
-
-	outPrefix := fmt.Sprintf("%s:%s:stdout> ", t.Name(), label)
-	errPrefix := fmt.Sprintf("%s:%s:stderr> ", t.Name(), label)
-
-	stdout, err := prefixpipe.New(outPrefix)
-	if err != nil {
-		t.Fatalf("Setting up output prefix: %s", err)
-	}
-	stderr, err := prefixpipe.New(errPrefix)
-	if err != nil {
-		t.Fatalf("Setting up output prefix: %s", err)
-	}
-	return stdout, stderr
 }

--- a/test/smoke/utils.go
+++ b/test/smoke/utils.go
@@ -1,12 +1,10 @@
 package smoke
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -19,11 +17,14 @@ import (
 
 	"github.com/opentable/sous/dev_support/sous_qa_setup/desc"
 	sous "github.com/opentable/sous/lib"
+	"github.com/opentable/sous/util/prefixpipe"
 )
 
 // timeGoTestInvoked is used to group test data for tests run
 // via the same go test invocation.
 var timeGoTestInvoked = time.Now().Format(time.RFC3339)
+
+var perCommandTimeout = 5 * time.Minute
 
 func quiet() bool {
 	return os.Getenv("SMOKE_TEST_QUIET") == "YES"
@@ -100,73 +101,6 @@ func makeEmptyDirAbs(dir string) {
 	}
 }
 
-// makeFile attempts to write bytes to baseDir/fileName and returns the full
-// path to the file. It assumes the directory baseDir already exists and
-// contains no file named fileName, and will fail otherwise.
-func makeFile(baseDir, fileName string, bytes []byte) string {
-	filePath := path.Join(baseDir, fileName)
-	if _, err := os.Open(filePath); err != nil {
-		if !isNotExist(err) {
-			panic(fmt.Errorf("unable to check if file %q exists: %s", filePath, err))
-		}
-	} else {
-		panic(fmt.Errorf("file %q already exists", filePath))
-	}
-
-	if err := ioutil.WriteFile(filePath, bytes, 0777); err != nil {
-		panic(fmt.Errorf("unable to write file %q: %s", filePath, err))
-	}
-	return filePath
-}
-
-func mustOpenFileAppendOnly(baseDir, fileName string) *os.File {
-	filePath := path.Join(baseDir, fileName)
-	assertDirNotExists(filePath)
-	if !fileExists(filePath) {
-		makeFile(baseDir, fileName, nil)
-	}
-	file, err := os.OpenFile(filePath,
-		os.O_APPEND|os.O_WRONLY|os.O_SYNC, 0x777)
-	if err != nil {
-		panic(fmt.Errorf("opening file for append: %s", err))
-	}
-	return file
-}
-
-// makeFileString is a convenience wrapper around makeFile, using string s
-// as the bytes to be written.
-func makeFileString(baseDir, fileName string, s string) string {
-	return makeFile(baseDir, fileName, []byte(s))
-}
-
-func fileExists(filePath string) bool {
-	s, err := os.Stat(filePath)
-	if err == nil {
-		return s.Mode().IsRegular()
-	}
-	if isNotExist(err) {
-		return false
-	}
-	panic(fmt.Errorf("checking if file exists: %s", err))
-}
-
-func assertDirNotExists(filePath string) {
-	if dirExists(filePath) {
-		panic(fmt.Errorf("%s exists and is a directory", filePath))
-	}
-}
-
-func dirExists(filePath string) bool {
-	s, err := os.Stat(filePath)
-	if err == nil {
-		return s.IsDir()
-	}
-	if isNotExist(err) {
-		return false
-	}
-	panic(fmt.Errorf("checking if dir exists: %s", err))
-}
-
 func dirExistsAndIsNotEmpty(dir string) bool {
 	f, err := os.Open(dir)
 	if err != nil {
@@ -239,8 +173,6 @@ func doCMD(dir, name string, args ...string) error {
 	return err
 }
 
-var perCommandTimeout = 5 * time.Minute
-
 func mkCMD(dir, name string, args ...string) (*exec.Cmd, context.CancelFunc) {
 	ctx, cancel := context.WithTimeout(context.Background(), perCommandTimeout)
 	c := exec.CommandContext(ctx, name, args...)
@@ -248,28 +180,12 @@ func mkCMD(dir, name string, args ...string) (*exec.Cmd, context.CancelFunc) {
 	return c, cancel
 }
 
-// testing os.ErrNotExist seems to not work in the majority of cases,
-// at least on Darwin.
-// TODO SS: Find out why...
 func isNotExist(err error) bool {
 	if err == nil {
 		panic("cannot check nil error")
 	}
 	return err == os.ErrNotExist ||
 		strings.Contains(err.Error(), "no such file or directory")
-}
-
-func closeFiles(fs ...*os.File) error {
-	var failures []string
-	for _, f := range fs {
-		if err := f.Close(); err != nil {
-			failures = append(failures, fmt.Sprintf("%s: %s", f.Name(), err))
-		}
-	}
-	if len(failures) == 0 {
-		return nil
-	}
-	return fmt.Errorf("failed to close files: %s", strings.Join(failures, "; "))
 }
 
 var lastPort int
@@ -334,43 +250,17 @@ func oneFreePort(ip string, start, min, max int) (int, string, net.Listener, err
 	return 0, "", nil, fmt.Errorf("unable to find a free port in range %d-%d", min, max)
 }
 
-func prefixedPipe(prefixFormat string, a ...interface{}) (io.Writer, error) {
-	prefix := fmt.Sprintf(prefixFormat, a...)
-	r, w, err := os.Pipe()
-	if err != nil {
-		return nil, err
-	}
-	go func() {
-		defer func() {
-			if err := r.Close(); err != nil {
-				rtLog("Failed to close reader: %s", err)
-			}
-			if err := w.Close(); err != nil {
-				rtLog("Failed to close writer: %s", err)
-			}
-		}()
-		scanner := bufio.NewScanner(r)
-		for scanner.Scan() {
-			if err := scanner.Err(); err != nil {
-				rtLog("Error prefixing: %s", err)
-			}
-			fmt.Fprintf(os.Stdout, "%s%s\n", prefix, scanner.Text())
-		}
-	}()
-	return w, nil
-}
-
 func prefixWithTestName(t *testing.T, label string) (prefixedOut, prefixedErr io.Writer) {
 	t.Helper()
 
 	outPrefix := fmt.Sprintf("%s:%s:stdout> ", t.Name(), label)
 	errPrefix := fmt.Sprintf("%s:%s:stderr> ", t.Name(), label)
 
-	stdout, err := prefixedPipe(outPrefix)
+	stdout, err := prefixpipe.New(outPrefix)
 	if err != nil {
 		t.Fatalf("Setting up output prefix: %s", err)
 	}
-	stderr, err := prefixedPipe(errPrefix)
+	stderr, err := prefixpipe.New(errPrefix)
 	if err != nil {
 		t.Fatalf("Setting up output prefix: %s", err)
 	}

--- a/util/prefixpipe/prefixpipe.go
+++ b/util/prefixpipe/prefixpipe.go
@@ -1,0 +1,52 @@
+package prefixpipe
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"os"
+)
+
+// PrefixPipe is an io.Writer with some extra settings.
+type PrefixPipe struct {
+	// Writer is the receiving Writer which is prefixed and written to Out.
+	io.Writer
+	// Out is the destination writer, defaults to os.Stdout.
+	Out io.Writer
+	// LogFunc, if set, receives error logs. Defaults to log.Printf from stdlib.
+	LogFunc func(string, ...interface{})
+}
+
+// New returns a new PrefixPipe that prefixes every line written with the
+// formatted string provided.
+func New(prefixFormat string, a ...interface{}) (*PrefixPipe, error) {
+	prefix := fmt.Sprintf(prefixFormat, a...)
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	pp := &PrefixPipe{
+		Writer:  w,
+		Out:     os.Stdout,
+		LogFunc: log.Printf,
+	}
+	go func() {
+		defer func() {
+			if err := r.Close(); err != nil {
+				pp.LogFunc("Failed to close reader: %s", err)
+			}
+			if err := w.Close(); err != nil {
+				pp.LogFunc("Failed to close writer: %s", err)
+			}
+		}()
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				pp.LogFunc("Error prefixing: %s", err)
+			}
+			fmt.Fprintf(pp.Out, "%s%s\n", prefix, scanner.Text())
+		}
+	}()
+	return pp, nil
+}

--- a/util/prefixpipe/prefixpipe.go
+++ b/util/prefixpipe/prefixpipe.go
@@ -10,26 +10,44 @@ import (
 
 // PrefixPipe is an io.Writer with some extra settings.
 type PrefixPipe struct {
-	// Writer is the receiving Writer which is prefixed and written to Out.
+	Opts
+	// Dest is the destination writer.
+	Dest io.Writer
+	// Writer is the receiving Writer which is prefixed and written to Dest.
 	io.Writer
-	// Out is the destination writer, defaults to os.Stdout.
-	Out io.Writer
+}
+
+// Opts configures your PrefixPipe.
+type Opts struct {
 	// LogFunc, if set, receives error logs. Defaults to log.Printf from stdlib.
 	LogFunc func(string, ...interface{})
 }
 
+// DefaultOpts returns the default Opts.
+func DefaultOpts() Opts {
+	return Opts{
+		LogFunc: log.Printf,
+	}
+}
+
 // New returns a new PrefixPipe that prefixes every line written with the
-// formatted string provided.
-func New(prefixFormat string, a ...interface{}) (*PrefixPipe, error) {
-	prefix := fmt.Sprintf(prefixFormat, a...)
+// formatted string provided and writes it to dest.
+//
+// Optionally pass one or more config funcs to tweak the options for this
+// PrefixPipe, options start as DefaultOpts() and each config func is run
+// in the order specified from left to right.
+func New(dest io.Writer, prefix string, config ...func(*Opts)) (*PrefixPipe, error) {
+	opts := DefaultOpts()
+	for _, cfg := range config {
+		cfg(&opts)
+	}
 	r, w, err := os.Pipe()
 	if err != nil {
 		return nil, err
 	}
 	pp := &PrefixPipe{
-		Writer:  w,
-		Out:     os.Stdout,
-		LogFunc: log.Printf,
+		Opts:   opts,
+		Writer: w,
 	}
 	go func() {
 		defer func() {
@@ -45,7 +63,7 @@ func New(prefixFormat string, a ...interface{}) (*PrefixPipe, error) {
 			if err := scanner.Err(); err != nil {
 				pp.LogFunc("Error prefixing: %s", err)
 			}
-			fmt.Fprintf(pp.Out, "%s%s\n", prefix, scanner.Text())
+			fmt.Fprintf(pp.Dest, "%s%s\n", prefix, scanner.Text())
 		}
 	}()
 	return pp, nil

--- a/util/prefixpipe/prefixpipe.go
+++ b/util/prefixpipe/prefixpipe.go
@@ -47,6 +47,7 @@ func New(dest io.Writer, prefix string, config ...func(*Opts)) (*PrefixPipe, err
 	}
 	pp := &PrefixPipe{
 		Opts:   opts,
+		Dest:   dest,
 		Writer: w,
 	}
 	go func() {

--- a/util/prefixpipe/prefixpipe.go
+++ b/util/prefixpipe/prefixpipe.go
@@ -7,7 +7,7 @@ import (
 	"log"
 )
 
-// PrefixPipe is an io.Writer with some extra settings.
+// PrefixPipe prefixes all lines written to it, and writes them to Dest.
 type PrefixPipe struct {
 	Opts
 	// Dest is the destination writer.
@@ -38,7 +38,11 @@ func DefaultOpts() Opts {
 // Optionally pass one or more config funcs to tweak the options for this
 // PrefixPipe, options start as DefaultOpts() and each config func is run
 // in the order specified from left to right.
-func New(dest io.Writer, prefix string, config ...func(*Opts)) (*PrefixPipe, error) {
+//
+// To ensure you don't leak goroutines, you must call Close() on the returned
+// *PrefixPipe. To ensure every line gets written to Dest, you must call Wait()
+// after Close().
+func New(dest io.Writer, prefix string, config ...func(*Opts)) *PrefixPipe {
 	opts := DefaultOpts()
 	for _, cfg := range config {
 		cfg(&opts)
@@ -70,7 +74,7 @@ func New(dest io.Writer, prefix string, config ...func(*Opts)) (*PrefixPipe, err
 		}
 	}()
 
-	return pp, nil
+	return pp
 }
 
 // Wait waits for the pipe to be closed and to flush all its contents.

--- a/util/prefixpipe/prefixpipe_test.go
+++ b/util/prefixpipe/prefixpipe_test.go
@@ -1,0 +1,35 @@
+package prefixpipe
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestPrefixPipe_ok_noconfig(t *testing.T) {
+
+	dest := &bytes.Buffer{}
+
+	pipe, err := New(dest, "prefix1: ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := fmt.Fprintln(pipe, "line one"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprint(pipe, "line two"); err != nil {
+		t.Fatal(err)
+	}
+
+	pipe.Close()
+	pipe.Wait()
+
+	want := "prefix1: line one\nprefix1: line two\n"
+
+	got := dest.String()
+
+	if got != want {
+		t.Errorf("got %q; want %q", got, want)
+	}
+}

--- a/util/prefixpipe/prefixpipe_test.go
+++ b/util/prefixpipe/prefixpipe_test.go
@@ -10,10 +10,7 @@ func TestPrefixPipe_ok_noconfig(t *testing.T) {
 
 	dest := &bytes.Buffer{}
 
-	pipe, err := New(dest, "prefix1: ")
-	if err != nil {
-		t.Fatal(err)
-	}
+	pipe := New(dest, "prefix1: ")
 
 	if _, err := fmt.Fprintln(pipe, "line one"); err != nil {
 		t.Fatal(err)

--- a/util/testagents/bin.go
+++ b/util/testagents/bin.go
@@ -46,7 +46,6 @@ type Bin struct {
 	// MassageArgs is called on the total set of args passed to the command,
 	// prior to execution; the args it returns are what is finally used.
 	MassageArgs func([]string) []string
-	Finished    chan struct{}
 
 	// ShouldStillBeRunningAfterTest should is set to true for servers etc, it
 	// enables crash detection.
@@ -84,7 +83,6 @@ func NewBin(t *testing.T, pm ProcMan, path, name, baseDir, rootDir string, finis
 		InstanceName: name,
 		RootDir:      rootDir,
 		Env:          map[string]string{},
-		Finished:     finished,
 		LogFunc:      log.Printf,
 		ProcMan:      pm,
 	}

--- a/util/testagents/bin.go
+++ b/util/testagents/bin.go
@@ -259,7 +259,7 @@ func (c *Bin) prefixWriter(label string) *prefixpipe.PrefixPipe {
 	prefix := fmt.Sprintf("%s:%s> ", c.ID(), label)
 	w, err := prefixpipe.New(os.Stdout, prefix)
 	if err != nil {
-		log.Panicf("unable to create prefix writer %q: %s", err)
+		log.Panicf("unable to create prefix writer %q: %s", prefix, err)
 	}
 	return w
 }

--- a/util/testagents/bin.go
+++ b/util/testagents/bin.go
@@ -83,8 +83,8 @@ func NewBin(t *testing.T, pm ProcMan, path, name, baseDir, rootDir string, finis
 		RootDir:      rootDir,
 		Env:          map[string]string{},
 		Finished:     finished,
-
-		ProcMan: pm,
+		LogFunc:      log.Printf,
+		ProcMan:      pm,
 	}
 }
 

--- a/util/testagents/flags.go
+++ b/util/testagents/flags.go
@@ -1,4 +1,4 @@
-package smoke
+package testagents
 
 // Flags represents a set of flags to be passed to a Binary.
 type Flags interface {

--- a/util/testagents/invocation.go
+++ b/util/testagents/invocation.go
@@ -1,0 +1,18 @@
+package testagents
+
+import "fmt"
+
+// invocation is the invocation directly from the test, without any formatting
+// or manipulation.
+type invocation struct {
+	name, subcmd string
+	flags        Flags
+	args         []string
+	finalArgs    []string
+}
+
+// String returns this invocation roughly as a copy-pastable shell command.
+// Note: if args contain quotes some manual editing may be required.
+func (i invocation) String() string {
+	return fmt.Sprintf("%s %s", i.name, quotedArgsString(i.finalArgs))
+}

--- a/util/testagents/preparedcommand.go
+++ b/util/testagents/preparedcommand.go
@@ -1,0 +1,59 @@
+package testagents
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// PreparedCmd is a command ready to run.
+type PreparedCmd struct {
+	invocation
+	Cmd      *exec.Cmd
+	Cancel   func()
+	PreRun   func() error
+	PostRun  func() error
+	executed *ExecutedCMD
+}
+
+func (c *PreparedCmd) tryGetExitCode() (int, error) {
+	if c.Cmd == nil {
+		return -1, fmt.Errorf("Cmd is nil")
+	}
+	if c.Cmd.ProcessState == nil {
+		return -1, fmt.Errorf("command not run (no process state)")
+	}
+	if !c.Cmd.ProcessState.Exited() {
+		return -1, fmt.Errorf("command not finished")
+	}
+	if c.Cmd.ProcessState.Sys() == nil {
+		return -1, fmt.Errorf("process state returned nil for Sys()")
+	}
+	sys := c.Cmd.ProcessState.Sys()
+	ws, ok := sys.(syscall.WaitStatus)
+	if !ok {
+		return -1, fmt.Errorf("process state Sys() was a %T; want a syscall.WaitStatus", sys)
+	}
+	es := ws.ExitStatus()
+	if es < 0 {
+		return es, fmt.Errorf("invalid negative exit status %d", es)
+	}
+	return es, nil
+}
+
+func (c *PreparedCmd) runWithTimeout(timeout time.Duration) error {
+	defer c.PostRun()
+	c.PreRun()
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(errCh)
+		select {
+		case errCh <- c.Cmd.Run():
+		case <-time.After(timeout):
+			errCh <- fmt.Errorf("command timed out after %s: %s", timeout, c)
+			c.Cancel()
+		}
+	}()
+	return <-errCh
+}

--- a/util/testagents/service.go
+++ b/util/testagents/service.go
@@ -179,7 +179,7 @@ func (s *Service) debug(f string, a ...interface{}) {
 	s.LogFunc("[DEBUG:"+s.ID()+";pid:"+pid+"] "+f, a...)
 }
 
-// Stop stops this service.
+// Stop stops this service and waits for it to exit.
 func (s *Service) Stop() error {
 	if closed(s.Stopped) {
 		s.debug("not stopping as already stopped")


### PR DESCRIPTION
This addresses the problem of flaky smoke tests, which was primarily caused by a sequencing error and calling `*os.Process.Wait` multiple times. Fixing that issue surfaced another one (see below), and resulted in some other changes for better logging, which needed to be fixed to get a green PR.

Test coverage is not good for this change, mostly because it modified some code that was already not coverd by unit tests (just by smoke tests). To start getting it back to a decent level, I split out 2 packages: `util/prefixpipe` and `util/testagents` in order to test those components separately. The former now has a simple test, but the latter still needs them. Since this PR is growing, I want to stop adding changes here and address test coverage and a few other things in a follow-up.

**New issue discovered (still needs investigation, but workaround in place):**
Sending HTTP requests to a sous server too early in its initialisation causes the server to first refuse connection, then return an empty response, and then die, with 3 HTTP calls, in that order. Only the first call needs to be during early initialisation, the remaining ones can be an arbitrarily long time later. (This can be reproduced reliably using `make test-smoke` if you remove that sleep, and a debugger can then be attached to see what's going on.)  This was happening rarely (for roughly 2% of tests). It is ameliorated for now using a sleep after the servers start, but we should find the bug in the server that allows an HTTP request to break it, so we can remove that sleep.

**Behavioural change of sous:**
Logging added to test process handling resulted in a change to behaviour, see CHANGELOG: Sous server now shuts down gracefully, draining HTTP requests, on a SIGINT or SIGTERM, and logs the signal and action taken. This was helpful in seeing which servers had received TERM and which KILL. Running locally, servers are occasionally receiving a KILL signal unexpectedly, which is logged, need to find out where that is coming from.